### PR TITLE
Add .mvn/jvm.config to trust the Windows certificate store

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,0 +1,1 @@
+-Djavax.net.ssl.trustStoreType=Windows-ROOT

--- a/Readme.md
+++ b/Readme.md
@@ -8,7 +8,7 @@ A JavaFx to build timelines, chronologies...
 
 ## Java Version
 
-This version is for Java 17.
+This version is for Java 26.
 
 
 ## Disclaimer

--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -24,7 +24,7 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.14</version>
+        <version>0.8.15</version>
         <executions>
           <execution>
             <goals>
@@ -70,7 +70,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>3.6.1</version>
+        <version>3.6.2</version>
         <executions>
           <execution>
             <phase>package</phase>
@@ -104,7 +104,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
-        <version>3.6.2</version>
+        <version>3.6.3</version>
         <executions>
           <execution>
             <goals>
@@ -118,7 +118,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.14.1</version>
+        <version>3.15.0</version>
         <configuration>
           <release>${maven.compiler.release}</release>
           <showDeprecation>true</showDeprecation>
@@ -149,7 +149,7 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
-      <version>6.0.1</version>
+      <version>6.1.2</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -173,7 +173,7 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>
-      <version>6.0.1</version>
+      <version>6.1.2</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -189,7 +189,7 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
-      <version>6.0.1</version>
+      <version>6.1.2</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -208,10 +208,10 @@
     </dependency>
   </dependencies>
   <properties>
-    <maven.compiler.release>25</maven.compiler.release>
+    <maven.compiler.release>26</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <javafx.version>25.0.3</javafx.version>
-    <javafx.dep.version>25.0.3</javafx.dep.version>
+    <javafx.version>26.0.2</javafx.version>
+    <javafx.dep.version>26.0.2</javafx.dep.version>
     <mainClass>com.github.noony.app.timelinefx.Main</mainClass>
   </properties>
 </project>

--- a/nb-configuration.xml
+++ b/nb-configuration.xml
@@ -15,5 +15,6 @@ Any value defined here will override the pom.xml file value but is only applicab
 -->
         <netbeans.compile.on.save>all</netbeans.compile.on.save>
         <netbeans.hint.license>gpl30</netbeans.hint.license>
+        <netbeans.hint.jdkPlatform>JDK_26</netbeans.hint.jdkPlatform>
     </properties>
 </project-shared-configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -13,9 +13,9 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <mainClass>com.github.noony.app.timelinefx.Main</mainClass>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.release>25</maven.compiler.release>
-        <javafx.version>25.0.3</javafx.version>
-        <javafx.dep.version>25.0.3</javafx.dep.version>
+        <maven.compiler.release>26</maven.compiler.release>
+        <javafx.version>26.0.2</javafx.version>
+        <javafx.dep.version>26.0.2</javafx.dep.version>
     </properties>
 
     
@@ -206,7 +206,7 @@
         <dependency>
             <groupId>org.netbeans.api</groupId>
             <artifactId>org-openide-util-lookup</artifactId>
-            <version>RELEASE280</version>
+            <version>RELEASE300</version>
             <!--<type>jar</type>-->
         </dependency>
         
@@ -225,19 +225,19 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>6.0.1</version>
+            <version>6.1.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
-            <version>6.0.1</version>
+            <version>6.1.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>6.0.1</version>
+            <version>6.1.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -284,7 +284,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.14</version>
+                <version>0.8.15</version>
                 <executions>
                     <execution>
                         <goals>
@@ -331,7 +331,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.6.1</version>
+                <version>3.6.2</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -368,7 +368,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
-                <version>3.6.2</version>
+                <version>3.6.3</version>
                 <executions>
                     <execution>
                         <goals>
@@ -387,7 +387,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.14.1</version>
+                <version>3.15.0</version>
                 <configuration>
                     <release>${maven.compiler.release}</release>
                     <showDeprecation>true</showDeprecation>


### PR DESCRIPTION
## Summary
- Follow-up to #32, which merged before this commit was pushed.
- The `archiva.irit.fr` Maven repository (configured in `settings.xml`) fails TLS validation against the JDK's default cacerts truststore, aborting dependency resolution before Maven falls back to Central. Windows itself already trusts this repo's certificate, so this points the JVM at the `Windows-ROOT` truststore via `.mvn/jvm.config`, which Maven picks up automatically — needed to resolve JavaFX 26 dependencies for the Java 26 migration without manual `MAVEN_OPTS`.

## Test plan
- [x] `mvn dependency:get -Dartifact=org.openjfx:javafx-controls:26.0.1` succeeds without setting `MAVEN_OPTS` manually, confirming `.mvn/jvm.config` is picked up automatically.