### PR TITLE
Type FriezeFreeMap creation properties (closes #4)

### DIFF
--- a/src/main/java/com/github/noony/app/timelinefx/core/freemap/FriezeFreeMap.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/freemap/FriezeFreeMap.java
@@ -85,6 +85,11 @@ public final class FriezeFreeMap implements FriezeObject {
     private static final boolean DEFAULT_PLOT_VISIBILITY = true;
     private static final boolean DEFAULT_PORTRAIT_CONNECTOR_VISIBILITY = true;
 
+    public static final FriezeFreeMapProperties DEFAULT_PROPERTIES = new FriezeFreeMapProperties(
+            new Dimension2D(DEFAULT_WIDTH, DEFAULT_HEIGHT), DEFAULT_PERSONS_WIDTH, DEFAULT_PLACE_NAMES_WIDTH,
+            DEFAULT_FONT_SIZE, DEFAULT_PLOT_SEPARATION, DEFAULT_PLOT_SIZE, DEFAULT_PLOT_VISIBILITY,
+            DEFAULT_PORTRAIT_CONNECTOR_VISIBILITY, DEFAULT_PORTRAIT_RADIUS);
+
     private static final String DEFAULT_NAME = "FreeMap";
 
     private static final Logger LOG = Logger.getGlobal();
@@ -123,7 +128,7 @@ public final class FriezeFreeMap implements FriezeObject {
     //
 //    private TimeMode timeMode;
 
-    protected FriezeFreeMap(long anID, Frieze aFrieze, Map<String, String> inputParameters, List<FreeMapDateHandle> dateHandles,
+    protected FriezeFreeMap(long anID, Frieze aFrieze, FriezeFreeMapProperties properties, List<FreeMapDateHandle> dateHandles,
             List<FreeMapPerson> somePersons, List<FreeMapPlace> somePlaces, List<FreeMapStay> someStays, boolean allStays) {
         id = anID;
         propertyChangeSupport = new PropertyChangeSupport(FriezeFreeMap.this);
@@ -136,7 +141,7 @@ public final class FriezeFreeMap implements FriezeObject {
         //
         name = DEFAULT_NAME;
         //
-        loadParameters(inputParameters);
+        applyProperties(properties);
         //
         minDate = frieze.getMinDate();
         maxDate = frieze.getMaxDate();
@@ -175,7 +180,7 @@ public final class FriezeFreeMap implements FriezeObject {
     }
 
     protected FriezeFreeMap(long anID, Frieze aFrieze, boolean allStays) {
-        this(anID, aFrieze, new HashMap<>(), new LinkedList<>(), new LinkedList<>(), new LinkedList<>(), new LinkedList<>(), allStays);
+        this(anID, aFrieze, DEFAULT_PROPERTIES, new LinkedList<>(), new LinkedList<>(), new LinkedList<>(), new LinkedList<>(), allStays);
     }
 
     public void addPropertyChangeListener(PropertyChangeListener listener) {
@@ -374,6 +379,7 @@ public final class FriezeFreeMap implements FriezeObject {
     }
 
     public void setPlotSeparation(double plotSeparation) {
+        this.plotSeparation = plotSeparation;
         places.values().forEach(place -> place.setPlotSeparation(plotSeparation));
         distributePlaces();
     }
@@ -449,31 +455,31 @@ public final class FriezeFreeMap implements FriezeObject {
      * @return a new map containing the frieze parameters
      */
     public Map<String, String> getParemeters() {
-        Map<String, String> parameters = new HashMap<>();
-        parameters.put(FRIEZE_WIDTH, Double.toString(width));
-        parameters.put(FRIEZE_HEIGHT, Double.toString(height));
-        parameters.put(PERSONS_WIDTH, Double.toString(portraitWidth));
-        parameters.put(PLACE_NAMES_WIDTH, Double.toString(placeNamesWidth));
-        parameters.put(FONT_SIZE, Double.toString(fontSize));
-        parameters.put(PLOT_SEPARATION, Double.toString(plotSeparation));
-        parameters.put(PLOT_SIZE, Double.toString(plotSize));
-        parameters.put(PLOT_VISIBILITY, Boolean.toString(plotVisibiltiy));
-        parameters.put(PORTRAIT_CONNECTOR_VISIBILITY, Boolean.toString(portraitConnectorsVisibiltiy));
-        parameters.put(PORTRAIT_RADIUS, Double.toString(portraitRadius));
-        return parameters;
+        return getProperties().toParameterMap();
     }
 
-    private void loadParameters(Map<String, String> parameters) {
-        width = Double.parseDouble(parameters.getOrDefault(FRIEZE_WIDTH, Double.toString(DEFAULT_WIDTH)));
-        height = Double.parseDouble(parameters.getOrDefault(FRIEZE_HEIGHT, Double.toString(DEFAULT_HEIGHT)));
-        portraitWidth = Double.parseDouble(parameters.getOrDefault(PERSONS_WIDTH, Double.toString(DEFAULT_PERSONS_WIDTH)));
-        placeNamesWidth = Double.parseDouble(parameters.getOrDefault(PLACE_NAMES_WIDTH, Double.toString(DEFAULT_PLACE_NAMES_WIDTH)));
-        fontSize = Double.parseDouble(parameters.getOrDefault(FONT_SIZE, Double.toString(DEFAULT_FONT_SIZE)));
-        plotSeparation = getPlotSeparationParamerter(parameters);
-        plotSize = Double.parseDouble(parameters.getOrDefault(PLOT_SIZE, Double.toString(DEFAULT_PLOT_SIZE)));
-        plotVisibiltiy = Boolean.parseBoolean(parameters.getOrDefault(PLOT_VISIBILITY, Boolean.toString(DEFAULT_PLOT_VISIBILITY)));
-        portraitConnectorsVisibiltiy = Boolean.parseBoolean(parameters.getOrDefault(PORTRAIT_CONNECTOR_VISIBILITY, Boolean.toString(DEFAULT_PORTRAIT_CONNECTOR_VISIBILITY)));
-        portraitRadius = Double.parseDouble(parameters.getOrDefault(PORTRAIT_RADIUS, Double.toString(DEFAULT_PORTRAIT_RADIUS)));
+    public FriezeFreeMapProperties getProperties() {
+        return new FriezeFreeMapProperties(new Dimension2D(width, height), portraitWidth, placeNamesWidth,
+                fontSize, plotSeparation, plotSize, plotVisibiltiy, portraitConnectorsVisibiltiy, portraitRadius);
+    }
+
+    public void setProperties(FriezeFreeMapProperties properties) {
+        applyProperties(properties);
+        updateLayout();
+        distributePlaces();
+    }
+
+    private void applyProperties(FriezeFreeMapProperties properties) {
+        width = properties.dimension().getWidth();
+        height = properties.dimension().getHeight();
+        portraitWidth = properties.personWidth();
+        placeNamesWidth = properties.placeNameWidth();
+        fontSize = properties.fontSize();
+        plotSeparation = properties.plotSeparation();
+        plotSize = properties.plotSize();
+        plotVisibiltiy = properties.plotVisibility();
+        portraitConnectorsVisibiltiy = properties.portraitConnectorVisibility();
+        portraitRadius = properties.portraitRadius();
     }
 
     private void addPerson(Person person) {
@@ -803,11 +809,6 @@ public final class FriezeFreeMap implements FriezeObject {
     @Override
     public String toString() {
         return this.getClass().getSimpleName() + "_" + getName();
-    }
-
-    public static double getPlotSeparationParamerter(Map<String, String> parameters) {
-        return Double.parseDouble(parameters.getOrDefault(PLOT_SEPARATION, Double.toString(DEFAULT_PLOT_SEPARATION)));
-
     }
 
 }

--- a/src/main/java/com/github/noony/app/timelinefx/core/freemap/FriezeFreeMapFactory.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/freemap/FriezeFreeMapFactory.java
@@ -19,7 +19,6 @@ package com.github.noony.app.timelinefx.core.freemap;
 import com.github.noony.app.timelinefx.core.Factory;
 import com.github.noony.app.timelinefx.core.Frieze;
 import java.util.List;
-import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -66,14 +65,14 @@ public class FriezeFreeMapFactory {
         return friezeFreeMap;
     }
 
-    public static FriezeFreeMap createFriezeFreeMap(long anID, Frieze aFrieze, Map<String, String> inputParameters,
+    public static FriezeFreeMap createFriezeFreeMap(long anID, Frieze aFrieze, FriezeFreeMapProperties properties,
             List<FreeMapDateHandle> dateHandles, List<FreeMapPerson> persons, List<FreeMapPlace> places, List<FreeMapStay> stays) {
         //
         if (!FACTORY.isIdAvailable(anID)) {
             throw new IllegalArgumentException("Trying to create a friezeFreeMap with existing id=" + anID);
         }
         LOG.log(Level.WARNING, "Creating a friezeFreeMap (id={0} with Frieze={1} with its full content.", new Object[]{anID, aFrieze});
-        var friezeFreeMap = new FriezeFreeMap(anID, aFrieze, inputParameters, dateHandles, persons, places, stays, false);
+        var friezeFreeMap = new FriezeFreeMap(anID, aFrieze, properties, dateHandles, persons, places, stays, false);
         FACTORY.addObject(friezeFreeMap);
         return friezeFreeMap;
     }

--- a/src/main/java/com/github/noony/app/timelinefx/core/freemap/FriezeFreeMapProperties.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/freemap/FriezeFreeMapProperties.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2019 NoOnY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.github.noony.app.timelinefx.core.freemap;
+
+import java.util.HashMap;
+import java.util.Map;
+import javafx.geometry.Dimension2D;
+
+/**
+ * Bundles the layout attributes needed to create or reconfigure a {@link FriezeFreeMap}, replacing the
+ * previous {@code Map<String, String>}-based parameter passing with a typed value object. {@link #toParameterMap()}
+ * and {@link #fromParameterMap(Map, FriezeFreeMapProperties)} keep it interoperable with the existing XML
+ * save/load format, which still stores each attribute as a named string parameter.
+ *
+ * @author hamon
+ */
+public record FriezeFreeMapProperties(Dimension2D dimension, double personWidth, double placeNameWidth,
+        double fontSize, double plotSeparation, double plotSize, boolean plotVisibility,
+        boolean portraitConnectorVisibility, double portraitRadius) {
+
+    public Map<String, String> toParameterMap() {
+        var parameters = new HashMap<String, String>();
+        parameters.put(FriezeFreeMap.FRIEZE_WIDTH, Double.toString(dimension.getWidth()));
+        parameters.put(FriezeFreeMap.FRIEZE_HEIGHT, Double.toString(dimension.getHeight()));
+        parameters.put(FriezeFreeMap.PERSONS_WIDTH, Double.toString(personWidth));
+        parameters.put(FriezeFreeMap.PLACE_NAMES_WIDTH, Double.toString(placeNameWidth));
+        parameters.put(FriezeFreeMap.FONT_SIZE, Double.toString(fontSize));
+        parameters.put(FriezeFreeMap.PLOT_SEPARATION, Double.toString(plotSeparation));
+        parameters.put(FriezeFreeMap.PLOT_SIZE, Double.toString(plotSize));
+        parameters.put(FriezeFreeMap.PLOT_VISIBILITY, Boolean.toString(plotVisibility));
+        parameters.put(FriezeFreeMap.PORTRAIT_CONNECTOR_VISIBILITY, Boolean.toString(portraitConnectorVisibility));
+        parameters.put(FriezeFreeMap.PORTRAIT_RADIUS, Double.toString(portraitRadius));
+        return parameters;
+    }
+
+    public static FriezeFreeMapProperties fromParameterMap(Map<String, String> parameters, FriezeFreeMapProperties defaults) {
+        var width = Double.parseDouble(parameters.getOrDefault(FriezeFreeMap.FRIEZE_WIDTH, Double.toString(defaults.dimension().getWidth())));
+        var height = Double.parseDouble(parameters.getOrDefault(FriezeFreeMap.FRIEZE_HEIGHT, Double.toString(defaults.dimension().getHeight())));
+        var personWidthValue = Double.parseDouble(parameters.getOrDefault(FriezeFreeMap.PERSONS_WIDTH, Double.toString(defaults.personWidth())));
+        var placeNameWidthValue = Double.parseDouble(parameters.getOrDefault(FriezeFreeMap.PLACE_NAMES_WIDTH, Double.toString(defaults.placeNameWidth())));
+        var fontSizeValue = Double.parseDouble(parameters.getOrDefault(FriezeFreeMap.FONT_SIZE, Double.toString(defaults.fontSize())));
+        var plotSeparationValue = Double.parseDouble(parameters.getOrDefault(FriezeFreeMap.PLOT_SEPARATION, Double.toString(defaults.plotSeparation())));
+        var plotSizeValue = Double.parseDouble(parameters.getOrDefault(FriezeFreeMap.PLOT_SIZE, Double.toString(defaults.plotSize())));
+        var plotVisibilityValue = Boolean.parseBoolean(parameters.getOrDefault(FriezeFreeMap.PLOT_VISIBILITY, Boolean.toString(defaults.plotVisibility())));
+        var portraitConnectorVisibilityValue = Boolean.parseBoolean(parameters.getOrDefault(FriezeFreeMap.PORTRAIT_CONNECTOR_VISIBILITY, Boolean.toString(defaults.portraitConnectorVisibility())));
+        var portraitRadiusValue = Double.parseDouble(parameters.getOrDefault(FriezeFreeMap.PORTRAIT_RADIUS, Double.toString(defaults.portraitRadius())));
+        return new FriezeFreeMapProperties(new Dimension2D(width, height), personWidthValue, placeNameWidthValue,
+                fontSizeValue, plotSeparationValue, plotSizeValue, plotVisibilityValue, portraitConnectorVisibilityValue,
+                portraitRadiusValue);
+    }
+
+}

--- a/src/main/java/com/github/noony/app/timelinefx/save/v3/FreeMapProviderV3.java
+++ b/src/main/java/com/github/noony/app/timelinefx/save/v3/FreeMapProviderV3.java
@@ -28,8 +28,8 @@ import com.github.noony.app.timelinefx.core.freemap.FreeMapPortraitFactory;
 import com.github.noony.app.timelinefx.core.freemap.FreeMapStay;
 import com.github.noony.app.timelinefx.core.freemap.FreeMapStayFactory;
 import com.github.noony.app.timelinefx.core.freemap.FriezeFreeMap;
-import static com.github.noony.app.timelinefx.core.freemap.FriezeFreeMap.getPlotSeparationParamerter;
 import com.github.noony.app.timelinefx.core.freemap.FriezeFreeMapFactory;
+import com.github.noony.app.timelinefx.core.freemap.FriezeFreeMapProperties;
 import com.github.noony.app.timelinefx.core.freemap.connectors.FreeMapConnector;
 import com.github.noony.app.timelinefx.core.freemap.connectors.FreeMapConnectorFactory;
 import com.github.noony.app.timelinefx.core.freemap.links.FreeMapLinkFactory;
@@ -244,14 +244,15 @@ public class FreeMapProviderV3 {
         var freeMapName = freemapElement.getAttribute(NAME_ATR);
         // parse parameters
         var freeMapParameters = parseFreeMapParameters(freemapElement);
-        LOG.log(Level.INFO, "Parsed Freemap {0}_{1} parameters: {2}", new Object[]{freeMapID, freeMapName, freeMapParameters});
+        var freeMapProperties = FriezeFreeMapProperties.fromParameterMap(freeMapParameters, FriezeFreeMap.DEFAULT_PROPERTIES);
+        LOG.log(Level.INFO, "Parsed Freemap {0}_{1} parameters: {2}", new Object[]{freeMapID, freeMapName, freeMapProperties});
         // parse date handles
         var dateHandles = parseFreeMapDateHandles(freemapElement, freeMapID);
         // parse FreeMapPersons, step 01: only creation and portrait loading (no stays)
         var freeMapPersonsAndElements = parseFreeMapPersons(freemapElement, freeMapID);
         var freeMapPersons = freeMapPersonsAndElements.stream().map(aPair -> aPair.getKey()).collect(Collectors.toList());
         // parse FreemapPlaces
-        var freeMapPlaces = parseFreeMapPlaces(freemapElement, freeMapID, freeMapParameters, freeMapPersons);
+        var freeMapPlaces = parseFreeMapPlaces(freemapElement, freeMapID, freeMapProperties, freeMapPersons);
         //
         // parse FreeMapStays
         List<FreeMapStay> freeMapStays = new LinkedList<>();
@@ -260,7 +261,7 @@ public class FreeMapProviderV3 {
                         parseFreeMapPersonStep02(pair.getValue(), pair.getKey(), freeMapPlaces))
         );
         // create FreeMap
-        var freeMap = FriezeFreeMapFactory.createFriezeFreeMap(freeMapID, frieze, freeMapParameters, dateHandles, freeMapPersons, freeMapPlaces, freeMapStays);
+        var freeMap = FriezeFreeMapFactory.createFriezeFreeMap(freeMapID, frieze, freeMapProperties, dateHandles, freeMapPersons, freeMapPlaces, freeMapStays);
         freeMap.setName(freeMapName);
         // create Portraits
         freeMapPersonsAndElements.forEach(pair -> parseFreeMapPersonStep03(pair.getValue(), pair.getKey(), freeMapStays));
@@ -446,7 +447,7 @@ public class FreeMapProviderV3 {
         return portraitLink;
     }
 
-    private static List<FreeMapPlace> parseFreeMapPlaces(Element freemapElement, long parentFreeMapID, Map<String, String> freeMapParameters, List<FreeMapPerson> freeMapPersons) {
+    private static List<FreeMapPlace> parseFreeMapPlaces(Element freemapElement, long parentFreeMapID, FriezeFreeMapProperties freeMapProperties, List<FreeMapPerson> freeMapPersons) {
         var freemapPlacesElementList = freemapElement.getElementsByTagName(FREEMAP_PLACES_GROUP);
         if (freemapPlacesElementList.getLength() != 1) {
             throw new IllegalStateException("Error while parsing FreeMapPlaces: " + FREEMAP_PERSONS_GROUP + " count = " + freemapPlacesElementList.getLength());
@@ -457,13 +458,13 @@ public class FreeMapProviderV3 {
         var freemapPlacesElements = freemapPlacesElement.getElementsByTagName(FREEMAP_PLACE_ELEMENT);
         for (int i = 0; i < freemapPlacesElements.getLength(); i++) {
             var placeElement = (Element) freemapPlacesElements.item(i);
-            var freeMapPlace = parseFreeMapPlace(placeElement, parentFreeMapID, freeMapParameters, freeMapPersons);
+            var freeMapPlace = parseFreeMapPlace(placeElement, parentFreeMapID, freeMapProperties, freeMapPersons);
             freeMapPlaces.add(freeMapPlace);
         }
         return freeMapPlaces;
     }
 
-    private static FreeMapPlace parseFreeMapPlace(Element freemapPlaceElement, long parentFreeMapID, Map<String, String> freeMapParameters, List<FreeMapPerson> freeMapPersons) {
+    private static FreeMapPlace parseFreeMapPlace(Element freemapPlaceElement, long parentFreeMapID, FriezeFreeMapProperties freeMapProperties, List<FreeMapPerson> freeMapPersons) {
         var placeID = Long.parseLong(freemapPlaceElement.getAttribute(PLACE_ID_ATR));
         var height = Double.parseDouble(freemapPlaceElement.getAttribute(HEIGHT_ATR));
         var yPos = Double.parseDouble(freemapPlaceElement.getAttribute(Y_POS_ATR));
@@ -472,7 +473,7 @@ public class FreeMapProviderV3 {
         //
         var place = PlaceFactory.getPlace(placeID);
         //
-        var freeMapPlace = FreeMapPlace.createFreeMapPlace(parentFreeMapID, place, getPlotSeparationParamerter(freeMapParameters), nameWidth, fontSize);
+        var freeMapPlace = FreeMapPlace.createFreeMapPlace(parentFreeMapID, place, freeMapProperties.plotSeparation(), nameWidth, fontSize);
         //
         freeMapPlace.setHeight(height);
         freeMapPlace.setY(yPos);

--- a/src/test/java/com/github/noony/app/timelinefx/core/freemap/FriezeFreeMapPropertiesTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/freemap/FriezeFreeMapPropertiesTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2026 NoOnY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.github.noony.app.timelinefx.core.freemap;
+
+import java.util.HashMap;
+import java.util.Map;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Note: these tests deliberately stay at the {@link FriezeFreeMapProperties} level rather than going through
+ * {@link FriezeFreeMapFactory}/{@link com.github.noony.app.timelinefx.core.Frieze}, since constructing a
+ * {@link com.github.noony.app.timelinefx.core.TimeLineProject} requires app-level {@code Configuration} to be
+ * initialized first (it reads/writes a preferences file under the user's home directory), which existing tests
+ * in this project (e.g. {@code PlaceTest}) also avoid.
+ *
+ * @author solun
+ */
+public class FriezeFreeMapPropertiesTest {
+
+    public FriezeFreeMapPropertiesTest() {
+    }
+
+    /**
+     * Test that DEFAULT_PROPERTIES survives a round-trip through toParameterMap/fromParameterMap.
+     */
+    @Test
+    public void testParameterMapRoundTrip() {
+        var defaults = FriezeFreeMap.DEFAULT_PROPERTIES;
+        var roundTripped = FriezeFreeMapProperties.fromParameterMap(defaults.toParameterMap(), defaults);
+        assertEquals(defaults, roundTripped);
+    }
+
+    /**
+     * Test that fromParameterMap falls back to the supplied defaults for missing/partial keys.
+     */
+    @Test
+    public void testFromParameterMapUsesDefaultsForMissingKeys() {
+        var defaults = FriezeFreeMap.DEFAULT_PROPERTIES;
+        Map<String, String> partialParameters = new HashMap<>();
+        partialParameters.put(FriezeFreeMap.FONT_SIZE, "99.0");
+        var properties = FriezeFreeMapProperties.fromParameterMap(partialParameters, defaults);
+        assertEquals(99.0, properties.fontSize());
+        assertEquals(defaults.personWidth(), properties.personWidth());
+        assertEquals(defaults.plotSeparation(), properties.plotSeparation());
+        assertEquals(defaults.portraitRadius(), properties.portraitRadius());
+    }
+
+}


### PR DESCRIPTION
## Summary
- Closes #4. Replaces the stringly-typed `Map<String,String>` used to build/reconfigure `FriezeFreeMap` with a typed `FriezeFreeMapProperties` record (9 layout attributes: dimension, personWidth, placeNameWidth, fontSize, plotSeparation, plotSize, plotVisibility, portraitConnectorVisibility, portraitRadius).
- Adds `FriezeFreeMap.getProperties()` / `setProperties(...)`, meant to also be reused by the upcoming duplicate-freemap action this branch is preparing.
- Keeps the on-disk V3 XML format untouched: `toParameterMap()`/`fromParameterMap(...)` convert at the boundary, so `saveFreeMapElement`/`getParemeters()` (save path) needed zero changes — only the load path (`FreeMapProviderV3.parseFreeMap`/`parseFreeMapPlaces`/`parseFreeMapPlace`) now builds/passes the typed record.
- Fixes a pre-existing bug found while consolidating this code: `setPlotSeparation(double)` never actually updated its own `plotSeparation` field (parameter shadowing) — only child places received the value.

## Test plan
- [x] `mvn -o compile` — builds clean
- [x] `mvn -o test` — 15/15 tests pass, including 2 new tests in `FriezeFreeMapPropertiesTest` (parameter-map round-trip, defaulting behavior)
- [x] Diffed `FreeMapProviderV3.java` to confirm the save path is unchanged (no XML schema/migration risk)