### PR TITLE
Address Codacy findings across core.freemap and core packages

### DIFF
--- a/src/main/java/com/github/noony/app/timelinefx/core/AbstractPicture.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/AbstractPicture.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core;
 
 import com.github.noony.app.timelinefx.utils.MathUtils;
@@ -42,19 +43,27 @@ public abstract class AbstractPicture implements IPicture {
     private final Long id;
 
     private final List<Person> persons;
+
     private final List<Place> places;
+
     private final String filePath;
+
     private final int width;
+
     private final int height;
     //
+
     private String name;
     //
+
     private TimeFormat timeFormat;
+
     private double timestamp;
+
     private LocalDate date;
 
     @SuppressWarnings("this-escape")
-    protected AbstractPicture(long anID, String aName, String aFilePath, int aWidth, int aHeight, LocalDate aDate) {
+    protected AbstractPicture(final long anID, String aName, String aFilePath, int aWidth, int aHeight, LocalDate aDate) {
         id = anID;
         propertyChangeSupport = new PropertyChangeSupport(AbstractPicture.this);
         persons = new LinkedList<>();
@@ -71,7 +80,7 @@ public abstract class AbstractPicture implements IPicture {
     }
 
     @SuppressWarnings("this-escape")
-    protected AbstractPicture(long anID, String aName, String aFilePath, int aWidth, int aHeight, double aTimestamp) {
+    protected AbstractPicture(final long anID, String aName, String aFilePath, int aWidth, int aHeight, double aTimestamp) {
         id = anID;
         propertyChangeSupport = new PropertyChangeSupport(AbstractPicture.this);
         persons = new LinkedList<>();
@@ -98,7 +107,7 @@ public abstract class AbstractPicture implements IPicture {
     }
 
     @Override
-    public void setName(String aName) {
+    public void setName(final String aName) {
         if (!Objects.equals(aName, name)) {
             name = aName;
             propertyChangeSupport.firePropertyChange(NAME_CHANGED, null, name);
@@ -111,7 +120,7 @@ public abstract class AbstractPicture implements IPicture {
     }
 
     @Override
-    public boolean addPerson(Person aPerson) {
+    public boolean addPerson(final Person aPerson) {
         if (!persons.contains(aPerson)) {
             persons.add(aPerson);
             propertyChangeSupport.firePropertyChange(PERSON_ADDED, this, aPerson);
@@ -121,7 +130,7 @@ public abstract class AbstractPicture implements IPicture {
     }
 
     @Override
-    public boolean removePerson(Person aPerson) {
+    public boolean removePerson(final Person aPerson) {
         if (persons.contains(aPerson)) {
             persons.remove(aPerson);
             propertyChangeSupport.firePropertyChange(PERSON_REMOVED, this, aPerson);
@@ -136,7 +145,7 @@ public abstract class AbstractPicture implements IPicture {
     }
 
     @Override
-    public boolean addPlace(Place aPlace) {
+    public boolean addPlace(final Place aPlace) {
         if (!places.contains(aPlace)) {
             places.add(aPlace);
             propertyChangeSupport.firePropertyChange(PLACE_ADDED, this, aPlace);
@@ -146,7 +155,7 @@ public abstract class AbstractPicture implements IPicture {
     }
 
     @Override
-    public boolean removePlace(Place aPlace) {
+    public boolean removePlace(final Place aPlace) {
         if (places.contains(aPlace)) {
             places.remove(aPlace);
             propertyChangeSupport.firePropertyChange(PLACE_REMOVED, this, aPlace);
@@ -171,7 +180,7 @@ public abstract class AbstractPicture implements IPicture {
     }
 
     @Override
-    public void setTimeFormat(TimeFormat aTimeFormat) {
+    public void setTimeFormat(final TimeFormat aTimeFormat) {
         timeFormat = aTimeFormat;
         switch (timeFormat) {
             case LOCAL_TIME ->
@@ -194,7 +203,7 @@ public abstract class AbstractPicture implements IPicture {
     }
 
     @Override
-    public void setDate(LocalDate aDate) {
+    public void setDate(final LocalDate aDate) {
         if (aDate != null) {
             if (date != null && !date.equals(aDate)) {
                 date = aDate;
@@ -205,14 +214,14 @@ public abstract class AbstractPicture implements IPicture {
     }
 
     @Override
-    public void setValue(String aTimeValue) {
+    public void setValue(final String aTimeValue) {
         if (aTimeValue == null) {
             return;
         }
         switch (timeFormat) {
             case LOCAL_TIME -> {
                 try {
-                    var newDate = LocalDate.parse(aTimeValue);
+                    final var newDate = LocalDate.parse(aTimeValue);
                     if (!newDate.isEqual(date)) {
                         date = newDate;
                         propertyChangeSupport.firePropertyChange(DATE_CHANGED, timeFormat, date);
@@ -235,7 +244,7 @@ public abstract class AbstractPicture implements IPicture {
     }
 
     @Override
-    public void setTimestamp(double aTimestamp) {
+    public void setTimestamp(final double aTimestamp) {
         if (aTimestamp != timestamp) {
             timestamp = aTimestamp;
             timeFormat = TimeFormat.TIME_MIN;
@@ -244,7 +253,7 @@ public abstract class AbstractPicture implements IPicture {
     }
 
     @Override
-    public void setDate(IDateObject aDateObject) {
+    public void setDate(final IDateObject aDateObject) {
         if (aDateObject == null) {
             return;
         }
@@ -303,24 +312,24 @@ public abstract class AbstractPicture implements IPicture {
     }
 
     @Override
-    public void addPropertyChangeListener(PropertyChangeListener listener) {
+    public void addPropertyChangeListener(final PropertyChangeListener listener) {
         propertyChangeSupport.addPropertyChangeListener(listener);
     }
 
     @Override
-    public void removePropertyChangeListener(PropertyChangeListener listener) {
+    public void removePropertyChangeListener(final PropertyChangeListener listener) {
         propertyChangeSupport.removePropertyChangeListener(listener);
     }
 
-    public void movePersonUp(Person aPerson) {
-        int index = persons.indexOf(aPerson);
+    public void movePersonUp(final Person aPerson) {
+        final int index = persons.indexOf(aPerson);
         if (index > 0) {
             Collections.swap(persons, index, index - 1);
             propertyChangeSupport.firePropertyChange(PERSONS_REORDED, this, index);
         }
     }
 
-    public void movePersonDown(Person aPerson) {
+    public void movePersonDown(final Person aPerson) {
         int index = persons.indexOf(aPerson);
         if (index != 1 && index < persons.size() - 1) {
             Collections.swap(persons, index + 1, index);
@@ -329,11 +338,11 @@ public abstract class AbstractPicture implements IPicture {
     }
 
     @Override
-    public int compareTo(IFileObject other) {
+    public int compareTo(final IFileObject other) {
         if (other == null) {
             return 1;
         }
-        var timeComparison = Double.compare(getAbsoluteTime(), getAbsoluteTime());
+        final var timeComparison = Double.compare(getAbsoluteTime(), getAbsoluteTime());
         if (timeComparison != 0) {
             return timeComparison;
         }

--- a/src/main/java/com/github/noony/app/timelinefx/core/AbstractPicture.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/AbstractPicture.java
@@ -130,8 +130,7 @@ public abstract class AbstractPicture implements IPicture {
         name = aName;
     }
 
-    @Override
-    public long getId() {
+    @Override public long getId() {
         return id;
     }
 

--- a/src/main/java/com/github/noony/app/timelinefx/core/AbstractPicture.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/AbstractPicture.java
@@ -97,7 +97,7 @@ public abstract class AbstractPicture implements IPicture {
     private LocalDate date;
 
     @SuppressWarnings("this-escape")
-    protected AbstractPicture(final long anID, String aName, String aFilePath, int aWidth, int aHeight, LocalDate aDate) {
+    protected AbstractPicture(final long anID, final String aName, String aFilePath, int aWidth, int aHeight, LocalDate aDate) {
         id = anID;
         propertyChangeSupport = new PropertyChangeSupport(AbstractPicture.this);
         persons = new LinkedList<>();
@@ -114,7 +114,7 @@ public abstract class AbstractPicture implements IPicture {
     }
 
     @SuppressWarnings("this-escape")
-    protected AbstractPicture(final long anID, String aName, String aFilePath, int aWidth, int aHeight, double aTimestamp) {
+    protected AbstractPicture(final long anID, final String aName, String aFilePath, int aWidth, int aHeight, double aTimestamp) {
         id = anID;
         propertyChangeSupport = new PropertyChangeSupport(AbstractPicture.this);
         persons = new LinkedList<>();

--- a/src/main/java/com/github/noony/app/timelinefx/core/AbstractPicture.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/AbstractPicture.java
@@ -97,7 +97,7 @@ public abstract class AbstractPicture implements IPicture {
     private LocalDate date;
 
     @SuppressWarnings("this-escape")
-    protected AbstractPicture(final long anID, final String aName, String aFilePath, int aWidth, int aHeight, LocalDate aDate) {
+    protected AbstractPicture(final long anID, final String aName, final String aFilePath, int aWidth, int aHeight, LocalDate aDate) {
         id = anID;
         propertyChangeSupport = new PropertyChangeSupport(AbstractPicture.this);
         persons = new LinkedList<>();
@@ -114,7 +114,7 @@ public abstract class AbstractPicture implements IPicture {
     }
 
     @SuppressWarnings("this-escape")
-    protected AbstractPicture(final long anID, final String aName, String aFilePath, int aWidth, int aHeight, double aTimestamp) {
+    protected AbstractPicture(final long anID, final String aName, final String aFilePath, int aWidth, int aHeight, double aTimestamp) {
         id = anID;
         propertyChangeSupport = new PropertyChangeSupport(AbstractPicture.this);
         persons = new LinkedList<>();

--- a/src/main/java/com/github/noony/app/timelinefx/core/AbstractPicture.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/AbstractPicture.java
@@ -31,35 +31,69 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
+ * Base implementation shared by {@link Picture} and {@link Portrait}.
  *
  * @author hamon
  */
 public abstract class AbstractPicture implements IPicture {
 
+    /**
+     * Logger used by this class.
+     */
     private static final Logger LOG = Logger.getGlobal();
 
+    /**
+     * Support object used to fire property change events.
+     */
     private final PropertyChangeSupport propertyChangeSupport;
 
     private final Long id;
 
+    /**
+     * The persons appearing on this picture.
+     */
     private final List<Person> persons;
 
+    /**
+     * The places appearing on this picture.
+     */
     private final List<Place> places;
 
+    /**
+     * The picture file's path, relative to the project.
+     */
     private final String filePath;
 
+    /**
+     * The picture's width.
+     */
     private final int width;
 
+    /**
+     * The picture's height.
+     */
     private final int height;
     //
 
+    /**
+     * The picture's display name.
+     */
     private String name;
     //
 
+    /**
+     * Whether {@link #date} or {@link #timestamp} holds this picture's time value.
+     */
     private TimeFormat timeFormat;
 
+    /**
+     * This picture's raw numeric time value, used when {@link #timeFormat} is {@code TIME_MIN}.
+     */
     private double timestamp;
 
+    /**
+     * This picture's calendar date value, used when {@link #timeFormat} is {@code LOCAL_TIME}.
+     */
     private LocalDate date;
 
     @SuppressWarnings("this-escape")
@@ -321,6 +355,9 @@ public abstract class AbstractPicture implements IPicture {
         propertyChangeSupport.removePropertyChangeListener(listener);
     }
 
+    /**
+     * @param aPerson the person to move up in the persons list
+     */
     public void movePersonUp(final Person aPerson) {
         final int index = persons.indexOf(aPerson);
         if (index > 0) {
@@ -329,6 +366,9 @@ public abstract class AbstractPicture implements IPicture {
         }
     }
 
+    /**
+     * @param aPerson the person to move down in the persons list
+     */
     public void movePersonDown(final Person aPerson) {
         int index = persons.indexOf(aPerson);
         if (index != 1 && index < persons.size() - 1) {

--- a/src/main/java/com/github/noony/app/timelinefx/core/AnchorSide.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/AnchorSide.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core;
 
 /**

--- a/src/main/java/com/github/noony/app/timelinefx/core/AnchorSide.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/AnchorSide.java
@@ -18,11 +18,15 @@
 package com.github.noony.app.timelinefx.core;
 
 /**
+ * The side of an element an anchor attaches to.
  *
  * @author hamon
  */
 public enum AnchorSide {
 
+    /**
+     * The four cardinal sides, or no anchoring.
+     */
     TOP, BOTTOM, LEFT, RIGHT, NONE
 
 }

--- a/src/main/java/com/github/noony/app/timelinefx/core/DateObject.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/DateObject.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core;
 
 import com.github.noony.app.timelinefx.utils.MathUtils;
@@ -34,11 +35,14 @@ public final class DateObject implements IDateObject {
 
     private final PropertyChangeSupport propertyChangeSupport;
     //
+
     private TimeFormat timeFormat;
+
     private double timestamp;
+
     private LocalDate date;
 
-    public DateObject(LocalDate aDate) {
+    public DateObject(final LocalDate aDate) {
         propertyChangeSupport = new PropertyChangeSupport(DateObject.this);
         //
         timeFormat = TimeFormat.LOCAL_TIME;
@@ -46,7 +50,7 @@ public final class DateObject implements IDateObject {
         timestamp = -1;
     }
 
-    public DateObject(double aTimestamp) {
+    public DateObject(final double aTimestamp) {
         propertyChangeSupport = new PropertyChangeSupport(DateObject.this);
         //
         timeFormat = TimeFormat.TIME_MIN;
@@ -54,7 +58,7 @@ public final class DateObject implements IDateObject {
         date = null;
     }
 
-    public DateObject(IDateObject anotherDateObject) {
+    public DateObject(final IDateObject anotherDateObject) {
         propertyChangeSupport = new PropertyChangeSupport(DateObject.this);
         //
         timeFormat = anotherDateObject.getTimeFormat();
@@ -74,7 +78,7 @@ public final class DateObject implements IDateObject {
     }
 
     @Override
-    public void setTimeFormat(TimeFormat aTimeFormat) {
+    public void setTimeFormat(final TimeFormat aTimeFormat) {
         timeFormat = aTimeFormat;
         switch (timeFormat) {
             case LOCAL_TIME ->
@@ -97,21 +101,21 @@ public final class DateObject implements IDateObject {
     }
 
     @Override
-    public void setValue(String aTimeValue) {
+    public void setValue(final String aTimeValue) {
         if (aTimeValue == null) {
             return;
         }
         switch (timeFormat) {
             case LOCAL_TIME -> {
                 try {
-                    var newDate = LocalDate.parse(aTimeValue);
+                    final var newDate = LocalDate.parse(aTimeValue);
                     if (!newDate.isEqual(date)) {
                         date = newDate;
                         propertyChangeSupport.firePropertyChange(DATE_CHANGED, timeFormat, date);
                     }
                 } catch (Exception e) {
                     LOG.log(Level.WARNING, "Could not set date value to {0}, with '{1}': error: {2}",
-                            new Object[] { this, aTimeValue, e.getMessage() });
+                            new Object[]{this, aTimeValue, e.getMessage()});
                 }
             }
             case TIME_MIN -> {
@@ -119,7 +123,7 @@ public final class DateObject implements IDateObject {
                     timestamp = Double.parseDouble(aTimeValue);
                 } catch (NumberFormatException e) {
                     LOG.log(Level.WARNING, "Could not set timestamp value to {0}, with '{1}': error: {2}",
-                            new Object[] { this, aTimeValue, e.getMessage() });
+                            new Object[]{this, aTimeValue, e.getMessage()});
                 }
                 propertyChangeSupport.firePropertyChange(DATE_CHANGED, timeFormat, timestamp);
             }
@@ -129,7 +133,7 @@ public final class DateObject implements IDateObject {
     }
 
     @Override
-    public void setDate(LocalDate aDate) {
+    public void setDate(final LocalDate aDate) {
         if (aDate != null && !date.equals(aDate)) {
             date = aDate;
             timeFormat = TimeFormat.LOCAL_TIME;
@@ -138,7 +142,7 @@ public final class DateObject implements IDateObject {
     }
 
     @Override
-    public void setDate(IDateObject aDateObject) {
+    public void setDate(final IDateObject aDateObject) {
         if (aDateObject == null) {
             return;
         }
@@ -158,7 +162,7 @@ public final class DateObject implements IDateObject {
     }
 
     @Override
-    public void setTimestamp(double aTimestamp) {
+    public void setTimestamp(final double aTimestamp) {
         if (aTimestamp != timestamp) {
             timestamp = aTimestamp;
             timeFormat = TimeFormat.TIME_MIN;
@@ -196,12 +200,12 @@ public final class DateObject implements IDateObject {
     }
 
     @Override
-    public void addPropertyChangeListener(PropertyChangeListener listener) {
+    public void addPropertyChangeListener(final PropertyChangeListener listener) {
         propertyChangeSupport.addPropertyChangeListener(listener);
     }
 
     @Override
-    public void removePropertyChangeListener(PropertyChangeListener listener) {
+    public void removePropertyChangeListener(final PropertyChangeListener listener) {
         propertyChangeSupport.removePropertyChangeListener(listener);
     }
 

--- a/src/main/java/com/github/noony/app/timelinefx/core/DateObject.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/DateObject.java
@@ -26,22 +26,44 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
+ * Standalone {@link IDateObject} implementation, used where a date/time value is needed
+ * without being attached to a picture or stay.
  *
  * @author hamon
  */
 public final class DateObject implements IDateObject {
 
+    /**
+     * Logger used by this class.
+     */
     private static final Logger LOG = Logger.getGlobal();
 
+    /**
+     * Support object used to fire property change events.
+     */
     private final PropertyChangeSupport propertyChangeSupport;
     //
 
+    /**
+     * Whether {@link #date} or {@link #timestamp} holds this instance's value.
+     */
     private TimeFormat timeFormat;
 
+    /**
+     * This instance's raw numeric time value, used when {@link #timeFormat} is {@code TIME_MIN}.
+     */
     private double timestamp;
 
+    /**
+     * This instance's calendar date value, used when {@link #timeFormat} is {@code LOCAL_TIME}.
+     */
     private LocalDate date;
 
+    /**
+     * Creates a date object holding a calendar date.
+     *
+     * @param aDate the date value
+     */
     public DateObject(final LocalDate aDate) {
         propertyChangeSupport = new PropertyChangeSupport(DateObject.this);
         //
@@ -50,6 +72,11 @@ public final class DateObject implements IDateObject {
         timestamp = -1;
     }
 
+    /**
+     * Creates a date object holding a raw numeric timestamp.
+     *
+     * @param aTimestamp the timestamp value
+     */
     public DateObject(final double aTimestamp) {
         propertyChangeSupport = new PropertyChangeSupport(DateObject.this);
         //
@@ -58,6 +85,11 @@ public final class DateObject implements IDateObject {
         date = null;
     }
 
+    /**
+     * Creates a date object copying the value of another one.
+     *
+     * @param anotherDateObject the date object to copy
+     */
     public DateObject(final IDateObject anotherDateObject) {
         propertyChangeSupport = new PropertyChangeSupport(DateObject.this);
         //

--- a/src/main/java/com/github/noony/app/timelinefx/core/DateObject.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/DateObject.java
@@ -104,8 +104,7 @@ public final class DateObject implements IDateObject {
         }
     }
 
-    @Override
-    public TimeFormat getTimeFormat() {
+    @Override public TimeFormat getTimeFormat() {
         return timeFormat;
     }
 

--- a/src/main/java/com/github/noony/app/timelinefx/core/Event.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/Event.java
@@ -23,23 +23,48 @@ import java.util.LinkedList;
 import java.util.List;
 
 /**
+ * A named point in time, optionally associated with persons and places.
  *
  * @author hamon
  */
 public class Event {
 
+    /**
+     * The event's name.
+     */
     private final String name;
 
+    /**
+     * The persons associated with this event.
+     */
     private final List<Person> persons;
 
+    /**
+     * The places associated with this event.
+     */
     private final List<Place> places;
 
+    /**
+     * Whether {@link #localDate} or {@link #date} holds this event's time value.
+     */
     private final TimeFormat timeFormat;
 
+    /**
+     * This event's calendar date value, or null when {@link #timeFormat} is {@code TIME_MIN}.
+     */
     private final LocalDate localDate;
 
+    /**
+     * This event's raw numeric time value.
+     */
     private final long date;
 
+    /**
+     * Creates an event with a raw numeric time value.
+     *
+     * @param eventName the event's name
+     * @param aDate the event's time value
+     */
     public Event(final String eventName, long aDate) {
         name = eventName;
         persons = new LinkedList<>();
@@ -49,6 +74,12 @@ public class Event {
         timeFormat = TimeFormat.TIME_MIN;
     }
 
+    /**
+     * Creates an event with a calendar date.
+     *
+     * @param eventName the event's name
+     * @param aDate the event's date
+     */
     public Event(final String eventName, LocalDate aDate) {
         name = eventName;
         persons = new LinkedList<>();
@@ -58,26 +89,44 @@ public class Event {
         timeFormat = TimeFormat.LOCAL_TIME;
     }
 
+    /**
+     * @return this event's raw numeric time value
+     */
     public long getDate() {
         return date;
     }
 
+    /**
+     * @return this event's name
+     */
     public String getName() {
         return name;
     }
 
+    /**
+     * @return this event's time format
+     */
     public TimeFormat getTimeFormat() {
         return timeFormat;
     }
 
+    /**
+     * @return this event's calendar date value, or null if it uses a raw numeric time value
+     */
     public LocalDate getLocalDate() {
         return localDate;
     }
 
+    /**
+     * @return an unmodifiable list of the persons associated with this event
+     */
     public List<Person> getPersons() {
         return Collections.unmodifiableList(persons);
     }
 
+    /**
+     * @return an unmodifiable list of the places associated with this event
+     */
     public List<Place> getPlaces() {
         return Collections.unmodifiableList(places);
     }

--- a/src/main/java/com/github/noony/app/timelinefx/core/Event.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/Event.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core;
 
 import java.time.LocalDate;
@@ -28,14 +29,18 @@ import java.util.List;
 public class Event {
 
     private final String name;
+
     private final List<Person> persons;
+
     private final List<Place> places;
 
     private final TimeFormat timeFormat;
+
     private final LocalDate localDate;
+
     private final long date;
 
-    public Event(String eventName, long aDate) {
+    public Event(final String eventName, long aDate) {
         name = eventName;
         persons = new LinkedList<>();
         places = new LinkedList<>();
@@ -44,7 +49,7 @@ public class Event {
         timeFormat = TimeFormat.TIME_MIN;
     }
 
-    public Event(String eventName, LocalDate aDate) {
+    public Event(final String eventName, LocalDate aDate) {
         name = eventName;
         persons = new LinkedList<>();
         places = new LinkedList<>();

--- a/src/main/java/com/github/noony/app/timelinefx/core/Event.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/Event.java
@@ -65,7 +65,7 @@ public class Event {
      * @param eventName the event's name
      * @param aDate the event's time value
      */
-    public Event(final String eventName, long aDate) {
+    public Event(final String eventName, final long aDate) {
         name = eventName;
         persons = new LinkedList<>();
         places = new LinkedList<>();
@@ -80,7 +80,7 @@ public class Event {
      * @param eventName the event's name
      * @param aDate the event's date
      */
-    public Event(final String eventName, LocalDate aDate) {
+    public Event(final String eventName, final LocalDate aDate) {
         name = eventName;
         persons = new LinkedList<>();
         places = new LinkedList<>();

--- a/src/main/java/com/github/noony/app/timelinefx/core/Factory.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/Factory.java
@@ -25,6 +25,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
+ * Generic registry assigning unique ids to, and keeping track of, instances of {@code T}.
  *
  * @author hamon
  * @param <T> Any class implementing FriezeObject
@@ -36,13 +37,25 @@ public class Factory<T extends FriezeObject> {
      */
     public static final Level CREATION_LOGGING_LEVEL = Level.FINE;
 
+    /**
+     * Logger used by this factory.
+     */
     private static final Logger LOG = Logger.getGlobal();
 
+    /**
+     * Objects registered in this factory, keyed by id.
+     */
     private final Map<Long, T> objects = new HashMap<>();
     //
 
+    /**
+     * The next id to be handed out by {@link #getNextID()}.
+     */
     private long nextUniqueId;
 
+    /**
+     * Default constructor.
+     */
     public Factory() {
         // private utility constructor
     }
@@ -97,6 +110,9 @@ public class Factory<T extends FriezeObject> {
         return !objects.containsKey(id);
     }
 
+    /**
+     * @return all the objects currently registered in this factory
+     */
     public List<T> getObjects() {
         return new ArrayList<>(objects.values());
     }

--- a/src/main/java/com/github/noony/app/timelinefx/core/Factory.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/Factory.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core;
 
 import java.util.ArrayList;
@@ -36,9 +37,11 @@ public class Factory<T extends FriezeObject> {
     public static final Level CREATION_LOGGING_LEVEL = Level.FINE;
 
     private static final Logger LOG = Logger.getGlobal();
+
     private final Map<Long, T> objects = new HashMap<>();
     //
-    private long nextUniqueId = 0L;
+
+    private long nextUniqueId;
 
     public Factory() {
         // private utility constructor
@@ -57,7 +60,7 @@ public class Factory<T extends FriezeObject> {
      *
      * @param object the object the be added
      */
-    public final void addObject(T object) {
+    public final void addObject(final T object) {
         if (objects.containsKey(object.getId())) {
             throw new IllegalStateException();
         }
@@ -71,7 +74,7 @@ public class Factory<T extends FriezeObject> {
      * @return the next available unique id
      */
     public final long getNextID() {
-        long result = nextUniqueId;
+        final long result = nextUniqueId;
         incrID();
         return result;
     }
@@ -81,7 +84,7 @@ public class Factory<T extends FriezeObject> {
      * @param id an id
      * @return the corresponding FriezeObject if it exists, null otherwise.
      */
-    public final T get(long id) {
+    public final T get(final long id) {
         return objects.get(id);
     }
 
@@ -90,7 +93,7 @@ public class Factory<T extends FriezeObject> {
      * @param id an id
      * @return whether the id is already used by an object.
      */
-    public final boolean isIdAvailable(long id) {
+    public final boolean isIdAvailable(final long id) {
         return !objects.containsKey(id);
     }
 

--- a/src/main/java/com/github/noony/app/timelinefx/core/Frieze.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/Frieze.java
@@ -34,81 +34,181 @@ import java.util.stream.Collectors;
 import static javafx.application.Platform.runLater;
 
 /**
+ * A subset of a project's places, persons and stays, laid out over a shared time window.
  *
  * @author hamon
  */
 public final class Frieze implements FriezeObject {
 
+    /**
+     * Prefix used to namespace this class's property change event names.
+     */
     public static final String CLASS_NAME = "Frieze";
+    /**
+     * Name of the property change event fired when the visible date window changes.
+     */
     public static final String DATE_WINDOW_CHANGED = CLASS_NAME + "__dateWindowChanged";
 
+    /**
+     * Name of the property change event fired when this frieze's name changes.
+     */
     public static final String NAME_CHANGED = CLASS_NAME + "__nameChanged";
 
+    /**
+     * Name of the property change event fired when a stay is added.
+     */
     public static final String STAY_ADDED = CLASS_NAME + "__stayAdded";
 
+    /**
+     * Name of the property change event fired when a stay is removed.
+     */
     public static final String STAY_REMOVED = CLASS_NAME + "__stayRemoved";
 
+    /**
+     * Name of the property change event fired when a stay's dates change.
+     */
     public static final String STAY_UPDATED = CLASS_NAME + "__stayUpdated";
 
+    /**
+     * Name of the property change event fired when a person is added.
+     */
     public static final String PERSON_ADDED = CLASS_NAME + "__personAdded";
 
+    /**
+     * Name of the property change event fired when a place is added.
+     */
     public static final String PLACE_ADDED = CLASS_NAME + "__placeAdded";
 
+    /**
+     * Name of the property change event fired when a person is removed.
+     */
     public static final String PERSON_REMOVED = CLASS_NAME + "__personRemoved";
 
+    /**
+     * Name of the property change event fired when a place is removed.
+     */
     public static final String PLACE_REMOVED = CLASS_NAME + "__placeRemoved";
 
+    /**
+     * Name of the property change event fired when a start date is added.
+     */
     public static final String START_DATE_ADDED = CLASS_NAME + "__startDateAdded";
 
+    /**
+     * Name of the property change event fired when a start date is removed.
+     */
     public static final String START_DATE_REMOVED = CLASS_NAME + "__startDateRemoved";
 
+    /**
+     * Name of the property change event fired when an end date is added.
+     */
     public static final String END_DATE_ADDED = CLASS_NAME + "__endDateAdded";
 
+    /**
+     * Name of the property change event fired when an end date is removed.
+     */
     public static final String END_DATE_REMOVED = CLASS_NAME + "__endDateRemoved";
     // TODO : merge with other use
 
+    /**
+     * Fallback minimum date used when the frieze has no stays.
+     */
     private static final long DEFAULT_MIN_DATE = 0;
 
+    /**
+     * Fallback maximum date used when the frieze has no stays.
+     */
     private static final long DEFAULT_MAX_DATE = 500;
 
+    /**
+     * Logger used by this class.
+     */
     private static final Logger LOG = Logger.getGlobal();
 
     private final Long id;
+    /**
+     * The project this frieze belongs to.
+     */
     private final TimeLineProject project;
 
+    /**
+     * The stays represented in this frieze.
+     */
     private final List<StayPeriod> stayPeriods;
 
+    /**
+     * The places represented in this frieze.
+     */
     private final List<Place> places;
 
+    /**
+     * The persons represented in this frieze.
+     */
     private final List<Person> persons;
 
+    /**
+     * The persons present at each place.
+     */
     private final Map<Place, List<Person>> personsAtPlaces;
 
+    /**
+     * Support object used to fire property change events.
+     */
     private final PropertyChangeSupport propertyChangeSupport;
 
+    /**
+     * The free maps built from this frieze.
+     */
     private final List<FriezeFreeMap> friezeFreeMaps;
     //
 
+    /**
+     * All the start/end dates represented in this frieze.
+     */
     private final List<Double> dates;
 
+    /**
+     * The start dates represented in this frieze.
+     */
     private final List<Double> startDates;
 
+    /**
+     * The end dates represented in this frieze.
+     */
     private final List<Double> endDates;
     //
 
+    /**
+     * Listener attached to every stay in this frieze, to react to date changes.
+     */
     private final PropertyChangeListener stayChangesListener;
     //
 
+    /**
+     * This frieze's display name.
+     */
     private String name;
     //
 
+    /**
+     * The earliest date across this frieze's stays.
+     */
     private double minDate = DEFAULT_MIN_DATE;
 
+    /**
+     * The latest date across this frieze's stays.
+     */
     private double maxDate = DEFAULT_MAX_DATE;
     //
 
+    /**
+     * The earliest date currently visible.
+     */
     private double minDateWindow = minDate;
 
+    /**
+     * The latest date currently visible.
+     */
     private double maxDateWindow = maxDate;
     //
     private double constraintMinDate = Double.NEGATIVE_INFINITY;
@@ -145,19 +245,35 @@ public final class Frieze implements FriezeObject {
         return id;
     }
 
+    /**
+     * Creates a frieze containing all of the project's stays.
+     *
+     * @param anID the id to assign to the new frieze
+     * @param aProject the project the frieze belongs to
+     * @param friezeName the frieze's name
+     */
     public Frieze(final long anID, TimeLineProject aProject, String friezeName) {
         this(anID, aProject, friezeName, Collections.emptyList());
     }
 
+    /**
+     * @param aName this frieze's new name
+     */
     public void setName(final String aName) {
         name = aName;
         propertyChangeSupport.firePropertyChange(NAME_CHANGED, this, name);
     }
 
+    /**
+     * @return this frieze's name
+     */
     public String getName() {
         return name;
     }
 
+    /**
+     * @return the project this frieze belongs to
+     */
     public TimeLineProject getProject() {
         return project;
     }
@@ -253,6 +369,9 @@ public final class Frieze implements FriezeObject {
         stays.forEach(this::removeStay);
     }
 
+    /**
+     * @param stay the stay to remove from this frieze
+     */
     public void removeStay(final StayPeriod stay) {
         if (stayPeriods.contains(stay)) {
             stayPeriods.remove(stay);
@@ -296,6 +415,10 @@ public final class Frieze implements FriezeObject {
         }
     }
 
+    /**
+     * @param aPlace the place whose selection changed
+     * @param selected whether the place is now selected
+     */
     public void updatePlaceSelection(final Place aPlace, boolean selected) {
         //
         //System.err.println(" C'est ici qu'il faut faire l'update");
@@ -319,6 +442,10 @@ public final class Frieze implements FriezeObject {
         }
     }
 
+    /**
+     * @param p a place
+     * @return an unmodifiable list of the persons present at the given place
+     */
     public List<Person> getPersonsAtPlace(final Place p) {
         if (personsAtPlaces.containsKey(p)) {
             return Collections.unmodifiableList(personsAtPlaces.get(p));
@@ -326,108 +453,188 @@ public final class Frieze implements FriezeObject {
         return Collections.emptyList();
     }
 
+    /**
+     * @param listener the listener to add
+     */
     public void addListener(final PropertyChangeListener listener) {
         propertyChangeSupport.addPropertyChangeListener(listener);
     }
 
+    /**
+     * @param listener the listener to remove
+     */
     public void removeListener(final PropertyChangeListener listener) {
         propertyChangeSupport.addPropertyChangeListener(listener);
     }
 
+    /**
+     * @return an unmodifiable list of the stays in this frieze
+     */
     public List<StayPeriod> getStayPeriods() {
         return Collections.unmodifiableList(stayPeriods);
     }
 
+    /**
+     * @param person a person
+     * @return the stays for the given person
+     */
     public List<StayPeriod> getStayPeriods(final Person person) {
         return stayPeriods.stream().filter(s -> s.getPerson().equals(person)).collect(Collectors.toList());
     }
 
+    /**
+     * @param aPlace a place
+     * @return the stays at the given place
+     */
     public List<StayPeriod> getStayPeriods(final Place aPlace) {
         return stayPeriods.stream().filter(s -> s.getPlace().equals(aPlace)).collect(Collectors.toList());
     }
 
+    /**
+     * @param stayPeriod a stay
+     * @return the index of the stay's person in this frieze's persons list
+     */
     public int getStayIndex(final StayPeriod stayPeriod) {
         return persons.indexOf(stayPeriod.getPerson());
     }
 
+    /**
+     * @return the number of stays in this frieze
+     */
     public int getNbStays() {
         return stayPeriods.size();
     }
 
+    /**
+     * @return the number of persons in this frieze
+     */
     public int getNbPersons() {
         return persons.size();
     }
 
+    /**
+     * @return an unmodifiable list of the persons in this frieze
+     */
     public List<Person> getPersons() {
         return Collections.unmodifiableList(persons);
     }
 
+    /**
+     * Creates a new free map view of this frieze, containing all of its content.
+     *
+     * @return the created free map
+     */
     public FriezeFreeMap createFriezeFreeMap() {
         final var friezeFreeMap = FriezeFreeMapFactory.createFriezeFreeMap(this, true);
         friezeFreeMaps.add(friezeFreeMap);
         return friezeFreeMap;
     }
 
+    /**
+     * @param friezeFreeMap the free map to attach to this frieze
+     */
     public void addFriezeFreeMap(final FriezeFreeMap friezeFreeMap) {
         if (!friezeFreeMaps.contains(friezeFreeMap)) {
             friezeFreeMaps.add(friezeFreeMap);
         }
     }
 
+    /**
+     * @param aFriezeFreeMap the free map to detach from this frieze
+     */
     public void removeFriezeFreeMap(final FriezeFreeMap aFriezeFreeMap) {
         friezeFreeMaps.remove(aFriezeFreeMap);
     }
 
+    /**
+     * @return an unmodifiable list of the free maps built from this frieze
+     */
     public List<FriezeFreeMap> getFriezeFreeMaps() {
         return Collections.unmodifiableList(friezeFreeMaps);
     }
 
+    /**
+     * @return an unmodifiable list of all the start/end dates in this frieze
+     */
     public List<Double> getDates() {
         return Collections.unmodifiableList(dates);
     }
 
+    /**
+     * @return an unmodifiable list of the start dates in this frieze
+     */
     public List<Double> getStartDates() {
         return Collections.unmodifiableList(startDates);
     }
 
+    /**
+     * @return an unmodifiable list of the end dates in this frieze
+     */
     public List<Double> getEndDates() {
         return Collections.unmodifiableList(endDates);
     }
 
+    /**
+     * @return the earliest date across this frieze's stays
+     */
     public double getMinDate() {
         return minDate;
     }
 
+    /**
+     * @return the latest date across this frieze's stays
+     */
     public double getMaxDate() {
         return maxDate;
     }
 
+    /**
+     * @return the number of distinct dates in this frieze
+     */
     public int getNbDates() {
         return dates.size();
     }
 
+    /**
+     * @return the earliest date currently visible
+     */
     public double getMinDateWindow() {
         return minDateWindow;
     }
 
+    /**
+     * @return the latest date currently visible
+     */
     public double getMaxDateWindow() {
         return maxDateWindow;
     }
 
+    /**
+     * @param newMinDateWindow the new earliest visible date
+     */
     public void setMinDateWindow(final double newMinDateWindow) {
         minDateWindow = newMinDateWindow;
         propertyChangeSupport.firePropertyChange(DATE_WINDOW_CHANGED, minDateWindow, maxDateWindow);
     }
 
+    /**
+     * @param newMaxDateWindow the new latest visible date
+     */
     public void setMaxDateWindow(final double newMaxDateWindow) {
         maxDateWindow = newMaxDateWindow;
         propertyChangeSupport.firePropertyChange(DATE_WINDOW_CHANGED, minDateWindow, maxDateWindow);
     }
 
+    /**
+     * @return an unmodifiable list of the places in this frieze
+     */
     public List<Place> getPlaces() {
         return Collections.unmodifiableList(places);
     }
 
+    /**
+     * @return the time format used by this frieze's stays, or {@code TIME_MIN} if it has none
+     */
     public TimeFormat getTimeFormat() {
         return stayPeriods.isEmpty() ? TimeFormat.TIME_MIN : stayPeriods.get(0).getTimeFormat();
     }

--- a/src/main/java/com/github/noony/app/timelinefx/core/Frieze.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/Frieze.java
@@ -216,7 +216,7 @@ public final class Frieze implements FriezeObject {
     //
     private ItemSelectionPropagation itemSelectionPropagation = ItemSelectionPropagation.RECURSIVE;
 
-    protected Frieze(final long anID, TimeLineProject aProject, String friezeName, List<StayPeriod> staysToConsider) {
+    protected Frieze(final long anID, final TimeLineProject aProject, String friezeName, List<StayPeriod> staysToConsider) {
         id = anID;
         project = aProject;
         name = friezeName;
@@ -252,7 +252,7 @@ public final class Frieze implements FriezeObject {
      * @param aProject the project the frieze belongs to
      * @param friezeName the frieze's name
      */
-    public Frieze(final long anID, TimeLineProject aProject, String friezeName) {
+    public Frieze(final long anID, final TimeLineProject aProject, String friezeName) {
         this(anID, aProject, friezeName, Collections.emptyList());
     }
 
@@ -419,7 +419,7 @@ public final class Frieze implements FriezeObject {
      * @param aPlace the place whose selection changed
      * @param selected whether the place is now selected
      */
-    public void updatePlaceSelection(final Place aPlace, boolean selected) {
+    public void updatePlaceSelection(final Place aPlace, final boolean selected) {
         //
         //System.err.println(" C'est ici qu'il faut faire l'update");
         if (selected) {
@@ -710,7 +710,7 @@ public final class Frieze implements FriezeObject {
         return true;
     }
 
-    private void updateDatesOnRemoval(final double dateRemoved, boolean isStartDate) {
+    private void updateDatesOnRemoval(final double dateRemoved, final boolean isStartDate) {
         final var notInStartDates = stayPeriods.stream().mapToDouble(StayPeriod::getStartDate).noneMatch(d -> d == dateRemoved);
         final var notInEndDates = stayPeriods.stream().mapToDouble(StayPeriod::getEndDate).noneMatch(d -> d == dateRemoved);
         if (isStartDate && notInStartDates) {
@@ -726,7 +726,7 @@ public final class Frieze implements FriezeObject {
 
     }
 
-    private void updateDatesOnCreation(final double dateAdded, boolean isStartDate) {
+    private void updateDatesOnCreation(final double dateAdded, final boolean isStartDate) {
         // start by updating min max
         final var minWindowsAtMinDate = minDate == minDateWindow;
         final var maxWindowsAtMaxDate = maxDate == maxDateWindow;

--- a/src/main/java/com/github/noony/app/timelinefx/core/Frieze.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/Frieze.java
@@ -216,7 +216,7 @@ public final class Frieze implements FriezeObject {
     //
     private ItemSelectionPropagation itemSelectionPropagation = ItemSelectionPropagation.RECURSIVE;
 
-    protected Frieze(final long anID, final TimeLineProject aProject, String friezeName, List<StayPeriod> staysToConsider) {
+    protected Frieze(final long anID, final TimeLineProject aProject, final String friezeName, List<StayPeriod> staysToConsider) {
         id = anID;
         project = aProject;
         name = friezeName;
@@ -252,7 +252,7 @@ public final class Frieze implements FriezeObject {
      * @param aProject the project the frieze belongs to
      * @param friezeName the frieze's name
      */
-    public Frieze(final long anID, final TimeLineProject aProject, String friezeName) {
+    public Frieze(final long anID, final TimeLineProject aProject, final String friezeName) {
         this(anID, aProject, friezeName, Collections.emptyList());
     }
 

--- a/src/main/java/com/github/noony/app/timelinefx/core/Frieze.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/Frieze.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core;
 
 import com.github.noony.app.timelinefx.core.freemap.FriezeFreeMap;
@@ -40,45 +41,74 @@ public final class Frieze implements FriezeObject {
 
     public static final String CLASS_NAME = "Frieze";
     public static final String DATE_WINDOW_CHANGED = CLASS_NAME + "__dateWindowChanged";
+
     public static final String NAME_CHANGED = CLASS_NAME + "__nameChanged";
+
     public static final String STAY_ADDED = CLASS_NAME + "__stayAdded";
+
     public static final String STAY_REMOVED = CLASS_NAME + "__stayRemoved";
+
     public static final String STAY_UPDATED = CLASS_NAME + "__stayUpdated";
+
     public static final String PERSON_ADDED = CLASS_NAME + "__personAdded";
+
     public static final String PLACE_ADDED = CLASS_NAME + "__placeAdded";
+
     public static final String PERSON_REMOVED = CLASS_NAME + "__personRemoved";
+
     public static final String PLACE_REMOVED = CLASS_NAME + "__placeRemoved";
+
     public static final String START_DATE_ADDED = CLASS_NAME + "__startDateAdded";
+
     public static final String START_DATE_REMOVED = CLASS_NAME + "__startDateRemoved";
+
     public static final String END_DATE_ADDED = CLASS_NAME + "__endDateAdded";
+
     public static final String END_DATE_REMOVED = CLASS_NAME + "__endDateRemoved";
     // TODO : merge with other use
+
     private static final long DEFAULT_MIN_DATE = 0;
+
     private static final long DEFAULT_MAX_DATE = 500;
 
     private static final Logger LOG = Logger.getGlobal();
 
     private final Long id;
     private final TimeLineProject project;
+
     private final List<StayPeriod> stayPeriods;
+
     private final List<Place> places;
+
     private final List<Person> persons;
+
     private final Map<Place, List<Person>> personsAtPlaces;
+
     private final PropertyChangeSupport propertyChangeSupport;
+
     private final List<FriezeFreeMap> friezeFreeMaps;
     //
+
     private final List<Double> dates;
+
     private final List<Double> startDates;
+
     private final List<Double> endDates;
     //
+
     private final PropertyChangeListener stayChangesListener;
     //
+
     private String name;
     //
+
     private double minDate = DEFAULT_MIN_DATE;
+
     private double maxDate = DEFAULT_MAX_DATE;
     //
+
     private double minDateWindow = minDate;
+
     private double maxDateWindow = maxDate;
     //
     private double constraintMinDate = Double.NEGATIVE_INFINITY;
@@ -86,7 +116,7 @@ public final class Frieze implements FriezeObject {
     //
     private ItemSelectionPropagation itemSelectionPropagation = ItemSelectionPropagation.RECURSIVE;
 
-    protected Frieze(long anID, TimeLineProject aProject, String friezeName, List<StayPeriod> staysToConsider) {
+    protected Frieze(final long anID, TimeLineProject aProject, String friezeName, List<StayPeriod> staysToConsider) {
         id = anID;
         project = aProject;
         name = friezeName;
@@ -115,11 +145,11 @@ public final class Frieze implements FriezeObject {
         return id;
     }
 
-    public Frieze(long anID, TimeLineProject aProject, String friezeName) {
+    public Frieze(final long anID, TimeLineProject aProject, String friezeName) {
         this(anID, aProject, friezeName, Collections.emptyList());
     }
 
-    public void setName(String aName) {
+    public void setName(final String aName) {
         name = aName;
         propertyChangeSupport.firePropertyChange(NAME_CHANGED, this, name);
     }
@@ -135,10 +165,10 @@ public final class Frieze implements FriezeObject {
     private void addPerson(Person aPerson) {
         if (!persons.contains(aPerson)) {
             persons.add(aPerson);
-            var stays = project.getStays().stream().filter(s -> s.getPerson() == aPerson).toList();
-            var tmpPlaces = stays.stream().map(StayPeriod::getPlace).distinct().toList();
+            final var stays = project.getStays().stream().filter(s -> s.getPerson() == aPerson).toList();
+            final var tmpPlaces = stays.stream().map(StayPeriod::getPlace).distinct().toList();
             tmpPlaces.forEach(place -> {
-                var tempPersons = personsAtPlaces.computeIfAbsent(place, k -> new LinkedList<>());
+                final var tempPersons = personsAtPlaces.computeIfAbsent(place, k -> new LinkedList<>());
                 tempPersons.add(aPerson);
             });
             // notify place added
@@ -223,7 +253,7 @@ public final class Frieze implements FriezeObject {
         stays.forEach(this::removeStay);
     }
 
-    public void removeStay(StayPeriod stay) {
+    public void removeStay(final StayPeriod stay) {
         if (stayPeriods.contains(stay)) {
             stayPeriods.remove(stay);
             stay.removeListener(stayChangesListener);
@@ -231,10 +261,10 @@ public final class Frieze implements FriezeObject {
             //
             updateMinMaxDates();
             //
-            var startDate = stay.getStartDate();
-            var endDate = stay.getEndDate();
-            var removeStart = stayPeriods.stream().mapToDouble(StayPeriod::getStartDate).noneMatch(d -> d == startDate);
-            var removeEnd = stayPeriods.stream().mapToDouble(StayPeriod::getEndDate).noneMatch(d -> d == endDate);
+            final var startDate = stay.getStartDate();
+            final var endDate = stay.getEndDate();
+            final var removeStart = stayPeriods.stream().mapToDouble(StayPeriod::getStartDate).noneMatch(d -> d == startDate);
+            final var removeEnd = stayPeriods.stream().mapToDouble(StayPeriod::getEndDate).noneMatch(d -> d == endDate);
             maxDate = stayPeriods.stream().mapToDouble(StayPeriod::getEndDate).max().orElse(DEFAULT_MAX_DATE);
             if (removeStart) {
                 startDates.remove(startDate);
@@ -266,7 +296,7 @@ public final class Frieze implements FriezeObject {
         }
     }
 
-    public void updatePlaceSelection(Place aPlace, boolean selected) {
+    public void updatePlaceSelection(final Place aPlace, boolean selected) {
         //
         //System.err.println(" C'est ici qu'il faut faire l'update");
         if (selected) {
@@ -289,18 +319,18 @@ public final class Frieze implements FriezeObject {
         }
     }
 
-    public List<Person> getPersonsAtPlace(Place p) {
+    public List<Person> getPersonsAtPlace(final Place p) {
         if (personsAtPlaces.containsKey(p)) {
             return Collections.unmodifiableList(personsAtPlaces.get(p));
         }
         return Collections.emptyList();
     }
 
-    public void addListener(PropertyChangeListener listener) {
+    public void addListener(final PropertyChangeListener listener) {
         propertyChangeSupport.addPropertyChangeListener(listener);
     }
 
-    public void removeListener(PropertyChangeListener listener) {
+    public void removeListener(final PropertyChangeListener listener) {
         propertyChangeSupport.addPropertyChangeListener(listener);
     }
 
@@ -308,15 +338,15 @@ public final class Frieze implements FriezeObject {
         return Collections.unmodifiableList(stayPeriods);
     }
 
-    public List<StayPeriod> getStayPeriods(Person person) {
+    public List<StayPeriod> getStayPeriods(final Person person) {
         return stayPeriods.stream().filter(s -> s.getPerson().equals(person)).collect(Collectors.toList());
     }
 
-    public List<StayPeriod> getStayPeriods(Place aPlace) {
+    public List<StayPeriod> getStayPeriods(final Place aPlace) {
         return stayPeriods.stream().filter(s -> s.getPlace().equals(aPlace)).collect(Collectors.toList());
     }
 
-    public int getStayIndex(StayPeriod stayPeriod) {
+    public int getStayIndex(final StayPeriod stayPeriod) {
         return persons.indexOf(stayPeriod.getPerson());
     }
 
@@ -333,18 +363,18 @@ public final class Frieze implements FriezeObject {
     }
 
     public FriezeFreeMap createFriezeFreeMap() {
-        var friezeFreeMap = FriezeFreeMapFactory.createFriezeFreeMap(this, true);
+        final var friezeFreeMap = FriezeFreeMapFactory.createFriezeFreeMap(this, true);
         friezeFreeMaps.add(friezeFreeMap);
         return friezeFreeMap;
     }
 
-    public void addFriezeFreeMap(FriezeFreeMap friezeFreeMap) {
+    public void addFriezeFreeMap(final FriezeFreeMap friezeFreeMap) {
         if (!friezeFreeMaps.contains(friezeFreeMap)) {
             friezeFreeMaps.add(friezeFreeMap);
         }
     }
 
-    public void removeFriezeFreeMap(FriezeFreeMap aFriezeFreeMap) {
+    public void removeFriezeFreeMap(final FriezeFreeMap aFriezeFreeMap) {
         friezeFreeMaps.remove(aFriezeFreeMap);
     }
 
@@ -384,12 +414,12 @@ public final class Frieze implements FriezeObject {
         return maxDateWindow;
     }
 
-    public void setMinDateWindow(double newMinDateWindow) {
+    public void setMinDateWindow(final double newMinDateWindow) {
         minDateWindow = newMinDateWindow;
         propertyChangeSupport.firePropertyChange(DATE_WINDOW_CHANGED, minDateWindow, maxDateWindow);
     }
 
-    public void setMaxDateWindow(double newMaxDateWindow) {
+    public void setMaxDateWindow(final double newMaxDateWindow) {
         maxDateWindow = newMaxDateWindow;
         propertyChangeSupport.firePropertyChange(DATE_WINDOW_CHANGED, minDateWindow, maxDateWindow);
     }
@@ -402,7 +432,7 @@ public final class Frieze implements FriezeObject {
         return stayPeriods.isEmpty() ? TimeFormat.TIME_MIN : stayPeriods.get(0).getTimeFormat();
     }
 
-    private void handleTimeLineProjectChanges(PropertyChangeEvent event) {
+    private void handleTimeLineProjectChanges(final PropertyChangeEvent event) {
         switch (event.getPropertyName()) {
             case TimeLineProject.HIGH_LEVEL_PLACE_ADDED, TimeLineProject.PLACE_ADDED -> {
                 // Nothing to do
@@ -427,10 +457,10 @@ public final class Frieze implements FriezeObject {
         }
     }
 
-    private void handleStayPeriodChanges(PropertyChangeEvent event) {
+    private void handleStayPeriodChanges(final PropertyChangeEvent event) {
         switch (event.getPropertyName()) {
             case StayPeriod.START_DATE_CHANGED -> {
-                var stay = (StayPeriod) event.getSource();
+                final var stay = (StayPeriod) event.getSource();
                 // First update the relevant dates before notifying of the stay change
                 updateDatesOnRemoval((long) event.getOldValue(), true);
                 updateDatesOnCreation((long) event.getNewValue(), true);
@@ -448,10 +478,10 @@ public final class Frieze implements FriezeObject {
         }
     }
 
-    private void removePlace(Place placeRemoved) {
+    private void removePlace(final Place placeRemoved) {
         places.remove(placeRemoved);
         personsAtPlaces.remove(placeRemoved);
-        var staysToRemove = stayPeriods.stream().filter(s -> s.getPlace() == placeRemoved).toList();
+        final var staysToRemove = stayPeriods.stream().filter(s -> s.getPlace() == placeRemoved).toList();
         // for concurrency accces...
         staysToRemove.forEach(this::removeStay);
         propertyChangeSupport.firePropertyChange(PLACE_REMOVED, this, placeRemoved);
@@ -466,16 +496,16 @@ public final class Frieze implements FriezeObject {
             return false;
         }
         personsAtPlaces.forEach((place, list) -> list.remove(personRemoved));
-        List<StayPeriod> impactedStays = stayPeriods.stream().filter(s -> s.getPerson() == personRemoved).toList();
+        final List<StayPeriod> impactedStays = stayPeriods.stream().filter(s -> s.getPerson() == personRemoved).toList();
         impactedStays.forEach(this::removeStay);
         LOG.log(Level.INFO, " > Done removing person: {0},\t >> propagating change.", new Object[]{personRemoved, this});
         propertyChangeSupport.firePropertyChange(PERSON_REMOVED, this, personRemoved);
         return true;
     }
 
-    private void updateDatesOnRemoval(double dateRemoved, boolean isStartDate) {
-        var notInStartDates = stayPeriods.stream().mapToDouble(StayPeriod::getStartDate).noneMatch(d -> d == dateRemoved);
-        var notInEndDates = stayPeriods.stream().mapToDouble(StayPeriod::getEndDate).noneMatch(d -> d == dateRemoved);
+    private void updateDatesOnRemoval(final double dateRemoved, boolean isStartDate) {
+        final var notInStartDates = stayPeriods.stream().mapToDouble(StayPeriod::getStartDate).noneMatch(d -> d == dateRemoved);
+        final var notInEndDates = stayPeriods.stream().mapToDouble(StayPeriod::getEndDate).noneMatch(d -> d == dateRemoved);
         if (isStartDate && notInStartDates) {
             startDates.remove(dateRemoved);
             propertyChangeSupport.firePropertyChange(START_DATE_REMOVED, this, dateRemoved);
@@ -489,12 +519,12 @@ public final class Frieze implements FriezeObject {
 
     }
 
-    private void updateDatesOnCreation(double dateAdded, boolean isStartDate) {
+    private void updateDatesOnCreation(final double dateAdded, boolean isStartDate) {
         // start by updating min max
-        var minWindowsAtMinDate = minDate == minDateWindow;
-        var maxWindowsAtMaxDate = maxDate == maxDateWindow;
-        var oldMinDate = minDate;
-        var oldMaxDate = maxDate;
+        final var minWindowsAtMinDate = minDate == minDateWindow;
+        final var maxWindowsAtMaxDate = maxDate == maxDateWindow;
+        final var oldMinDate = minDate;
+        final var oldMaxDate = maxDate;
         minDate = stayPeriods.stream().mapToDouble(StayPeriod::getStartDate).min().orElse(DEFAULT_MIN_DATE);
         maxDate = stayPeriods.stream().mapToDouble(StayPeriod::getEndDate).max().orElse(DEFAULT_MAX_DATE);
         //

--- a/src/main/java/com/github/noony/app/timelinefx/core/FriezeFactory.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/FriezeFactory.java
@@ -22,31 +22,56 @@ import java.util.logging.Logger;
 import static com.github.noony.app.timelinefx.core.Factory.CREATION_LOGGING_LEVEL;
 
 /**
+ * Entry point for creating and retrieving {@link Frieze} instances.
  *
  * @author hamon
  */
 public final class FriezeFactory {
 
+    /**
+     * Logger used by this factory.
+     */
     private static final Logger LOG = Logger.getGlobal();
 
+    /**
+     * Registry of created friezes.
+     */
     private static final Factory<Frieze> FACTORY = new Factory<>();
 
     private FriezeFactory() {
         // private utility constructor
     }
 
+    /**
+     * Resets the factory, discarding all created friezes.
+     */
     public static void reset() {
         FACTORY.reset();
     }
 
+    /**
+     * @return all the friezes created so far
+     */
     public static List<Frieze> getFriezes() {
         return FACTORY.getObjects();
     }
 
+    /**
+     * @param friezeID a frieze's id
+     * @return the frieze with the given id, or null if none exists
+     */
     public static Frieze getFrieze(final long friezeID) {
         return FACTORY.get(friezeID);
     }
 
+    /**
+     * Creates a new frieze restricted to the given stays.
+     *
+     * @param aProject the project the frieze belongs to
+     * @param friezeName the frieze's name
+     * @param staysToConsider the stays to include in the frieze
+     * @return the created frieze
+     */
     public static Frieze createFrieze(final TimeLineProject aProject, String friezeName, List<StayPeriod> staysToConsider) {
         LOG.log(CREATION_LOGGING_LEVEL, "Creating a frieze with TimeLineProject={0} friezeName={1} staysToConsider={2} ", new Object[]{aProject.getName(), friezeName, staysToConsider});
         final var frieze = new Frieze(FACTORY.getNextID(), aProject, friezeName, staysToConsider);
@@ -54,6 +79,15 @@ public final class FriezeFactory {
         return frieze;
     }
 
+    /**
+     * Creates a new frieze with a specific id, restricted to the given stays.
+     *
+     * @param anID the id to assign to the new frieze
+     * @param aProject the project the frieze belongs to
+     * @param friezeName the frieze's name
+     * @param staysToConsider the stays to include in the frieze
+     * @return the created frieze
+     */
     public static Frieze createFrieze(final long anID, TimeLineProject aProject, String friezeName, List<StayPeriod> staysToConsider) {
         if (!FACTORY.isIdAvailable(anID)) {
             throw new IllegalArgumentException("trying to create a frieze " + friezeName + " with existing id=" + anID);
@@ -64,6 +98,13 @@ public final class FriezeFactory {
         return frieze;
     }
 
+    /**
+     * Creates a new frieze containing all of the project's stays.
+     *
+     * @param aProject the project the frieze belongs to
+     * @param friezeName the frieze's name
+     * @return the created frieze
+     */
     public static Frieze createFrieze(final TimeLineProject aProject, String friezeName) {
         LOG.log(CREATION_LOGGING_LEVEL, "Creating a frieze with TimeLineProject={0} friezeName={1}", new Object[]{aProject.getName(), friezeName});
         final var frieze = new Frieze(FACTORY.getNextID(), aProject, friezeName);

--- a/src/main/java/com/github/noony/app/timelinefx/core/FriezeFactory.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/FriezeFactory.java
@@ -72,7 +72,7 @@ public final class FriezeFactory {
      * @param staysToConsider the stays to include in the frieze
      * @return the created frieze
      */
-    public static Frieze createFrieze(final TimeLineProject aProject, String friezeName, List<StayPeriod> staysToConsider) {
+    public static Frieze createFrieze(final TimeLineProject aProject, final String friezeName, List<StayPeriod> staysToConsider) {
         LOG.log(CREATION_LOGGING_LEVEL, "Creating a frieze with TimeLineProject={0} friezeName={1} staysToConsider={2} ", new Object[]{aProject.getName(), friezeName, staysToConsider});
         final var frieze = new Frieze(FACTORY.getNextID(), aProject, friezeName, staysToConsider);
         FACTORY.addObject(frieze);
@@ -88,7 +88,7 @@ public final class FriezeFactory {
      * @param staysToConsider the stays to include in the frieze
      * @return the created frieze
      */
-    public static Frieze createFrieze(final long anID, TimeLineProject aProject, String friezeName, List<StayPeriod> staysToConsider) {
+    public static Frieze createFrieze(final long anID, final TimeLineProject aProject, String friezeName, List<StayPeriod> staysToConsider) {
         if (!FACTORY.isIdAvailable(anID)) {
             throw new IllegalArgumentException("trying to create a frieze " + friezeName + " with existing id=" + anID);
         }
@@ -105,7 +105,7 @@ public final class FriezeFactory {
      * @param friezeName the frieze's name
      * @return the created frieze
      */
-    public static Frieze createFrieze(final TimeLineProject aProject, String friezeName) {
+    public static Frieze createFrieze(final TimeLineProject aProject, final String friezeName) {
         LOG.log(CREATION_LOGGING_LEVEL, "Creating a frieze with TimeLineProject={0} friezeName={1}", new Object[]{aProject.getName(), friezeName});
         final var frieze = new Frieze(FACTORY.getNextID(), aProject, friezeName);
         FACTORY.addObject(frieze);

--- a/src/main/java/com/github/noony/app/timelinefx/core/FriezeFactory.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/FriezeFactory.java
@@ -72,7 +72,7 @@ public final class FriezeFactory {
      * @param staysToConsider the stays to include in the frieze
      * @return the created frieze
      */
-    public static Frieze createFrieze(final TimeLineProject aProject, final String friezeName, List<StayPeriod> staysToConsider) {
+    public static Frieze createFrieze(final TimeLineProject aProject, final String friezeName, final List<StayPeriod> staysToConsider) {
         LOG.log(CREATION_LOGGING_LEVEL, "Creating a frieze with TimeLineProject={0} friezeName={1} staysToConsider={2} ", new Object[]{aProject.getName(), friezeName, staysToConsider});
         final var frieze = new Frieze(FACTORY.getNextID(), aProject, friezeName, staysToConsider);
         FACTORY.addObject(frieze);
@@ -88,7 +88,7 @@ public final class FriezeFactory {
      * @param staysToConsider the stays to include in the frieze
      * @return the created frieze
      */
-    public static Frieze createFrieze(final long anID, final TimeLineProject aProject, String friezeName, List<StayPeriod> staysToConsider) {
+    public static Frieze createFrieze(final long anID, final TimeLineProject aProject, final String friezeName, List<StayPeriod> staysToConsider) {
         if (!FACTORY.isIdAvailable(anID)) {
             throw new IllegalArgumentException("trying to create a frieze " + friezeName + " with existing id=" + anID);
         }

--- a/src/main/java/com/github/noony/app/timelinefx/core/FriezeFactory.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/FriezeFactory.java
@@ -14,11 +14,12 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core;
 
-import static com.github.noony.app.timelinefx.core.Factory.CREATION_LOGGING_LEVEL;
 import java.util.List;
 import java.util.logging.Logger;
+import static com.github.noony.app.timelinefx.core.Factory.CREATION_LOGGING_LEVEL;
 
 /**
  *
@@ -28,7 +29,7 @@ public final class FriezeFactory {
 
     private static final Logger LOG = Logger.getGlobal();
 
-    private static final Factory<Frieze> FACTORY =new Factory<>();
+    private static final Factory<Frieze> FACTORY = new Factory<>();
 
     private FriezeFactory() {
         // private utility constructor
@@ -42,30 +43,30 @@ public final class FriezeFactory {
         return FACTORY.getObjects();
     }
 
-    public static Frieze getFrieze(long friezeID) {
+    public static Frieze getFrieze(final long friezeID) {
         return FACTORY.get(friezeID);
     }
 
-    public static Frieze createFrieze(TimeLineProject aProject, String friezeName, List<StayPeriod> staysToConsider) {
+    public static Frieze createFrieze(final TimeLineProject aProject, String friezeName, List<StayPeriod> staysToConsider) {
         LOG.log(CREATION_LOGGING_LEVEL, "Creating a frieze with TimeLineProject={0} friezeName={1} staysToConsider={2} ", new Object[]{aProject.getName(), friezeName, staysToConsider});
-        var frieze = new Frieze(FACTORY.getNextID(), aProject, friezeName, staysToConsider);
+        final var frieze = new Frieze(FACTORY.getNextID(), aProject, friezeName, staysToConsider);
         FACTORY.addObject(frieze);
         return frieze;
     }
 
-    public static Frieze createFrieze(long anID, TimeLineProject aProject, String friezeName, List<StayPeriod> staysToConsider) {
+    public static Frieze createFrieze(final long anID, TimeLineProject aProject, String friezeName, List<StayPeriod> staysToConsider) {
         if (!FACTORY.isIdAvailable(anID)) {
             throw new IllegalArgumentException("trying to create a frieze " + friezeName + " with existing id=" + anID);
         }
         LOG.log(CREATION_LOGGING_LEVEL, "Creating a frieze (id={0} with TimeLineProject={1} friezeName={2} staysToConsider={3} ", new Object[]{anID, aProject.getName(), friezeName, staysToConsider});
-        var frieze = new Frieze(anID, aProject, friezeName, staysToConsider);
+        final var frieze = new Frieze(anID, aProject, friezeName, staysToConsider);
         FACTORY.addObject(frieze);
         return frieze;
     }
 
-    public static Frieze createFrieze(TimeLineProject aProject, String friezeName) {
+    public static Frieze createFrieze(final TimeLineProject aProject, String friezeName) {
         LOG.log(CREATION_LOGGING_LEVEL, "Creating a frieze with TimeLineProject={0} friezeName={1}", new Object[]{aProject.getName(), friezeName});
-        var frieze = new Frieze(FACTORY.getNextID(), aProject, friezeName);
+        final var frieze = new Frieze(FACTORY.getNextID(), aProject, friezeName);
         FACTORY.addObject(frieze);
         return frieze;
     }

--- a/src/main/java/com/github/noony/app/timelinefx/core/FriezeObject.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/FriezeObject.java
@@ -27,12 +27,12 @@ public interface FriezeObject {
     /**
      * Value used for objects that have not been assigned a real id yet.
      */
-    final long NO_ID = -1;
+    long NO_ID = -1;
 
     /**
      * Each IFriezeObject instance has a unique id in its project's scope
      *
      * @return the object unique ID
      */
-    abstract long getId();
+    long getId();
 }

--- a/src/main/java/com/github/noony/app/timelinefx/core/FriezeObject.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/FriezeObject.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core;
 
 /**
@@ -22,12 +23,12 @@ package com.github.noony.app.timelinefx.core;
  */
 public interface FriezeObject {
 
-    long NO_ID = -1;
+    final long NO_ID = -1;
 
     /**
      * Each IFriezeObject instance has a unique id in its project's scope
      *
      * @return the object unique ID
      */
-    long getId();
+    abstract long getId();
 }

--- a/src/main/java/com/github/noony/app/timelinefx/core/FriezeObjectFactory.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/FriezeObjectFactory.java
@@ -18,6 +18,7 @@
 package com.github.noony.app.timelinefx.core;
 
 /**
+ * Utility entry point for resetting all the object factories in the {@code core} package at once.
  *
  * @author arnaud
  */

--- a/src/main/java/com/github/noony/app/timelinefx/core/FriezeObjectFactory.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/FriezeObjectFactory.java
@@ -14,13 +14,14 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core;
 
 /**
  *
  * @author arnaud
  */
-public class FriezeObjectFactory {
+public final class FriezeObjectFactory {
 
 
     private FriezeObjectFactory() {

--- a/src/main/java/com/github/noony/app/timelinefx/core/IDateObject.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/IDateObject.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core;
 
 import java.beans.PropertyChangeListener;
@@ -26,93 +27,93 @@ import java.time.format.DateTimeFormatter;
  */
 public interface IDateObject {
 
-    DateTimeFormatter DEFAULT_DATE_FORMATTER = DateTimeFormatter.ISO_DATE;
+    final DateTimeFormatter DEFAULT_DATE_FORMATTER = DateTimeFormatter.ISO_DATE;
 
-    DateTimeFormatter DEFAULT_DATE_TIME_FORMATTER = DateTimeFormatter.ISO_DATE_TIME;
+    final DateTimeFormatter DEFAULT_DATE_TIME_FORMATTER = DateTimeFormatter.ISO_DATE_TIME;
 
     /**
      * The default time stamp
      */
-    long DEFAULT_TIMESTAMP = 0;
+    final long DEFAULT_TIMESTAMP = 0;
 
     /**
      * Name of the property change event for date change
      */
-    String DATE_CHANGED = "pictureDateChanged";
+    final String DATE_CHANGED = "pictureDateChanged";
 
     /**
      *
      * @return the TimeFormat used by the instance
      */
-    TimeFormat getTimeFormat();
+    abstract TimeFormat getTimeFormat();
 
     /**
      *
      * @param aTimeFormat the new time format to be used by the instance
      */
-    void setTimeFormat(TimeFormat aTimeFormat);
+    abstract void setTimeFormat(TimeFormat aTimeFormat);
 
     /**
      *
      * @return the instance date value, or null if not set or if the time format is
      *         not compatible
      */
-    LocalDate getDate();
+    abstract LocalDate getDate();
 
     /**
      *
      * @return the instance time stamp
      */
-    double getTimestamp();
+    abstract double getTimestamp();
 
     /**
      *
      * @param aTimeValue updates the time value based on the input parameter
      */
-    void setValue(String aTimeValue);
+    abstract void setValue(String aTimeValue);
 
     /**
      *
      * @param aDate the instance's new date value
      */
-    void setDate(LocalDate aDate);
+    abstract void setDate(LocalDate aDate);
 
     /**
      *
      * @param aTimestamp the instance new time stamp
      */
-    void setTimestamp(double aTimestamp);
+    abstract void setTimestamp(double aTimestamp);
 
     /**
      *
      * @param aDateObject the date object containing the date to be retreived
      */
-    void setDate(IDateObject aDateObject);
+    abstract void setDate(IDateObject aDateObject);
 
     /**
      *
      * @return an absolute time value to compare dateObjects no matter their time
      *         format
      */
-    double getAbsoluteTime();
+    abstract double getAbsoluteTime();
 
     /**
      *
      * @return a string representation of the time no matter the time format
      */
-    String getAbsoluteTimeAsString();
+    abstract String getAbsoluteTimeAsString();
 
     /**
      * PropertyChangeListener to be added
-     * 
+     *
      * @param listener
      */
-    void addPropertyChangeListener(PropertyChangeListener listener);
+    abstract void addPropertyChangeListener(PropertyChangeListener listener);
 
     /**
      * PropertyChangeListener to be removed
-     * 
+     *
      * @param listener
      */
-    void removePropertyChangeListener(PropertyChangeListener listener);
+    abstract void removePropertyChangeListener(PropertyChangeListener listener);
 }

--- a/src/main/java/com/github/noony/app/timelinefx/core/IDateObject.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/IDateObject.java
@@ -22,13 +22,21 @@ import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 
 /**
+ * Contract for objects holding a date/time value that can be represented either as a
+ * calendar date or as a raw numeric timestamp.
  *
  * @author hamon
  */
 public interface IDateObject {
 
+    /**
+     * Formatter used to parse/format {@link #DEFAULT_DATE_FORMATTER}-style dates.
+     */
     final DateTimeFormatter DEFAULT_DATE_FORMATTER = DateTimeFormatter.ISO_DATE;
 
+    /**
+     * Formatter used to parse/format date-time values.
+     */
     final DateTimeFormatter DEFAULT_DATE_TIME_FORMATTER = DateTimeFormatter.ISO_DATE_TIME;
 
     /**
@@ -106,14 +114,14 @@ public interface IDateObject {
     /**
      * PropertyChangeListener to be added
      *
-     * @param listener
+     * @param listener the listener to add
      */
     abstract void addPropertyChangeListener(PropertyChangeListener listener);
 
     /**
      * PropertyChangeListener to be removed
      *
-     * @param listener
+     * @param listener the listener to remove
      */
     abstract void removePropertyChangeListener(PropertyChangeListener listener);
 }

--- a/src/main/java/com/github/noony/app/timelinefx/core/IDateObject.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/IDateObject.java
@@ -32,96 +32,96 @@ public interface IDateObject {
     /**
      * Formatter used to parse/format {@link #DEFAULT_DATE_FORMATTER}-style dates.
      */
-    final DateTimeFormatter DEFAULT_DATE_FORMATTER = DateTimeFormatter.ISO_DATE;
+    DateTimeFormatter DEFAULT_DATE_FORMATTER = DateTimeFormatter.ISO_DATE;
 
     /**
      * Formatter used to parse/format date-time values.
      */
-    final DateTimeFormatter DEFAULT_DATE_TIME_FORMATTER = DateTimeFormatter.ISO_DATE_TIME;
+    DateTimeFormatter DEFAULT_DATE_TIME_FORMATTER = DateTimeFormatter.ISO_DATE_TIME;
 
     /**
      * The default time stamp
      */
-    final long DEFAULT_TIMESTAMP = 0;
+    long DEFAULT_TIMESTAMP = 0;
 
     /**
      * Name of the property change event for date change
      */
-    final String DATE_CHANGED = "pictureDateChanged";
+    String DATE_CHANGED = "pictureDateChanged";
 
     /**
      *
      * @return the TimeFormat used by the instance
      */
-    abstract TimeFormat getTimeFormat();
+    TimeFormat getTimeFormat();
 
     /**
      *
      * @param aTimeFormat the new time format to be used by the instance
      */
-    abstract void setTimeFormat(TimeFormat aTimeFormat);
+    void setTimeFormat(TimeFormat aTimeFormat);
 
     /**
      *
      * @return the instance date value, or null if not set or if the time format is
      *         not compatible
      */
-    abstract LocalDate getDate();
+    LocalDate getDate();
 
     /**
      *
      * @return the instance time stamp
      */
-    abstract double getTimestamp();
+    double getTimestamp();
 
     /**
      *
      * @param aTimeValue updates the time value based on the input parameter
      */
-    abstract void setValue(String aTimeValue);
+    void setValue(String aTimeValue);
 
     /**
      *
      * @param aDate the instance's new date value
      */
-    abstract void setDate(LocalDate aDate);
+    void setDate(LocalDate aDate);
 
     /**
      *
      * @param aTimestamp the instance new time stamp
      */
-    abstract void setTimestamp(double aTimestamp);
+    void setTimestamp(double aTimestamp);
 
     /**
      *
      * @param aDateObject the date object containing the date to be retreived
      */
-    abstract void setDate(IDateObject aDateObject);
+    void setDate(IDateObject aDateObject);
 
     /**
      *
      * @return an absolute time value to compare dateObjects no matter their time
      *         format
      */
-    abstract double getAbsoluteTime();
+    double getAbsoluteTime();
 
     /**
      *
      * @return a string representation of the time no matter the time format
      */
-    abstract String getAbsoluteTimeAsString();
+    String getAbsoluteTimeAsString();
 
     /**
      * PropertyChangeListener to be added
      *
      * @param listener the listener to add
      */
-    abstract void addPropertyChangeListener(PropertyChangeListener listener);
+    void addPropertyChangeListener(PropertyChangeListener listener);
 
     /**
      * PropertyChangeListener to be removed
      *
      * @param listener the listener to remove
      */
-    abstract void removePropertyChangeListener(PropertyChangeListener listener);
+    void removePropertyChangeListener(PropertyChangeListener listener);
 }

--- a/src/main/java/com/github/noony/app/timelinefx/core/IDrawableObject.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/IDrawableObject.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core;
 
 /**
@@ -26,11 +27,11 @@ public interface IDrawableObject {
      *
      * @return the object's width
      */
-    double getWidth();
+    abstract double getWidth();
 
     /**
      *
      * @return the object's height
      */
-    double getHeight();
+    abstract double getHeight();
 }

--- a/src/main/java/com/github/noony/app/timelinefx/core/IDrawableObject.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/IDrawableObject.java
@@ -18,6 +18,7 @@
 package com.github.noony.app.timelinefx.core;
 
 /**
+ * Contract for objects with a drawable width and height.
  *
  * @author hamon
  */

--- a/src/main/java/com/github/noony/app/timelinefx/core/IDrawableObject.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/IDrawableObject.java
@@ -28,11 +28,11 @@ public interface IDrawableObject {
      *
      * @return the object's width
      */
-    abstract double getWidth();
+    double getWidth();
 
     /**
      *
      * @return the object's height
      */
-    abstract double getHeight();
+    double getHeight();
 }

--- a/src/main/java/com/github/noony/app/timelinefx/core/IFileObject.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/IFileObject.java
@@ -27,32 +27,32 @@ public interface IFileObject extends FriezeObject {
     /**
      * @return the object's display name
      */
-    abstract String getName();
+    String getName();
 
     //TODO :: in FriezeObject ?
     /**
      * @param aName the object's new display name
      */
-    abstract void setName(String aName);
+    void setName(String aName);
 
     /**
      * @return the project this object belongs to
      */
-    abstract TimeLineProject getProject();
+    TimeLineProject getProject();
 
     /**
      * @return the object's file path, relative to the project's folder
      */
-    abstract String getProjectRelativePath();
+    String getProjectRelativePath();
 
     /**
      * @return the object's absolute file path
      */
-    abstract String getAbsolutePath();
+    String getAbsolutePath();
 
     /**
      * @param other the object to compare with
      * @return a negative, zero, or positive value as this object precedes, equals, or follows {@code other}
      */
-    abstract int compareTo(IFileObject other);
+    int compareTo(IFileObject other);
 }

--- a/src/main/java/com/github/noony/app/timelinefx/core/IFileObject.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/IFileObject.java
@@ -18,21 +18,41 @@
 package com.github.noony.app.timelinefx.core;
 
 /**
+ * Contract for a domain object backed by a file relative to its project.
  *
  * @author hamon
  */
 public interface IFileObject extends FriezeObject {
 
+    /**
+     * @return the object's display name
+     */
     abstract String getName();
 
     //TODO :: in FriezeObject ?
+    /**
+     * @param aName the object's new display name
+     */
     abstract void setName(String aName);
 
+    /**
+     * @return the project this object belongs to
+     */
     abstract TimeLineProject getProject();
 
+    /**
+     * @return the object's file path, relative to the project's folder
+     */
     abstract String getProjectRelativePath();
 
+    /**
+     * @return the object's absolute file path
+     */
     abstract String getAbsolutePath();
 
+    /**
+     * @param other the object to compare with
+     * @return a negative, zero, or positive value as this object precedes, equals, or follows {@code other}
+     */
     abstract int compareTo(IFileObject other);
 }

--- a/src/main/java/com/github/noony/app/timelinefx/core/IFileObject.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/IFileObject.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core;
 
 /**
@@ -22,16 +23,16 @@ package com.github.noony.app.timelinefx.core;
  */
 public interface IFileObject extends FriezeObject {
 
-    String getName();
+    abstract String getName();
 
     //TODO :: in FriezeObject ?
-    void setName(String aName);
+    abstract void setName(String aName);
 
-    TimeLineProject getProject();
+    abstract TimeLineProject getProject();
 
-    String getProjectRelativePath();
+    abstract String getProjectRelativePath();
 
-    String getAbsolutePath();
+    abstract String getAbsolutePath();
 
-    int compareTo(IFileObject other);
+    abstract int compareTo(IFileObject other);
 }

--- a/src/main/java/com/github/noony/app/timelinefx/core/IPicture.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/IPicture.java
@@ -30,32 +30,32 @@ public interface IPicture extends IDateObject, IFileObject, IDrawableObject {
     /**
      * Name of the property change event for name change
      */
-    final String NAME_CHANGED = "pictureNameChanged";
+    String NAME_CHANGED = "pictureNameChanged";
 
     /**
      * Name of the property change event when a person is added
      */
-    final String PERSON_ADDED = "picturePersonAdded";
+    String PERSON_ADDED = "picturePersonAdded";
 
     /**
      * Name of the property change event when a person is removed
      */
-    final String PERSON_REMOVED = "picturePersonRemoved";
+    String PERSON_REMOVED = "picturePersonRemoved";
 
     /**
      * Name of the property change event when persons are reordered
      */
-    final String PERSONS_REORDED = "picturePersonsReordered";
+    String PERSONS_REORDED = "picturePersonsReordered";
 
     /**
      * Name of the property change event when a place is added
      */
-    final String PLACE_ADDED = "picturePlaceAdded";
+    String PLACE_ADDED = "picturePlaceAdded";
 
     /**
      * Name of the property change event when a place is removed
      */
-    final String PLACE_REMOVED = "picturePlaceRemoved";
+    String PLACE_REMOVED = "picturePlaceRemoved";
 
     /**
      * Searches the various factories to find the corresponding object.
@@ -63,7 +63,7 @@ public interface IPicture extends IDateObject, IFileObject, IDrawableObject {
      * @param pictureID an object's id
      * @return the IPicture instance with the same id, null if none exists
      */
-    public static IPicture getPicture(final long pictureID) {
+    static IPicture getPicture(final long pictureID) {
         final var picture = PictureFactory.getPicture(pictureID);
         if (picture != null) {
             return picture;
@@ -76,7 +76,7 @@ public interface IPicture extends IDateObject, IFileObject, IDrawableObject {
      *
      * @return an unmodifiable list of the persons on the IPicture
      */
-    abstract List<Person> getPersons();
+    List<Person> getPersons();
 
     /**
      * Adds a person to the picture.
@@ -84,7 +84,7 @@ public interface IPicture extends IDateObject, IFileObject, IDrawableObject {
      * @param aPerson the person to be added
      * @return true if the person was added successfully
      */
-    abstract boolean addPerson(Person aPerson);
+    boolean addPerson(Person aPerson);
 
     /**
      * Removes a person from the picture.
@@ -92,14 +92,14 @@ public interface IPicture extends IDateObject, IFileObject, IDrawableObject {
      * @param aPerson the person to be removed
      * @return true if the person was removed successfully
      */
-    abstract boolean removePerson(Person aPerson);
+    boolean removePerson(Person aPerson);
 
     /**
      * Gets the places on the picture.
      *
      * @return the places on the IPicture
      */
-    abstract List<Place> getPlaces();
+    List<Place> getPlaces();
 
     /**
      * Adds a place to the picture.
@@ -107,7 +107,7 @@ public interface IPicture extends IDateObject, IFileObject, IDrawableObject {
      * @param aPlace the place to be added
      * @return true if the place was added successfully
      */
-    abstract boolean addPlace(Place aPlace);
+    boolean addPlace(Place aPlace);
 
     /**
      * Removes a place from the picture.
@@ -115,6 +115,6 @@ public interface IPicture extends IDateObject, IFileObject, IDrawableObject {
      * @param aPlace the place to be removed
      * @return true if the place was removed successfully
      */
-    abstract boolean removePlace(Place aPlace);
+    boolean removePlace(Place aPlace);
 
 }

--- a/src/main/java/com/github/noony/app/timelinefx/core/IPicture.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/IPicture.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core;
 
 import java.util.List;
@@ -29,27 +30,32 @@ public interface IPicture extends IDateObject, IFileObject, IDrawableObject {
     /**
      * Name of the property change event for name change
      */
-    String NAME_CHANGED = "pictureNameChanged";
+    final String NAME_CHANGED = "pictureNameChanged";
+
     /**
      * Name of the property change event when a person is added
      */
-    String PERSON_ADDED = "picturePersonAdded";
+    final String PERSON_ADDED = "picturePersonAdded";
+
     /**
      * Name of the property change event when a person is removed
      */
-    String PERSON_REMOVED = "picturePersonRemoved";
+    final String PERSON_REMOVED = "picturePersonRemoved";
+
     /**
      * Name of the property change event when persons are reordered
      */
-    String PERSONS_REORDED = "picturePersonsReordered";
+    final String PERSONS_REORDED = "picturePersonsReordered";
+
     /**
      * Name of the property change event when a place is added
      */
-    String PLACE_ADDED = "picturePlaceAdded";
+    final String PLACE_ADDED = "picturePlaceAdded";
+
     /**
      * Name of the property change event when a place is removed
      */
-    String PLACE_REMOVED = "picturePlaceRemoved";
+    final String PLACE_REMOVED = "picturePlaceRemoved";
 
     /**
      * Searches the various factories to find the corresponding object
@@ -57,8 +63,8 @@ public interface IPicture extends IDateObject, IFileObject, IDrawableObject {
      * @param pictureID an object's id
      * @return the IPicture instance with the same id, null if none exists
      */
-    static IPicture getPicture(long pictureID) {
-        var picture = PictureFactory.getPicture(pictureID);
+    public static IPicture getPicture(final long pictureID) {
+        final var picture = PictureFactory.getPicture(pictureID);
         if (picture != null) {
             return picture;
         }
@@ -69,40 +75,40 @@ public interface IPicture extends IDateObject, IFileObject, IDrawableObject {
      *
      * @return an unmodifiable list of the persons on the IPicture
      */
-    List<Person> getPersons();
+    abstract List<Person> getPersons();
 
     /**
      *
      * @param aPerson the person to be added
      * @return true if the person was added successfully
      */
-    boolean addPerson(Person aPerson);
+    abstract boolean addPerson(Person aPerson);
 
     /**
      *
      * @param aPerson the person to be removed
      * @return true if the person was removed successfully
      */
-    boolean removePerson(Person aPerson);
+    abstract boolean removePerson(Person aPerson);
 
     /**
      *
      * @return the places on the IPicture
      */
-    List<Place> getPlaces();
+    abstract List<Place> getPlaces();
 
     /**
      *
      * @param aPlace the place to be added
      * @return true if the place was added successfully
      */
-    boolean addPlace(Place aPlace);
+    abstract boolean addPlace(Place aPlace);
 
     /**
      *
      * @param aPlace the place to be removed
      * @return true if the place was removed successfully
      */
-    boolean removePlace(Place aPlace);
+    abstract boolean removePlace(Place aPlace);
 
 }

--- a/src/main/java/com/github/noony/app/timelinefx/core/IPicture.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/IPicture.java
@@ -58,7 +58,7 @@ public interface IPicture extends IDateObject, IFileObject, IDrawableObject {
     final String PLACE_REMOVED = "picturePlaceRemoved";
 
     /**
-     * Searches the various factories to find the corresponding object
+     * Searches the various factories to find the corresponding object.
      *
      * @param pictureID an object's id
      * @return the IPicture instance with the same id, null if none exists
@@ -72,12 +72,14 @@ public interface IPicture extends IDateObject, IFileObject, IDrawableObject {
     }
 
     /**
+     * Gets the persons on the picture.
      *
      * @return an unmodifiable list of the persons on the IPicture
      */
     abstract List<Person> getPersons();
 
     /**
+     * Adds a person to the picture.
      *
      * @param aPerson the person to be added
      * @return true if the person was added successfully
@@ -85,6 +87,7 @@ public interface IPicture extends IDateObject, IFileObject, IDrawableObject {
     abstract boolean addPerson(Person aPerson);
 
     /**
+     * Removes a person from the picture.
      *
      * @param aPerson the person to be removed
      * @return true if the person was removed successfully
@@ -92,12 +95,14 @@ public interface IPicture extends IDateObject, IFileObject, IDrawableObject {
     abstract boolean removePerson(Person aPerson);
 
     /**
+     * Gets the places on the picture.
      *
      * @return the places on the IPicture
      */
     abstract List<Place> getPlaces();
 
     /**
+     * Adds a place to the picture.
      *
      * @param aPlace the place to be added
      * @return true if the place was added successfully
@@ -105,6 +110,7 @@ public interface IPicture extends IDateObject, IFileObject, IDrawableObject {
     abstract boolean addPlace(Place aPlace);
 
     /**
+     * Removes a place from the picture.
      *
      * @param aPlace the place to be removed
      * @return true if the place was removed successfully

--- a/src/main/java/com/github/noony/app/timelinefx/core/ItemSelectionPropagation.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/ItemSelectionPropagation.java
@@ -18,9 +18,13 @@
 package com.github.noony.app.timelinefx.core;
 
 /**
+ * How selecting an item should propagate to its related items.
  *
  * @author hamon
  */
 public enum ItemSelectionPropagation {
+    /**
+     * Selection does not propagate, or propagates to related items.
+     */
     NONE, RECURSIVE
 }

--- a/src/main/java/com/github/noony/app/timelinefx/core/ItemSelectionPropagation.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/ItemSelectionPropagation.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core;
 
 /**

--- a/src/main/java/com/github/noony/app/timelinefx/core/Messages.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/Messages.java
@@ -14,17 +14,18 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core;
 
 /**
  *
  * @author hamon
  */
-public class Messages {
+public final class Messages {
 
-    public static final  String UNSUPPORTED_TIME_FORMAT = "Unsupported time format: ";
+    public static final String UNSUPPORTED_TIME_FORMAT = "Unsupported time format: ";
 
-    private Messages(){
+    private Messages() {
         // utility class
     }
 

--- a/src/main/java/com/github/noony/app/timelinefx/core/Messages.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/Messages.java
@@ -18,11 +18,15 @@
 package com.github.noony.app.timelinefx.core;
 
 /**
+ * Shared user-facing message strings.
  *
  * @author hamon
  */
 public final class Messages {
 
+    /**
+     * Message prefix used when an unsupported {@link TimeFormat} is encountered.
+     */
     public static final String UNSUPPORTED_TIME_FORMAT = "Unsupported time format: ";
 
     private Messages() {

--- a/src/main/java/com/github/noony/app/timelinefx/core/Person.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/Person.java
@@ -171,7 +171,7 @@ public final class Person implements FriezeObject {
      */
     private boolean visible;
 
-    protected Person(final TimeLineProject aProject, final Long personId, String personName, Color aColor, LocalDate aDoB, LocalDate aDoD) {
+    protected Person(final TimeLineProject aProject, final Long personId, final String personName, Color aColor, LocalDate aDoB, LocalDate aDoD) {
         id = personId;
         project = aProject;
         portraits = new LinkedList<>();
@@ -185,7 +185,7 @@ public final class Person implements FriezeObject {
         visible = true;
     }
 
-    protected Person(final TimeLineProject aProject, final Long personId, String personName, Color aColor, long aToB, long aToD) {
+    protected Person(final TimeLineProject aProject, final Long personId, final String personName, Color aColor, long aToB, long aToD) {
         id = personId;
         project = aProject;
         portraits = new LinkedList<>();
@@ -199,7 +199,7 @@ public final class Person implements FriezeObject {
         visible = true;
     }
 
-    protected Person(final TimeLineProject aProject, final Long personId, String personName) {
+    protected Person(final TimeLineProject aProject, final Long personId, final String personName) {
         this(aProject, personId, personName, DEFAULT_COLOR, 0, 0);
     }
 

--- a/src/main/java/com/github/noony/app/timelinefx/core/Person.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/Person.java
@@ -203,8 +203,7 @@ public final class Person implements FriezeObject {
         this(aProject, personId, personName, DEFAULT_COLOR, 0, 0);
     }
 
-    @Override
-    public long getId() {
+    @Override public long getId() {
         return id;
     }
 

--- a/src/main/java/com/github/noony/app/timelinefx/core/Person.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/Person.java
@@ -171,7 +171,7 @@ public final class Person implements FriezeObject {
      */
     private boolean visible;
 
-    protected Person(final TimeLineProject aProject, Long personId, String personName, Color aColor, LocalDate aDoB, LocalDate aDoD) {
+    protected Person(final TimeLineProject aProject, final Long personId, String personName, Color aColor, LocalDate aDoB, LocalDate aDoD) {
         id = personId;
         project = aProject;
         portraits = new LinkedList<>();
@@ -185,7 +185,7 @@ public final class Person implements FriezeObject {
         visible = true;
     }
 
-    protected Person(final TimeLineProject aProject, Long personId, String personName, Color aColor, long aToB, long aToD) {
+    protected Person(final TimeLineProject aProject, final Long personId, String personName, Color aColor, long aToB, long aToD) {
         id = personId;
         project = aProject;
         portraits = new LinkedList<>();
@@ -199,7 +199,7 @@ public final class Person implements FriezeObject {
         visible = true;
     }
 
-    protected Person(final TimeLineProject aProject, Long personId, String personName) {
+    protected Person(final TimeLineProject aProject, final Long personId, String personName) {
         this(aProject, personId, personName, DEFAULT_COLOR, 0, 0);
     }
 

--- a/src/main/java/com/github/noony/app/timelinefx/core/Person.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/Person.java
@@ -29,63 +29,146 @@ import java.util.logging.Logger;
 import javafx.scene.paint.Color;
 
 /**
+ * A person who can be associated with places, stays and pictures.
  *
  * @author hamon
  */
 public final class Person implements FriezeObject {
 
+    /**
+     * Default portrait picture used when a person has no portrait of their own.
+     */
     public static final String DEFAULT_PICTURE_NAME = "LegoHead.png";
 
+    /**
+     * Name of the property change event fired when this person's selection changes.
+     */
     public static final String SELECTION_CHANGED = "selectionChanged";
+    /**
+     * Name of the property change event fired when this person's visibility changes.
+     */
     public static final String VISIBILITY_CHANGED = "visibilityChanged";
+    /**
+     * Name of the property change event fired when this person's name changes.
+     */
     public static final String NAME_CHANGED = "nameChanged";
+    /**
+     * Name of the property change event fired when this person's date of birth changes.
+     */
     public static final String DATE_OF_BIRTH_CHANGED = "dateOfBirthChanged";
+    /**
+     * Name of the property change event fired when this person's date of death changes.
+     */
     public static final String DATE_OF_DEATH_CHANGED = "dateOfDeathChanged";
+    /**
+     * Name of the property change event fired when this person's color changes.
+     */
     public static final String COLOR_CHANGED = "colorChanged";
 
+    /**
+     * Name of the property change event fired when a portrait is added.
+     */
     public static final String PORTRAIT_ADDED = "portraitAdded";
 
+    /**
+     * Name of the property change event fired when a portrait is removed.
+     */
     public static final String PORTRAIT_REMOVED = "portraitRemoved";
 
+    /**
+     * Name of the property change event fired when the default portrait changes.
+     */
     public static final String DEFAULT_PORTRAIT_CHANGED = "defaultPortaitChanged";
 
+    /**
+     * Orders persons by name.
+     */
     public static final Comparator<Person> COMPARATOR = Comparator.comparing(Person::getName);
 
+    /**
+     * The color assigned to a person when none is specified.
+     */
     private static final Color DEFAULT_COLOR = Color.CHOCOLATE;
 
+    /**
+     * Logger used by this class.
+     */
     private static final Logger LOG = Logger.getGlobal();
 
+    /**
+     * Fallback value returned when no date/time is available.
+     */
     private static final long DEFAULT_TIME = -1;
 
+    /**
+     * Support object used to fire property change events.
+     */
     private final PropertyChangeSupport propertyChangeSupport;
     //
     private final Long id;
     //
 
+    /**
+     * The project this person belongs to.
+     */
     private final TimeLineProject project;
 
+    /**
+     * This person's portraits.
+     */
     private final List<Portrait> portraits;
     //
 
+    /**
+     * This person's display name.
+     */
     private String name;
 
+    /**
+     * This person's display color.
+     */
     private Color color;
 
+    /**
+     * Whether {@link #dateOfBirth}/{@link #dateOfDeath} or {@link #timeOfBirth}/{@link #timeOfDeath}
+     * holds this person's dates.
+     */
     private TimeFormat timeFormat;
 
+    /**
+     * This person's date of birth, used when {@link #timeFormat} is {@code LOCAL_TIME}.
+     */
     private LocalDate dateOfBirth;
 
+    /**
+     * This person's date of death, used when {@link #timeFormat} is {@code LOCAL_TIME}.
+     */
     private LocalDate dateOfDeath;
 
+    /**
+     * This person's raw numeric birth time, used when {@link #timeFormat} is {@code TIME_MIN}.
+     */
     private long timeOfBirth;
 
+    /**
+     * This person's raw numeric death time, used when {@link #timeFormat} is {@code TIME_MIN}.
+     */
     private long timeOfDeath;
 
+    /**
+     * This person's default portrait, lazily created on first access.
+     */
     private Portrait defaultPortrait;
     //
 
+    /**
+     * Whether this person is currently selected.
+     */
     private boolean selected;
 
+    /**
+     * Whether this person is currently visible.
+     */
     private boolean visible;
 
     protected Person(final TimeLineProject aProject, Long personId, String personName, Color aColor, LocalDate aDoB, LocalDate aDoD) {
@@ -125,10 +208,16 @@ public final class Person implements FriezeObject {
         return id;
     }
 
+    /**
+     * @return the project this person belongs to
+     */
     public TimeLineProject getProject() {
         return project;
     }
 
+    /**
+     * @return this person's default portrait, creating it if it doesn't exist yet
+     */
     public Portrait getDefaultPortrait() {
         // Checking it here to only create a default portrait when it really becomes necessary
         if (defaultPortrait == null) {
@@ -137,6 +226,9 @@ public final class Person implements FriezeObject {
         return defaultPortrait;
     }
 
+    /**
+     * @param aName this person's new name
+     */
     public void setName(final String aName) {
         if (!name.equals(aName)) {
             name = aName;
@@ -144,6 +236,9 @@ public final class Person implements FriezeObject {
         }
     }
 
+    /**
+     * @param aPortrait this person's new default portrait
+     */
     public void setDefaultPortrait(final Portrait aPortrait) {
         if (aPortrait != null && aPortrait != defaultPortrait) {
             addPortrait(aPortrait);
@@ -152,6 +247,9 @@ public final class Person implements FriezeObject {
         }
     }
 
+    /**
+     * @param aPortrait the portrait to add
+     */
     public void addPortrait(final Portrait aPortrait) {
         if (!portraits.contains(aPortrait)) {
             portraits.add(aPortrait);
@@ -159,6 +257,9 @@ public final class Person implements FriezeObject {
         }
     }
 
+    /**
+     * @return an unmodifiable list of this person's portraits
+     */
     public List<Portrait> getPortraits() {
         return Collections.unmodifiableList(portraits);
     }
@@ -167,24 +268,39 @@ public final class Person implements FriezeObject {
         return portraits.stream().filter(p -> p.getId() == aPortraiID).findAny().orElse(null);
     }
 
+    /**
+     * @param aPortrait the portrait to remove
+     */
     public void removePortrait(final Portrait aPortrait) {
         if (portraits.remove(aPortrait)) {
             propertyChangeSupport.firePropertyChange(PORTRAIT_REMOVED, null, aPortrait);
         }
     }
 
+    /**
+     * @param listener the listener to add
+     */
     public void addPropertyChangeListener(final PropertyChangeListener listener) {
         propertyChangeSupport.addPropertyChangeListener(listener);
     }
 
+    /**
+     * @param listener the listener to remove
+     */
     public void removePropertyChangeListener(final PropertyChangeListener listener) {
         propertyChangeSupport.removePropertyChangeListener(listener);
     }
 
+    /**
+     * @return this person's name
+     */
     public String getName() {
         return name;
     }
 
+    /**
+     * @param aColor this person's new color
+     */
     public void setColor(final Color aColor) {
         if (!color.equals(aColor)) {
             color = aColor;
@@ -192,22 +308,37 @@ public final class Person implements FriezeObject {
         }
     }
 
+    /**
+     * @return this person's color
+     */
     public Color getColor() {
         return color;
     }
 
+    /**
+     * @return this person's time format
+     */
     public TimeFormat getTimeFormat() {
         return timeFormat;
     }
 
+    /**
+     * @param aTimeFormat this person's new time format
+     */
     public void setTimeFormat(final TimeFormat aTimeFormat) {
         timeFormat = aTimeFormat;
     }
 
+    /**
+     * @return this person's date of birth
+     */
     public LocalDate getDateOfBirth() {
         return dateOfBirth;
     }
 
+    /**
+     * @param newDoB this person's new date of birth
+     */
     public void setDateOfBirth(final LocalDate newDoB) {
         if (newDoB == null) {
             // for the time being we do not support clearing date of birth
@@ -223,10 +354,16 @@ public final class Person implements FriezeObject {
         }
     }
 
+    /**
+     * @return this person's raw numeric birth time
+     */
     public long getTimeOfBirth() {
         return timeOfBirth;
     }
 
+    /**
+     * @return this person's birth time, as an absolute value comparable regardless of time format
+     */
     public long getAbsolutTimeOfBirth() {
         switch (timeFormat) {
             case LOCAL_TIME -> {
@@ -244,6 +381,9 @@ public final class Person implements FriezeObject {
         }
     }
 
+    /**
+     * @return this person's death time, as an absolute value comparable regardless of time format
+     */
     public long getAbsolutTimeOfDeath() {
         switch (timeFormat) {
             case LOCAL_TIME -> {
@@ -261,6 +401,9 @@ public final class Person implements FriezeObject {
         }
     }
 
+    /**
+     * @param newToB this person's new raw numeric birth time
+     */
     public void setTimeOfBirth(final long newToB) {
         if (timeOfBirth != newToB) {
             timeOfBirth = newToB;
@@ -269,10 +412,16 @@ public final class Person implements FriezeObject {
         }
     }
 
+    /**
+     * @return this person's date of death
+     */
     public LocalDate getDateOfDeath() {
         return dateOfDeath;
     }
 
+    /**
+     * @param newDoD this person's new date of death
+     */
     public void setDateOfDeath(final LocalDate newDoD) {
         if (newDoD == null) {
             // for the time being we do not support clearing date of death
@@ -288,10 +437,16 @@ public final class Person implements FriezeObject {
         }
     }
 
+    /**
+     * @return this person's raw numeric death time
+     */
     public long getTimeOfDeath() {
         return timeOfDeath;
     }
 
+    /**
+     * @param newToD this person's new raw numeric death time
+     */
     public void setTimeOfDeath(final long newToD) {
         if (timeOfDeath != newToD) {
             timeOfDeath = newToD;
@@ -300,6 +455,9 @@ public final class Person implements FriezeObject {
         }
     }
 
+    /**
+     * @param isSelected whether this person is now selected
+     */
     public void setSelected(final boolean isSelected) {
         final var update = selected != isSelected;
         selected = isSelected;
@@ -308,10 +466,16 @@ public final class Person implements FriezeObject {
         }
     }
 
+    /**
+     * @return whether this person is currently selected
+     */
     public boolean isSelected() {
         return selected;
     }
 
+    /**
+     * @param isVisible whether this person is now visible
+     */
     public void setVisible(final boolean isVisible) {
         final var update = visible != isVisible;
         visible = isVisible;
@@ -320,6 +484,9 @@ public final class Person implements FriezeObject {
         }
     }
 
+    /**
+     * @return whether this person is currently visible
+     */
     public boolean isVisible() {
         return visible;
     }

--- a/src/main/java/com/github/noony/app/timelinefx/core/Person.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/Person.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core;
 
 import java.beans.PropertyChangeListener;
@@ -43,35 +44,51 @@ public final class Person implements FriezeObject {
     public static final String COLOR_CHANGED = "colorChanged";
 
     public static final String PORTRAIT_ADDED = "portraitAdded";
+
     public static final String PORTRAIT_REMOVED = "portraitRemoved";
+
     public static final String DEFAULT_PORTRAIT_CHANGED = "defaultPortaitChanged";
 
     public static final Comparator<Person> COMPARATOR = Comparator.comparing(Person::getName);
 
     private static final Color DEFAULT_COLOR = Color.CHOCOLATE;
+
     private static final Logger LOG = Logger.getGlobal();
+
     private static final long DEFAULT_TIME = -1;
 
     private final PropertyChangeSupport propertyChangeSupport;
     //
     private final Long id;
     //
+
     private final TimeLineProject project;
+
     private final List<Portrait> portraits;
     //
+
     private String name;
+
     private Color color;
+
     private TimeFormat timeFormat;
+
     private LocalDate dateOfBirth;
+
     private LocalDate dateOfDeath;
+
     private long timeOfBirth;
+
     private long timeOfDeath;
-    private Portrait defaultPortrait = null;
+
+    private Portrait defaultPortrait;
     //
+
     private boolean selected;
+
     private boolean visible;
 
-    protected Person(TimeLineProject aProject, Long personId, String personName, Color aColor, LocalDate aDoB, LocalDate aDoD) {
+    protected Person(final TimeLineProject aProject, Long personId, String personName, Color aColor, LocalDate aDoB, LocalDate aDoD) {
         id = personId;
         project = aProject;
         portraits = new LinkedList<>();
@@ -85,7 +102,7 @@ public final class Person implements FriezeObject {
         visible = true;
     }
 
-    protected Person(TimeLineProject aProject, Long personId, String personName, Color aColor, long aToB, long aToD) {
+    protected Person(final TimeLineProject aProject, Long personId, String personName, Color aColor, long aToB, long aToD) {
         id = personId;
         project = aProject;
         portraits = new LinkedList<>();
@@ -99,7 +116,7 @@ public final class Person implements FriezeObject {
         visible = true;
     }
 
-    protected Person(TimeLineProject aProject, Long personId, String personName) {
+    protected Person(final TimeLineProject aProject, Long personId, String personName) {
         this(aProject, personId, personName, DEFAULT_COLOR, 0, 0);
     }
 
@@ -120,14 +137,14 @@ public final class Person implements FriezeObject {
         return defaultPortrait;
     }
 
-    public void setName(String aName) {
+    public void setName(final String aName) {
         if (!name.equals(aName)) {
             name = aName;
             propertyChangeSupport.firePropertyChange(NAME_CHANGED, this, name);
         }
     }
 
-    public void setDefaultPortrait(Portrait aPortrait) {
+    public void setDefaultPortrait(final Portrait aPortrait) {
         if (aPortrait != null && aPortrait != defaultPortrait) {
             addPortrait(aPortrait);
             defaultPortrait = aPortrait;
@@ -135,7 +152,7 @@ public final class Person implements FriezeObject {
         }
     }
 
-    public void addPortrait(Portrait aPortrait) {
+    public void addPortrait(final Portrait aPortrait) {
         if (!portraits.contains(aPortrait)) {
             portraits.add(aPortrait);
             propertyChangeSupport.firePropertyChange(PORTRAIT_ADDED, this, aPortrait);
@@ -150,17 +167,17 @@ public final class Person implements FriezeObject {
         return portraits.stream().filter(p -> p.getId() == aPortraiID).findAny().orElse(null);
     }
 
-    public void removePortrait(Portrait aPortrait) {
+    public void removePortrait(final Portrait aPortrait) {
         if (portraits.remove(aPortrait)) {
             propertyChangeSupport.firePropertyChange(PORTRAIT_REMOVED, null, aPortrait);
         }
     }
 
-    public void addPropertyChangeListener(PropertyChangeListener listener) {
+    public void addPropertyChangeListener(final PropertyChangeListener listener) {
         propertyChangeSupport.addPropertyChangeListener(listener);
     }
 
-    public void removePropertyChangeListener(PropertyChangeListener listener) {
+    public void removePropertyChangeListener(final PropertyChangeListener listener) {
         propertyChangeSupport.removePropertyChangeListener(listener);
     }
 
@@ -168,7 +185,7 @@ public final class Person implements FriezeObject {
         return name;
     }
 
-    public void setColor(Color aColor) {
+    public void setColor(final Color aColor) {
         if (!color.equals(aColor)) {
             color = aColor;
             propertyChangeSupport.firePropertyChange(COLOR_CHANGED, this, color);
@@ -183,7 +200,7 @@ public final class Person implements FriezeObject {
         return timeFormat;
     }
 
-    public void setTimeFormat(TimeFormat aTimeFormat) {
+    public void setTimeFormat(final TimeFormat aTimeFormat) {
         timeFormat = aTimeFormat;
     }
 
@@ -191,7 +208,7 @@ public final class Person implements FriezeObject {
         return dateOfBirth;
     }
 
-    public void setDateOfBirth(LocalDate newDoB) {
+    public void setDateOfBirth(final LocalDate newDoB) {
         if (newDoB == null) {
             // for the time being we do not support clearing date of birth
             LOG.log(Level.INFO, "Clearing date of birth is not supported yet in {0}", new Object[]{this});
@@ -244,7 +261,7 @@ public final class Person implements FriezeObject {
         }
     }
 
-    public void setTimeOfBirth(long newToB) {
+    public void setTimeOfBirth(final long newToB) {
         if (timeOfBirth != newToB) {
             timeOfBirth = newToB;
             timeFormat = TimeFormat.TIME_MIN;
@@ -256,7 +273,7 @@ public final class Person implements FriezeObject {
         return dateOfDeath;
     }
 
-    public void setDateOfDeath(LocalDate newDoD) {
+    public void setDateOfDeath(final LocalDate newDoD) {
         if (newDoD == null) {
             // for the time being we do not support clearing date of death
             LOG.log(Level.INFO, "Clearing date of death is not supported yet in {0}", new Object[]{this});
@@ -275,7 +292,7 @@ public final class Person implements FriezeObject {
         return timeOfDeath;
     }
 
-    public void setTimeOfDeath(long newToD) {
+    public void setTimeOfDeath(final long newToD) {
         if (timeOfDeath != newToD) {
             timeOfDeath = newToD;
             timeFormat = TimeFormat.TIME_MIN;
@@ -283,8 +300,8 @@ public final class Person implements FriezeObject {
         }
     }
 
-    public void setSelected(boolean isSelected) {
-        var update = selected != isSelected;
+    public void setSelected(final boolean isSelected) {
+        final var update = selected != isSelected;
         selected = isSelected;
         if (update) {
             propertyChangeSupport.firePropertyChange(SELECTION_CHANGED, null, selected);
@@ -295,8 +312,8 @@ public final class Person implements FriezeObject {
         return selected;
     }
 
-    public void setVisible(boolean isVisible) {
-        var update = visible != isVisible;
+    public void setVisible(final boolean isVisible) {
+        final var update = visible != isVisible;
         visible = isVisible;
         if (update) {
             propertyChangeSupport.firePropertyChange(VISIBILITY_CHANGED, this, visible);

--- a/src/main/java/com/github/noony/app/timelinefx/core/PersonFactory.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/PersonFactory.java
@@ -14,12 +14,13 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core;
 
-import static com.github.noony.app.timelinefx.core.Factory.CREATION_LOGGING_LEVEL;
 import java.util.List;
 import java.util.logging.Logger;
 import javafx.scene.paint.Color;
+import static com.github.noony.app.timelinefx.core.Factory.CREATION_LOGGING_LEVEL;
 
 /**
  *
@@ -39,35 +40,35 @@ public final class PersonFactory {
         FACTORY.reset();
     }
 
-    public static Person getPerson(long id) {
+    public static Person getPerson(final long id) {
         return FACTORY.get(id);
     }
 
-    public static Person createPerson(TimeLineProject project, String personName) {
+    public static Person createPerson(final TimeLineProject project, String personName) {
         LOG.log(CREATION_LOGGING_LEVEL, "Creating person with personName={0}  ", new Object[]{personName});
-        var person = new Person(project, FACTORY.getNextID(), personName);
+        final var person = new Person(project, FACTORY.getNextID(), personName);
         FACTORY.addObject(person);
         return person;
     }
 
-    public static Person createPerson(TimeLineProject project, String personName, Color color) {
+    public static Person createPerson(final TimeLineProject project, String personName, Color color) {
         LOG.log(CREATION_LOGGING_LEVEL, "Creating person with personName={0} color={1} ", new Object[]{personName, color});
-        var person = new Person(project, FACTORY.getNextID(), personName, color, null, null);
+        final var person = new Person(project, FACTORY.getNextID(), personName, color, null, null);
         FACTORY.addObject(person);
         return person;
     }
 
-    public static Person createPerson(TimeLineProject project, long id, String personName, Color color) {
+    public static Person createPerson(final TimeLineProject project, long id, String personName, Color color) {
         LOG.log(CREATION_LOGGING_LEVEL, "Creating person with id={0} personName={1} color={2}", new Object[]{id, personName, color});
         if (!FACTORY.isIdAvailable(id)) {
             throw new IllegalArgumentException("trying to create person " + personName + " with existing id=" + id + " (exists : " + FACTORY.get(id) + "[" + FACTORY.get(id).getId() + "])");
         }
-        var person = new Person(project, id, personName, color, null, null);
+        final var person = new Person(project, id, personName, color, null, null);
         FACTORY.addObject(person);
         return person;
     }
 
-    public static List< Person> getPERSONS() {
+    public static List<Person> getPERSONS() {
         return FACTORY.getObjects().stream().sorted(Person.COMPARATOR).toList();
     }
 

--- a/src/main/java/com/github/noony/app/timelinefx/core/PersonFactory.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/PersonFactory.java
@@ -23,27 +23,48 @@ import javafx.scene.paint.Color;
 import static com.github.noony.app.timelinefx.core.Factory.CREATION_LOGGING_LEVEL;
 
 /**
+ * Entry point for creating and retrieving {@link Person} instances.
  *
  * @author hamon
  */
 public final class PersonFactory {
 
+    /**
+     * Logger used by this factory.
+     */
     private static final Logger LOG = Logger.getGlobal();
 
+    /**
+     * Registry of created persons.
+     */
     private static final Factory<Person> FACTORY = new Factory<>();
 
     private PersonFactory() {
         // private utility constructor
     }
 
+    /**
+     * Resets the factory, discarding all created persons.
+     */
     public static void reset() {
         FACTORY.reset();
     }
 
+    /**
+     * @param id a person's id
+     * @return the person with the given id, or null if none exists
+     */
     public static Person getPerson(final long id) {
         return FACTORY.get(id);
     }
 
+    /**
+     * Creates a new person with the default color.
+     *
+     * @param project the project the person belongs to
+     * @param personName the person's name
+     * @return the created person
+     */
     public static Person createPerson(final TimeLineProject project, String personName) {
         LOG.log(CREATION_LOGGING_LEVEL, "Creating person with personName={0}  ", new Object[]{personName});
         final var person = new Person(project, FACTORY.getNextID(), personName);
@@ -51,6 +72,14 @@ public final class PersonFactory {
         return person;
     }
 
+    /**
+     * Creates a new person.
+     *
+     * @param project the project the person belongs to
+     * @param personName the person's name
+     * @param color the person's color
+     * @return the created person
+     */
     public static Person createPerson(final TimeLineProject project, String personName, Color color) {
         LOG.log(CREATION_LOGGING_LEVEL, "Creating person with personName={0} color={1} ", new Object[]{personName, color});
         final var person = new Person(project, FACTORY.getNextID(), personName, color, null, null);
@@ -58,6 +87,15 @@ public final class PersonFactory {
         return person;
     }
 
+    /**
+     * Creates a new person with a specific id.
+     *
+     * @param project the project the person belongs to
+     * @param id the id to assign to the new person
+     * @param personName the person's name
+     * @param color the person's color
+     * @return the created person
+     */
     public static Person createPerson(final TimeLineProject project, long id, String personName, Color color) {
         LOG.log(CREATION_LOGGING_LEVEL, "Creating person with id={0} personName={1} color={2}", new Object[]{id, personName, color});
         if (!FACTORY.isIdAvailable(id)) {
@@ -68,6 +106,9 @@ public final class PersonFactory {
         return person;
     }
 
+    /**
+     * @return all created persons, sorted by name
+     */
     public static List<Person> getPERSONS() {
         return FACTORY.getObjects().stream().sorted(Person.COMPARATOR).toList();
     }

--- a/src/main/java/com/github/noony/app/timelinefx/core/PersonFactory.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/PersonFactory.java
@@ -80,7 +80,7 @@ public final class PersonFactory {
      * @param color the person's color
      * @return the created person
      */
-    public static Person createPerson(final TimeLineProject project, final String personName, Color color) {
+    public static Person createPerson(final TimeLineProject project, final String personName, final Color color) {
         LOG.log(CREATION_LOGGING_LEVEL, "Creating person with personName={0} color={1} ", new Object[]{personName, color});
         final var person = new Person(project, FACTORY.getNextID(), personName, color, null, null);
         FACTORY.addObject(person);
@@ -96,7 +96,7 @@ public final class PersonFactory {
      * @param color the person's color
      * @return the created person
      */
-    public static Person createPerson(final TimeLineProject project, final long id, String personName, Color color) {
+    public static Person createPerson(final TimeLineProject project, final long id, final String personName, Color color) {
         LOG.log(CREATION_LOGGING_LEVEL, "Creating person with id={0} personName={1} color={2}", new Object[]{id, personName, color});
         if (!FACTORY.isIdAvailable(id)) {
             throw new IllegalArgumentException("trying to create person " + personName + " with existing id=" + id + " (exists : " + FACTORY.get(id) + "[" + FACTORY.get(id).getId() + "])");

--- a/src/main/java/com/github/noony/app/timelinefx/core/PersonFactory.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/PersonFactory.java
@@ -65,7 +65,7 @@ public final class PersonFactory {
      * @param personName the person's name
      * @return the created person
      */
-    public static Person createPerson(final TimeLineProject project, String personName) {
+    public static Person createPerson(final TimeLineProject project, final String personName) {
         LOG.log(CREATION_LOGGING_LEVEL, "Creating person with personName={0}  ", new Object[]{personName});
         final var person = new Person(project, FACTORY.getNextID(), personName);
         FACTORY.addObject(person);
@@ -80,7 +80,7 @@ public final class PersonFactory {
      * @param color the person's color
      * @return the created person
      */
-    public static Person createPerson(final TimeLineProject project, String personName, Color color) {
+    public static Person createPerson(final TimeLineProject project, final String personName, Color color) {
         LOG.log(CREATION_LOGGING_LEVEL, "Creating person with personName={0} color={1} ", new Object[]{personName, color});
         final var person = new Person(project, FACTORY.getNextID(), personName, color, null, null);
         FACTORY.addObject(person);
@@ -96,7 +96,7 @@ public final class PersonFactory {
      * @param color the person's color
      * @return the created person
      */
-    public static Person createPerson(final TimeLineProject project, long id, String personName, Color color) {
+    public static Person createPerson(final TimeLineProject project, final long id, String personName, Color color) {
         LOG.log(CREATION_LOGGING_LEVEL, "Creating person with id={0} personName={1} color={2}", new Object[]{id, personName, color});
         if (!FACTORY.isIdAvailable(id)) {
             throw new IllegalArgumentException("trying to create person " + personName + " with existing id=" + id + " (exists : " + FACTORY.get(id) + "[" + FACTORY.get(id).getId() + "])");

--- a/src/main/java/com/github/noony/app/timelinefx/core/Picture.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/Picture.java
@@ -31,7 +31,7 @@ public class Picture extends AbstractPicture {
      */
     private final TimeLineProject project;
 
-    protected Picture(final TimeLineProject aProject, long id, String pictureName, LocalDate pictureCreationDate, String picturePath, int pictureWidth, int pictureHeight) {
+    protected Picture(final TimeLineProject aProject, final long id, String pictureName, LocalDate pictureCreationDate, String picturePath, int pictureWidth, int pictureHeight) {
         super(id, pictureName, picturePath, pictureWidth, pictureHeight, pictureCreationDate);
         project = aProject;
     }

--- a/src/main/java/com/github/noony/app/timelinefx/core/Picture.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/Picture.java
@@ -20,11 +20,15 @@ package com.github.noony.app.timelinefx.core;
 import java.time.LocalDate;
 
 /**
+ * A picture that belongs to a project (as opposed to a portrait).
  *
  * @author hamon
  */
 public class Picture extends AbstractPicture {
 
+    /**
+     * The project this picture belongs to.
+     */
     private final TimeLineProject project;
 
     protected Picture(final TimeLineProject aProject, long id, String pictureName, LocalDate pictureCreationDate, String picturePath, int pictureWidth, int pictureHeight) {

--- a/src/main/java/com/github/noony/app/timelinefx/core/Picture.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/Picture.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core;
 
 import java.time.LocalDate;
@@ -26,7 +27,7 @@ public class Picture extends AbstractPicture {
 
     private final TimeLineProject project;
 
-    protected Picture(TimeLineProject aProject, long id, String pictureName, LocalDate pictureCreationDate, String picturePath, int pictureWidth, int pictureHeight) {
+    protected Picture(final TimeLineProject aProject, long id, String pictureName, LocalDate pictureCreationDate, String picturePath, int pictureWidth, int pictureHeight) {
         super(id, pictureName, picturePath, pictureWidth, pictureHeight, pictureCreationDate);
         project = aProject;
     }

--- a/src/main/java/com/github/noony/app/timelinefx/core/Picture.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/Picture.java
@@ -36,8 +36,7 @@ public class Picture extends AbstractPicture {
         project = aProject;
     }
 
-    @Override
-    public TimeLineProject getProject() {
+    @Override public TimeLineProject getProject() {
         return project;
     }
 

--- a/src/main/java/com/github/noony/app/timelinefx/core/Picture.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/Picture.java
@@ -31,7 +31,7 @@ public class Picture extends AbstractPicture {
      */
     private final TimeLineProject project;
 
-    protected Picture(final TimeLineProject aProject, final long id, String pictureName, LocalDate pictureCreationDate, String picturePath, int pictureWidth, int pictureHeight) {
+    protected Picture(final TimeLineProject aProject, final long id, final String pictureName, LocalDate pictureCreationDate, String picturePath, int pictureWidth, int pictureHeight) {
         super(id, pictureName, picturePath, pictureWidth, pictureHeight, pictureCreationDate);
         project = aProject;
     }

--- a/src/main/java/com/github/noony/app/timelinefx/core/PictureFactory.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/PictureFactory.java
@@ -14,9 +14,9 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core;
 
-import static com.github.noony.app.timelinefx.core.Factory.CREATION_LOGGING_LEVEL;
 import com.github.noony.app.timelinefx.utils.MetadataParser;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.apache.commons.io.FileUtils;
+import static com.github.noony.app.timelinefx.core.Factory.CREATION_LOGGING_LEVEL;
 
 /**
  *
@@ -39,6 +40,7 @@ public final class PictureFactory {
     private static final Logger LOG = Logger.getGlobal();
 
     private static final Factory<Picture> FACTORY = new Factory<>();
+
     private static final PropertyChangeSupport PROPERTY_CHANGE_SUPPORT = new PropertyChangeSupport(FACTORY);
 
     private PictureFactory() {
@@ -53,13 +55,13 @@ public final class PictureFactory {
         return FACTORY.getObjects();
     }
 
-    public static Picture getPicture(long pictureID) {
+    public static Picture getPicture(final long pictureID) {
         return FACTORY.get(pictureID);
     }
 
-    public static Picture createPicture(TimeLineProject project, File originalPictureFile, String pictureName) {
+    public static Picture createPicture(final TimeLineProject project, File originalPictureFile, String pictureName) {
         LOG.log(CREATION_LOGGING_LEVEL, "Creating picture with pictureName={0} file={1}", new Object[]{pictureName, originalPictureFile});
-        File pictureFile;
+        final File pictureFile;
         pictureFile = new File(project.getPicturesFolder(), originalPictureFile.getName());
         if (!pictureFile.exists()) {
             try {
@@ -69,30 +71,30 @@ public final class PictureFactory {
                 LOG.log(Level.SEVERE, "Error while copying picture file to: {0} : {1}", new Object[]{pictureFile, ex});
             }
         }
-        var picInfo = MetadataParser.parseMetadata(project, pictureFile);
+        final var picInfo = MetadataParser.parseMetadata(project, pictureFile);
         assert picInfo != null;
-        var picture = new Picture(project, FACTORY.getNextID(), pictureName, picInfo.getCreationDate().toLocalDate(), picInfo.getPath(), picInfo.getWidth(), picInfo.getHeight());
+        final var picture = new Picture(project, FACTORY.getNextID(), pictureName, picInfo.getCreationDate().toLocalDate(), picInfo.getPath(), picInfo.getWidth(), picInfo.getHeight());
         FACTORY.addObject(picture);
         PROPERTY_CHANGE_SUPPORT.firePropertyChange(PICTURE_ADDED, null, picture);
         return picture;
     }
 
-    public static Picture createPicture(TimeLineProject project, long id, String pictureName, LocalDateTime pictureCreationDate, String picturePath, int pictureWidth, int pictureHeight) {
+    public static Picture createPicture(final TimeLineProject project, long id, String pictureName, LocalDateTime pictureCreationDate, String picturePath, int pictureWidth, int pictureHeight) {
         LOG.log(CREATION_LOGGING_LEVEL, "Creating picture with id={0} pictureName={1}", new Object[]{id, pictureName});
         if (!FACTORY.isIdAvailable(id)) {
             throw new IllegalArgumentException("Trying to create picture " + pictureName + " with existing id=" + id + " :: " + FACTORY.get(id));
         }
-        var picture = new Picture(project, id, pictureName, pictureCreationDate.toLocalDate(), picturePath, pictureWidth, pictureHeight);
+        final var picture = new Picture(project, id, pictureName, pictureCreationDate.toLocalDate(), picturePath, pictureWidth, pictureHeight);
         FACTORY.addObject(picture);
         PROPERTY_CHANGE_SUPPORT.firePropertyChange(PICTURE_ADDED, null, picture);
         return picture;
     }
 
-    public static void addPropertyChangeListener(PropertyChangeListener listener) {
+    public static void addPropertyChangeListener(final PropertyChangeListener listener) {
         PROPERTY_CHANGE_SUPPORT.addPropertyChangeListener(listener);
     }
 
-    public static void removePropertyChangeListener(PropertyChangeListener listener) {
+    public static void removePropertyChangeListener(final PropertyChangeListener listener) {
         PROPERTY_CHANGE_SUPPORT.removePropertyChangeListener(listener);
     }
 

--- a/src/main/java/com/github/noony/app/timelinefx/core/PictureFactory.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/PictureFactory.java
@@ -30,35 +30,66 @@ import org.apache.commons.io.FileUtils;
 import static com.github.noony.app.timelinefx.core.Factory.CREATION_LOGGING_LEVEL;
 
 /**
+ * Entry point for creating and retrieving {@link Picture} instances.
  *
  * @author hamon
  */
 public final class PictureFactory {
 
+    /**
+     * Name of the property change event fired when a picture is created.
+     */
     public static final String PICTURE_ADDED = "pictureAdded";
 
+    /**
+     * Logger used by this factory.
+     */
     private static final Logger LOG = Logger.getGlobal();
 
+    /**
+     * Registry of created pictures.
+     */
     private static final Factory<Picture> FACTORY = new Factory<>();
 
+    /**
+     * Support object used to fire property change events.
+     */
     private static final PropertyChangeSupport PROPERTY_CHANGE_SUPPORT = new PropertyChangeSupport(FACTORY);
 
     private PictureFactory() {
         // private utility constructor
     }
 
+    /**
+     * Resets the factory, discarding all created pictures.
+     */
     public static void reset() {
         FACTORY.reset();
     }
 
+    /**
+     * @return all created pictures
+     */
     public static List<Picture> getPictures() {
         return FACTORY.getObjects();
     }
 
+    /**
+     * @param pictureID a picture's id
+     * @return the picture with the given id, or null if none exists
+     */
     public static Picture getPicture(final long pictureID) {
         return FACTORY.get(pictureID);
     }
 
+    /**
+     * Creates a new picture by copying an existing file into the project's pictures folder.
+     *
+     * @param project the project the picture belongs to
+     * @param originalPictureFile the source picture file to copy
+     * @param pictureName the picture's name
+     * @return the created picture
+     */
     public static Picture createPicture(final TimeLineProject project, File originalPictureFile, String pictureName) {
         LOG.log(CREATION_LOGGING_LEVEL, "Creating picture with pictureName={0} file={1}", new Object[]{pictureName, originalPictureFile});
         final File pictureFile;
@@ -79,6 +110,18 @@ public final class PictureFactory {
         return picture;
     }
 
+    /**
+     * Creates a new picture with a specific id, referencing an already-existing file.
+     *
+     * @param project the project the picture belongs to
+     * @param id the id to assign to the new picture
+     * @param pictureName the picture's name
+     * @param pictureCreationDate the picture's creation date
+     * @param picturePath the picture file's path
+     * @param pictureWidth the picture's width
+     * @param pictureHeight the picture's height
+     * @return the created picture
+     */
     public static Picture createPicture(final TimeLineProject project, long id, String pictureName, LocalDateTime pictureCreationDate, String picturePath, int pictureWidth, int pictureHeight) {
         LOG.log(CREATION_LOGGING_LEVEL, "Creating picture with id={0} pictureName={1}", new Object[]{id, pictureName});
         if (!FACTORY.isIdAvailable(id)) {
@@ -90,10 +133,16 @@ public final class PictureFactory {
         return picture;
     }
 
+    /**
+     * @param listener the listener to add
+     */
     public static void addPropertyChangeListener(final PropertyChangeListener listener) {
         PROPERTY_CHANGE_SUPPORT.addPropertyChangeListener(listener);
     }
 
+    /**
+     * @param listener the listener to remove
+     */
     public static void removePropertyChangeListener(final PropertyChangeListener listener) {
         PROPERTY_CHANGE_SUPPORT.removePropertyChangeListener(listener);
     }

--- a/src/main/java/com/github/noony/app/timelinefx/core/PictureFactory.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/PictureFactory.java
@@ -90,7 +90,7 @@ public final class PictureFactory {
      * @param pictureName the picture's name
      * @return the created picture
      */
-    public static Picture createPicture(final TimeLineProject project, File originalPictureFile, String pictureName) {
+    public static Picture createPicture(final TimeLineProject project, final File originalPictureFile, String pictureName) {
         LOG.log(CREATION_LOGGING_LEVEL, "Creating picture with pictureName={0} file={1}", new Object[]{pictureName, originalPictureFile});
         final File pictureFile;
         pictureFile = new File(project.getPicturesFolder(), originalPictureFile.getName());
@@ -122,7 +122,7 @@ public final class PictureFactory {
      * @param pictureHeight the picture's height
      * @return the created picture
      */
-    public static Picture createPicture(final TimeLineProject project, long id, String pictureName, LocalDateTime pictureCreationDate, String picturePath, int pictureWidth, int pictureHeight) {
+    public static Picture createPicture(final TimeLineProject project, final long id, String pictureName, LocalDateTime pictureCreationDate, String picturePath, int pictureWidth, int pictureHeight) {
         LOG.log(CREATION_LOGGING_LEVEL, "Creating picture with id={0} pictureName={1}", new Object[]{id, pictureName});
         if (!FACTORY.isIdAvailable(id)) {
             throw new IllegalArgumentException("Trying to create picture " + pictureName + " with existing id=" + id + " :: " + FACTORY.get(id));

--- a/src/main/java/com/github/noony/app/timelinefx/core/PictureFactory.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/PictureFactory.java
@@ -90,7 +90,7 @@ public final class PictureFactory {
      * @param pictureName the picture's name
      * @return the created picture
      */
-    public static Picture createPicture(final TimeLineProject project, final File originalPictureFile, String pictureName) {
+    public static Picture createPicture(final TimeLineProject project, final File originalPictureFile, final String pictureName) {
         LOG.log(CREATION_LOGGING_LEVEL, "Creating picture with pictureName={0} file={1}", new Object[]{pictureName, originalPictureFile});
         final File pictureFile;
         pictureFile = new File(project.getPicturesFolder(), originalPictureFile.getName());
@@ -122,7 +122,7 @@ public final class PictureFactory {
      * @param pictureHeight the picture's height
      * @return the created picture
      */
-    public static Picture createPicture(final TimeLineProject project, final long id, String pictureName, LocalDateTime pictureCreationDate, String picturePath, int pictureWidth, int pictureHeight) {
+    public static Picture createPicture(final TimeLineProject project, final long id, final String pictureName, LocalDateTime pictureCreationDate, String picturePath, int pictureWidth, int pictureHeight) {
         LOG.log(CREATION_LOGGING_LEVEL, "Creating picture with id={0} pictureName={1}", new Object[]{id, pictureName});
         if (!FACTORY.isIdAvailable(id)) {
             throw new IllegalArgumentException("Trying to create picture " + pictureName + " with existing id=" + id + " :: " + FACTORY.get(id));

--- a/src/main/java/com/github/noony/app/timelinefx/core/PictureInfo.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/PictureInfo.java
@@ -3,6 +3,7 @@
  * To change this template file, choose Tools | Templates
  * and open the template in the editor.
  */
+
 package com.github.noony.app.timelinefx.core;
 
 import java.time.LocalDateTime;
@@ -14,12 +15,16 @@ import java.time.LocalDateTime;
 public class PictureInfo {
 
     private final String name;
+
     private final String path;
+
     private final LocalDateTime creationDate;
+
     private final int width;
+
     private final int height;
 
-    public PictureInfo(String name, String path, LocalDateTime creationDate, int width, int height) {
+    public PictureInfo(final String name, String path, LocalDateTime creationDate, int width, int height) {
         this.name = name;
         this.path = path;
         this.creationDate = creationDate;

--- a/src/main/java/com/github/noony/app/timelinefx/core/PictureInfo.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/PictureInfo.java
@@ -47,7 +47,7 @@ public class PictureInfo {
      * @param width the picture's width
      * @param height the picture's height
      */
-    public PictureInfo(final String name, final String path, LocalDateTime creationDate, int width, int height) {
+    public PictureInfo(final String name, final String path, final LocalDateTime creationDate, int width, int height) {
         this.name = name;
         this.path = path;
         this.creationDate = creationDate;

--- a/src/main/java/com/github/noony/app/timelinefx/core/PictureInfo.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/PictureInfo.java
@@ -9,21 +9,44 @@ package com.github.noony.app.timelinefx.core;
 import java.time.LocalDateTime;
 
 /**
+ * Metadata extracted from a picture file (name, location, creation date and dimensions).
  *
  * @author hamon
  */
 public class PictureInfo {
 
+    /**
+     * The picture's name.
+     */
     private final String name;
 
+    /**
+     * The picture file's path.
+     */
     private final String path;
 
+    /**
+     * The picture's creation date.
+     */
     private final LocalDateTime creationDate;
 
+    /**
+     * The picture's width.
+     */
     private final int width;
 
+    /**
+     * The picture's height.
+     */
     private final int height;
 
+    /**
+     * @param name the picture's name
+     * @param path the picture file's path
+     * @param creationDate the picture's creation date
+     * @param width the picture's width
+     * @param height the picture's height
+     */
     public PictureInfo(final String name, String path, LocalDateTime creationDate, int width, int height) {
         this.name = name;
         this.path = path;
@@ -32,22 +55,37 @@ public class PictureInfo {
         this.height = height;
     }
 
+    /**
+     * @return the picture's name
+     */
     public String getName() {
         return name;
     }
 
+    /**
+     * @return the picture file's path
+     */
     public String getPath() {
         return path;
     }
 
+    /**
+     * @return the picture's creation date
+     */
     public LocalDateTime getCreationDate() {
         return creationDate;
     }
 
+    /**
+     * @return the picture's width
+     */
     public int getWidth() {
         return width;
     }
 
+    /**
+     * @return the picture's height
+     */
     public int getHeight() {
         return height;
     }

--- a/src/main/java/com/github/noony/app/timelinefx/core/PictureInfo.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/PictureInfo.java
@@ -47,7 +47,7 @@ public class PictureInfo {
      * @param width the picture's width
      * @param height the picture's height
      */
-    public PictureInfo(final String name, String path, LocalDateTime creationDate, int width, int height) {
+    public PictureInfo(final String name, final String path, LocalDateTime creationDate, int width, int height) {
         this.name = name;
         this.path = path;
         this.creationDate = creationDate;

--- a/src/main/java/com/github/noony/app/timelinefx/core/Place.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/Place.java
@@ -101,7 +101,7 @@ public final class Place implements FriezeObject {
     private boolean selected;
     //
 
-    protected Place(final long placeId, final String placeName, PlaceLevel placeLevel, Place parentPlace, Color aColor) {
+    protected Place(final long placeId, final String placeName, final PlaceLevel placeLevel, Place parentPlace, Color aColor) {
         id = placeId;
         name = placeName;
         parent = parentPlace;
@@ -120,7 +120,7 @@ public final class Place implements FriezeObject {
         }
     }
 
-    protected Place(final long placeId, final String placeName, PlaceLevel placeLevel, Place parentPlace) {
+    protected Place(final long placeId, final String placeName, final PlaceLevel placeLevel, Place parentPlace) {
         this(placeId, placeName, placeLevel, parentPlace, DEFAULT_COLOR);
     }
 

--- a/src/main/java/com/github/noony/app/timelinefx/core/Place.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/Place.java
@@ -101,7 +101,7 @@ public final class Place implements FriezeObject {
     private boolean selected;
     //
 
-    protected Place(final long placeId, String placeName, PlaceLevel placeLevel, Place parentPlace, Color aColor) {
+    protected Place(final long placeId, final String placeName, PlaceLevel placeLevel, Place parentPlace, Color aColor) {
         id = placeId;
         name = placeName;
         parent = parentPlace;
@@ -120,7 +120,7 @@ public final class Place implements FriezeObject {
         }
     }
 
-    protected Place(final long placeId, String placeName, PlaceLevel placeLevel, Place parentPlace) {
+    protected Place(final long placeId, final String placeName, PlaceLevel placeLevel, Place parentPlace) {
         this(placeId, placeName, placeLevel, parentPlace, DEFAULT_COLOR);
     }
 

--- a/src/main/java/com/github/noony/app/timelinefx/core/Place.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/Place.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core;
 
 import java.beans.PropertyChangeListener;
@@ -43,19 +44,24 @@ public final class Place implements FriezeObject {
 
     private final Long id;
     private final List<Place> places;
+
     private String name;
+
     private Place parent;
+
     private PlaceLevel level;
+
     private boolean isRootPlace;
 
     private final PropertyChangeSupport propertyChangeSupport;
 
     // where to split into an HCI comp ?
     private Color color;
+
     private boolean selected;
     //
 
-    protected Place(long placeId, String placeName, PlaceLevel placeLevel, Place parentPlace, Color aColor) {
+    protected Place(final long placeId, String placeName, PlaceLevel placeLevel, Place parentPlace, Color aColor) {
         id = placeId;
         name = placeName;
         parent = parentPlace;
@@ -74,7 +80,7 @@ public final class Place implements FriezeObject {
         }
     }
 
-    protected Place(long placeId, String placeName, PlaceLevel placeLevel, Place parentPlace) {
+    protected Place(final long placeId, String placeName, PlaceLevel placeLevel, Place parentPlace) {
         this(placeId, placeName, placeLevel, parentPlace, DEFAULT_COLOR);
     }
 
@@ -83,12 +89,12 @@ public final class Place implements FriezeObject {
         return id;
     }
 
-    public void addPropertyChangeListener(PropertyChangeListener listener) {
+    public void addPropertyChangeListener(final PropertyChangeListener listener) {
         propertyChangeSupport.addPropertyChangeListener(listener);
     }
 
-    public void setSelected(boolean isSelected) {
-        var update = selected != isSelected;
+    public void setSelected(final boolean isSelected) {
+        final var update = selected != isSelected;
         selected = isSelected;
         if (update) {
             propertyChangeSupport.firePropertyChange(SELECTION_CHANGED, null, selected);
@@ -99,7 +105,7 @@ public final class Place implements FriezeObject {
         return name;
     }
 
-    public void setName(String aName) {
+    public void setName(final String aName) {
         name = aName;
         propertyChangeSupport.firePropertyChange(CONTENT_CHANGED, null, this);
     }
@@ -108,8 +114,8 @@ public final class Place implements FriezeObject {
         return level;
     }
 
-    public boolean setLevel(PlaceLevel aLevel) {
-        boolean placeConflict = places.stream().anyMatch(p -> p.getLevel().getLevelValue() >= aLevel.getLevelValue());
+    public boolean setLevel(final PlaceLevel aLevel) {
+        final boolean placeConflict = places.stream().anyMatch(p -> p.getLevel().getLevelValue() >= aLevel.getLevelValue());
         if (placeConflict) {
             LOG.log(Level.SEVERE, "New level cannot be set because of children levels : {0}", new Object[]{aLevel});
             return false;
@@ -127,8 +133,8 @@ public final class Place implements FriezeObject {
         return parent;
     }
 
-    public void setParent(Place aParentPlace) {
-        Place oldParent = parent;
+    public void setParent(final Place aParentPlace) {
+        final Place oldParent = parent;
         parent = aParentPlace;
         isRootPlace = parent == null || PlaceFactory.PLACES_PLACE.equals(parent);
         if (oldParent != null && oldParent != parent) {
@@ -154,8 +160,8 @@ public final class Place implements FriezeObject {
         }
     }
 
-    public boolean removePlace(Place place) {
-        boolean result = places.remove(place);
+    public boolean removePlace(final Place place) {
+        final boolean result = places.remove(place);
         propertyChangeSupport.firePropertyChange(CONTENT_CHANGED, null, this);
         return result;
     }
@@ -164,7 +170,7 @@ public final class Place implements FriezeObject {
         return color;
     }
 
-    public void setColor(Color aColor) {
+    public void setColor(final Color aColor) {
         color = aColor;
         propertyChangeSupport.firePropertyChange(CONTENT_CHANGED, null, this);
     }

--- a/src/main/java/com/github/noony/app/timelinefx/core/Place.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/Place.java
@@ -28,36 +28,76 @@ import java.util.logging.Logger;
 import javafx.scene.paint.Color;
 
 /**
+ * A named location, optionally nested under a parent place (e.g. a town within a country).
  *
  * @author hamon
  */
 public final class Place implements FriezeObject {
 
+    /**
+     * Name of the property change event fired when this place's selection changes.
+     */
     public static final String SELECTION_CHANGED = "selectionChanged";
+    /**
+     * Name of the property change event fired when this place's content (name, level, color, parent) changes.
+     */
     public static final String CONTENT_CHANGED = "contentChanged";
 
+    /**
+     * The color assigned to a place when none is specified.
+     */
     public static final Color DEFAULT_COLOR = Color.GREY;
 
+    /**
+     * Orders places by name.
+     */
     public static final Comparator<Place> COMPARATOR = Comparator.comparing(Place::getName);
 
+    /**
+     * Logger used by this class.
+     */
     private static final Logger LOG = Logger.getGlobal();
 
     private final Long id;
+    /**
+     * The places directly nested under this one.
+     */
     private final List<Place> places;
 
+    /**
+     * This place's display name.
+     */
     private String name;
 
+    /**
+     * This place's parent, or null for a root place.
+     */
     private Place parent;
 
+    /**
+     * This place's nesting level.
+     */
     private PlaceLevel level;
 
+    /**
+     * Whether this place has no parent (or its parent is the implicit root place).
+     */
     private boolean isRootPlace;
 
+    /**
+     * Support object used to fire property change events.
+     */
     private final PropertyChangeSupport propertyChangeSupport;
 
     // where to split into an HCI comp ?
+    /**
+     * This place's display color.
+     */
     private Color color;
 
+    /**
+     * Whether this place is currently selected.
+     */
     private boolean selected;
     //
 
@@ -89,10 +129,16 @@ public final class Place implements FriezeObject {
         return id;
     }
 
+    /**
+     * @param listener the listener to add
+     */
     public void addPropertyChangeListener(final PropertyChangeListener listener) {
         propertyChangeSupport.addPropertyChangeListener(listener);
     }
 
+    /**
+     * @param isSelected whether this place is now selected
+     */
     public void setSelected(final boolean isSelected) {
         final var update = selected != isSelected;
         selected = isSelected;
@@ -101,19 +147,32 @@ public final class Place implements FriezeObject {
         }
     }
 
+    /**
+     * @return this place's name
+     */
     public String getName() {
         return name;
     }
 
+    /**
+     * @param aName this place's new name
+     */
     public void setName(final String aName) {
         name = aName;
         propertyChangeSupport.firePropertyChange(CONTENT_CHANGED, null, this);
     }
 
+    /**
+     * @return this place's nesting level
+     */
     public PlaceLevel getLevel() {
         return level;
     }
 
+    /**
+     * @param aLevel this place's new nesting level
+     * @return true if the level was set, false if it conflicts with a child place's level
+     */
     public boolean setLevel(final PlaceLevel aLevel) {
         final boolean placeConflict = places.stream().anyMatch(p -> p.getLevel().getLevelValue() >= aLevel.getLevelValue());
         if (placeConflict) {
@@ -125,14 +184,23 @@ public final class Place implements FriezeObject {
         return true;
     }
 
+    /**
+     * @return whether this place has no parent (or its parent is the implicit root place)
+     */
     public boolean isRootPlace() {
         return isRootPlace;
     }
 
+    /**
+     * @return this place's parent, or null for a root place
+     */
     public Place getParent() {
         return parent;
     }
 
+    /**
+     * @param aParentPlace this place's new parent
+     */
     public void setParent(final Place aParentPlace) {
         final Place oldParent = parent;
         parent = aParentPlace;
@@ -146,6 +214,9 @@ public final class Place implements FriezeObject {
         propertyChangeSupport.firePropertyChange(CONTENT_CHANGED, null, this);
     }
 
+    /**
+     * @return an unmodifiable list of the places directly nested under this one
+     */
     public List<Place> getPlaces() {
         return Collections.unmodifiableList(places);
     }
@@ -160,16 +231,26 @@ public final class Place implements FriezeObject {
         }
     }
 
+    /**
+     * @param place the place to remove
+     * @return true if the place was removed, false if it wasn't a direct child of this one
+     */
     public boolean removePlace(final Place place) {
         final boolean result = places.remove(place);
         propertyChangeSupport.firePropertyChange(CONTENT_CHANGED, null, this);
         return result;
     }
 
+    /**
+     * @return this place's display color
+     */
     public Color getColor() {
         return color;
     }
 
+    /**
+     * @param aColor this place's new display color
+     */
     public void setColor(final Color aColor) {
         color = aColor;
         propertyChangeSupport.firePropertyChange(CONTENT_CHANGED, null, this);
@@ -180,6 +261,9 @@ public final class Place implements FriezeObject {
         return name;
     }
 
+    /**
+     * @return whether this place is currently selected
+     */
     public boolean isSelected() {
         return selected;
     }

--- a/src/main/java/com/github/noony/app/timelinefx/core/Place.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/Place.java
@@ -124,8 +124,7 @@ public final class Place implements FriezeObject {
         this(placeId, placeName, placeLevel, parentPlace, DEFAULT_COLOR);
     }
 
-    @Override
-    public long getId() {
+    @Override public long getId() {
         return id;
     }
 

--- a/src/main/java/com/github/noony/app/timelinefx/core/PlaceFactory.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/PlaceFactory.java
@@ -14,13 +14,16 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core;
 
-import static com.github.noony.app.timelinefx.core.Factory.CREATION_LOGGING_LEVEL;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import javafx.scene.paint.Color;
+import static com.github.noony.app.timelinefx.core.Factory.CREATION_LOGGING_LEVEL;
 
 /**
  *
@@ -53,14 +56,14 @@ public final class PlaceFactory {
         return new ArrayList<>(ROOT_PLACES);
     }
 
-    public static Place getPlace(long placeID) {
+    public static Place getPlace(final long placeID) {
         return FACTORY.get(placeID);
     }
 
-    public static Place createPlace(String placeName, PlaceLevel placeLevel, Place parentPlace) {
+    public static Place createPlace(final String placeName, PlaceLevel placeLevel, Place parentPlace) {
         LOG.log(CREATION_LOGGING_LEVEL, "Creating place with placeName={0} placeLevel={1} parentPlace={2} ", new Object[]{placeName, placeLevel, parentPlace});
-        var trueParentPlace = parentPlace != null ? parentPlace : PLACES_PLACE;
-        var place = new Place(FACTORY.getNextID(), placeName, placeLevel, trueParentPlace);
+        final var trueParentPlace = parentPlace != null ? parentPlace : PLACES_PLACE;
+        final var place = new Place(FACTORY.getNextID(), placeName, placeLevel, trueParentPlace);
         if (place.isRootPlace()) {
             addRootPlace(place);
         }
@@ -68,10 +71,10 @@ public final class PlaceFactory {
         return place;
     }
 
-    public static Place createPlace(String placeName, PlaceLevel placeLevel, Place parentPlace, Color color) {
+    public static Place createPlace(final String placeName, PlaceLevel placeLevel, Place parentPlace, Color color) {
         LOG.log(CREATION_LOGGING_LEVEL, "Creating place with placeName={0} placeLevel={1} parentPlace={2} color={3} ", new Object[]{placeName, placeLevel, parentPlace, color});
         var trueParentPlace = parentPlace != null ? parentPlace : PLACES_PLACE;
-        var place = new Place(FACTORY.getNextID(), placeName, placeLevel, trueParentPlace, color);
+        final var place = new Place(FACTORY.getNextID(), placeName, placeLevel, trueParentPlace, color);
         if (place.isRootPlace()) {
             addRootPlace(place);
         }
@@ -79,13 +82,13 @@ public final class PlaceFactory {
         return place;
     }
 
-    public static Place createPlace(long id, String placeName, PlaceLevel placeLevel, Place parentPlace, Color color) {
+    public static Place createPlace(final long id, String placeName, PlaceLevel placeLevel, Place parentPlace, Color color) {
         if (!FACTORY.isIdAvailable(id)) {
             throw new IllegalArgumentException("trying to create place " + placeName + " with existing id=" + id);
         }
         LOG.log(CREATION_LOGGING_LEVEL, "Creating place (id={0} with placeName={1} placeLevel={2} parentPlace={3} ", new Object[]{id, placeName, placeLevel, parentPlace});
         var trueParentPlace = parentPlace != null ? parentPlace : PLACES_PLACE;
-        var place = new Place(id, placeName, placeLevel, trueParentPlace, color);
+        final var place = new Place(id, placeName, placeLevel, trueParentPlace, color);
         if (place.isRootPlace()) {
             addRootPlace(place);
         }
@@ -93,7 +96,7 @@ public final class PlaceFactory {
         return place;
     }
 
-    private static void addRootPlace(Place aRootPlace) {
+    private static void addRootPlace(final Place aRootPlace) {
         ROOT_PLACES.add(aRootPlace);
         ROOT_PLACES.sort(Place.COMPARATOR);
     }

--- a/src/main/java/com/github/noony/app/timelinefx/core/PlaceFactory.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/PlaceFactory.java
@@ -94,7 +94,7 @@ public final class PlaceFactory {
      * @param parentPlace the place's parent, or null for a root place
      * @return the created place
      */
-    public static Place createPlace(final String placeName, PlaceLevel placeLevel, Place parentPlace) {
+    public static Place createPlace(final String placeName, final PlaceLevel placeLevel, Place parentPlace) {
         LOG.log(CREATION_LOGGING_LEVEL, "Creating place with placeName={0} placeLevel={1} parentPlace={2} ", new Object[]{placeName, placeLevel, parentPlace});
         final var trueParentPlace = parentPlace != null ? parentPlace : PLACES_PLACE;
         final var place = new Place(FACTORY.getNextID(), placeName, placeLevel, trueParentPlace);
@@ -114,7 +114,7 @@ public final class PlaceFactory {
      * @param color the place's color
      * @return the created place
      */
-    public static Place createPlace(final String placeName, PlaceLevel placeLevel, Place parentPlace, Color color) {
+    public static Place createPlace(final String placeName, final PlaceLevel placeLevel, Place parentPlace, Color color) {
         LOG.log(CREATION_LOGGING_LEVEL, "Creating place with placeName={0} placeLevel={1} parentPlace={2} color={3} ", new Object[]{placeName, placeLevel, parentPlace, color});
         var trueParentPlace = parentPlace != null ? parentPlace : PLACES_PLACE;
         final var place = new Place(FACTORY.getNextID(), placeName, placeLevel, trueParentPlace, color);
@@ -135,7 +135,7 @@ public final class PlaceFactory {
      * @param color the place's color
      * @return the created place
      */
-    public static Place createPlace(final long id, String placeName, PlaceLevel placeLevel, Place parentPlace, Color color) {
+    public static Place createPlace(final long id, final String placeName, PlaceLevel placeLevel, Place parentPlace, Color color) {
         if (!FACTORY.isIdAvailable(id)) {
             throw new IllegalArgumentException("trying to create place " + placeName + " with existing id=" + id);
         }

--- a/src/main/java/com/github/noony/app/timelinefx/core/PlaceFactory.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/PlaceFactory.java
@@ -94,7 +94,7 @@ public final class PlaceFactory {
      * @param parentPlace the place's parent, or null for a root place
      * @return the created place
      */
-    public static Place createPlace(final String placeName, final PlaceLevel placeLevel, Place parentPlace) {
+    public static Place createPlace(final String placeName, final PlaceLevel placeLevel, final Place parentPlace) {
         LOG.log(CREATION_LOGGING_LEVEL, "Creating place with placeName={0} placeLevel={1} parentPlace={2} ", new Object[]{placeName, placeLevel, parentPlace});
         final var trueParentPlace = parentPlace != null ? parentPlace : PLACES_PLACE;
         final var place = new Place(FACTORY.getNextID(), placeName, placeLevel, trueParentPlace);
@@ -114,7 +114,7 @@ public final class PlaceFactory {
      * @param color the place's color
      * @return the created place
      */
-    public static Place createPlace(final String placeName, final PlaceLevel placeLevel, Place parentPlace, Color color) {
+    public static Place createPlace(final String placeName, final PlaceLevel placeLevel, final Place parentPlace, Color color) {
         LOG.log(CREATION_LOGGING_LEVEL, "Creating place with placeName={0} placeLevel={1} parentPlace={2} color={3} ", new Object[]{placeName, placeLevel, parentPlace, color});
         var trueParentPlace = parentPlace != null ? parentPlace : PLACES_PLACE;
         final var place = new Place(FACTORY.getNextID(), placeName, placeLevel, trueParentPlace, color);
@@ -135,7 +135,7 @@ public final class PlaceFactory {
      * @param color the place's color
      * @return the created place
      */
-    public static Place createPlace(final long id, final String placeName, PlaceLevel placeLevel, Place parentPlace, Color color) {
+    public static Place createPlace(final long id, final String placeName, final PlaceLevel placeLevel, Place parentPlace, Color color) {
         if (!FACTORY.isIdAvailable(id)) {
             throw new IllegalArgumentException("trying to create place " + placeName + " with existing id=" + id);
         }

--- a/src/main/java/com/github/noony/app/timelinefx/core/PlaceFactory.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/PlaceFactory.java
@@ -26,40 +26,74 @@ import javafx.scene.paint.Color;
 import static com.github.noony.app.timelinefx.core.Factory.CREATION_LOGGING_LEVEL;
 
 /**
+ * Entry point for creating and retrieving {@link Place} instances.
  *
  * @author hamon
  */
 public final class PlaceFactory {
 
+    /**
+     * The implicit root place all top-level places are attached to.
+     */
     public static final Place PLACES_PLACE = new Place(-1, "PLACES", PlaceLevel.UNIVERSE, null);
 
+    /**
+     * Logger used by this factory.
+     */
     private static final Logger LOG = Logger.getGlobal();
 
+    /**
+     * Registry of created places.
+     */
     private static final Factory<Place> FACTORY = new Factory<>();
 
+    /**
+     * The places with no parent (or whose parent is {@link #PLACES_PLACE}).
+     */
     private static final List<Place> ROOT_PLACES = new LinkedList<>();
 
     private PlaceFactory() {
         // private utility constructor
     }
 
+    /**
+     * Resets the factory, discarding all created places.
+     */
     public static void reset() {
         FACTORY.reset();
         ROOT_PLACES.clear();
     }
 
+    /**
+     * @return all created places, sorted by name
+     */
     public static List<Place> getPlaces() {
         return FACTORY.getObjects().stream().sorted(Place.COMPARATOR).collect(Collectors.toList());
     }
 
+    /**
+     * @return the root places
+     */
     public static List<Place> getRootPlaces() {
         return new ArrayList<>(ROOT_PLACES);
     }
 
+    /**
+     * @param placeID a place's id
+     * @return the place with the given id, or null if none exists
+     */
     public static Place getPlace(final long placeID) {
         return FACTORY.get(placeID);
     }
 
+    /**
+     * Creates a new place with the default color.
+     *
+     * @param placeName the place's name
+     * @param placeLevel the place's level
+     * @param parentPlace the place's parent, or null for a root place
+     * @return the created place
+     */
     public static Place createPlace(final String placeName, PlaceLevel placeLevel, Place parentPlace) {
         LOG.log(CREATION_LOGGING_LEVEL, "Creating place with placeName={0} placeLevel={1} parentPlace={2} ", new Object[]{placeName, placeLevel, parentPlace});
         final var trueParentPlace = parentPlace != null ? parentPlace : PLACES_PLACE;
@@ -71,6 +105,15 @@ public final class PlaceFactory {
         return place;
     }
 
+    /**
+     * Creates a new place.
+     *
+     * @param placeName the place's name
+     * @param placeLevel the place's level
+     * @param parentPlace the place's parent, or null for a root place
+     * @param color the place's color
+     * @return the created place
+     */
     public static Place createPlace(final String placeName, PlaceLevel placeLevel, Place parentPlace, Color color) {
         LOG.log(CREATION_LOGGING_LEVEL, "Creating place with placeName={0} placeLevel={1} parentPlace={2} color={3} ", new Object[]{placeName, placeLevel, parentPlace, color});
         var trueParentPlace = parentPlace != null ? parentPlace : PLACES_PLACE;
@@ -82,6 +125,16 @@ public final class PlaceFactory {
         return place;
     }
 
+    /**
+     * Creates a new place with a specific id.
+     *
+     * @param id the id to assign to the new place
+     * @param placeName the place's name
+     * @param placeLevel the place's level
+     * @param parentPlace the place's parent, or null for a root place
+     * @param color the place's color
+     * @return the created place
+     */
     public static Place createPlace(final long id, String placeName, PlaceLevel placeLevel, Place parentPlace, Color color) {
         if (!FACTORY.isIdAvailable(id)) {
             throw new IllegalArgumentException("trying to create place " + placeName + " with existing id=" + id);

--- a/src/main/java/com/github/noony/app/timelinefx/core/PlaceLevel.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/PlaceLevel.java
@@ -18,19 +18,29 @@
 package com.github.noony.app.timelinefx.core;
 
 /**
+ * The nesting level of a {@link Place}, from the smallest (address) to the largest (universe).
  *
  * @author hamon
  */
 public enum PlaceLevel {
 
+    /**
+     * The available levels, ordered from smallest to largest.
+     */
     ADDRESS(10), TOWN(20), DEPARTMENT(30), REGION(40), COUNTRY(50), CONTINENT(60), PLANET(70), ORBIT(75), SYSTEM(80), INTER_SYSTEM_SPACE(90), GALAXY(100), UNIVERSE(1000);
 
+    /**
+     * The numeric value used to compare levels.
+     */
     private final int level;
 
     PlaceLevel(final int level) {
         this.level = level;
     }
 
+    /**
+     * @return this level's numeric value
+     */
     public int getLevelValue() {
         return level;
     }

--- a/src/main/java/com/github/noony/app/timelinefx/core/PlaceLevel.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/PlaceLevel.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core;
 
 /**
@@ -26,7 +27,7 @@ public enum PlaceLevel {
 
     private final int level;
 
-    PlaceLevel(int level) {
+    PlaceLevel(final int level) {
         this.level = level;
     }
 

--- a/src/main/java/com/github/noony/app/timelinefx/core/Portrait.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/Portrait.java
@@ -52,21 +52,21 @@ public class Portrait extends AbstractPicture {
      */
     private final ArrayList<Person> persons;
 
-    protected Portrait(final long aPortraitID, final Person aPerson, String aFilePath, int aWidth, int aHeight, long aTimestamp) {
+    protected Portrait(final long aPortraitID, final Person aPerson, final String aFilePath, int aWidth, int aHeight, long aTimestamp) {
         super(aPortraitID, aFilePath, aFilePath, aWidth, aHeight, aTimestamp);
         person = aPerson;
         persons = new ArrayList<>(1);
         persons.add(person);
     }
 
-    protected Portrait(final long aPortraitID, final Person aPerson, String aFilePath, int aWidth, int aHeight, LocalDate aDate) {
+    protected Portrait(final long aPortraitID, final Person aPerson, final String aFilePath, int aWidth, int aHeight, LocalDate aDate) {
         super(aPortraitID, aFilePath, aFilePath, aWidth, aHeight, aDate);
         person = aPerson;
         persons = new ArrayList<>(1);
         persons.add(person);
     }
 
-    protected Portrait(final long aPortraitID, final Person aPerson, String aFilePath, int aWidth, int aHeight) {
+    protected Portrait(final long aPortraitID, final Person aPerson, final String aFilePath, int aWidth, int aHeight) {
         this(aPortraitID, aPerson, aFilePath, aWidth, aHeight, DEFAULT_TIMESTAMP);
     }
 

--- a/src/main/java/com/github/noony/app/timelinefx/core/Portrait.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/Portrait.java
@@ -70,8 +70,7 @@ public class Portrait extends AbstractPicture {
         this(aPortraitID, aPerson, aFilePath, aWidth, aHeight, DEFAULT_TIMESTAMP);
     }
 
-    @Override
-    public List<Person> getPersons() {
+    @Override public List<Person> getPersons() {
         return Collections.unmodifiableList(persons);
     }
 

--- a/src/main/java/com/github/noony/app/timelinefx/core/Portrait.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/Portrait.java
@@ -52,21 +52,21 @@ public class Portrait extends AbstractPicture {
      */
     private final ArrayList<Person> persons;
 
-    protected Portrait(final long aPortraitID, Person aPerson, String aFilePath, int aWidth, int aHeight, long aTimestamp) {
+    protected Portrait(final long aPortraitID, final Person aPerson, String aFilePath, int aWidth, int aHeight, long aTimestamp) {
         super(aPortraitID, aFilePath, aFilePath, aWidth, aHeight, aTimestamp);
         person = aPerson;
         persons = new ArrayList<>(1);
         persons.add(person);
     }
 
-    protected Portrait(final long aPortraitID, Person aPerson, String aFilePath, int aWidth, int aHeight, LocalDate aDate) {
+    protected Portrait(final long aPortraitID, final Person aPerson, String aFilePath, int aWidth, int aHeight, LocalDate aDate) {
         super(aPortraitID, aFilePath, aFilePath, aWidth, aHeight, aDate);
         person = aPerson;
         persons = new ArrayList<>(1);
         persons.add(person);
     }
 
-    protected Portrait(final long aPortraitID, Person aPerson, String aFilePath, int aWidth, int aHeight) {
+    protected Portrait(final long aPortraitID, final Person aPerson, String aFilePath, int aWidth, int aHeight) {
         this(aPortraitID, aPerson, aFilePath, aWidth, aHeight, DEFAULT_TIMESTAMP);
     }
 

--- a/src/main/java/com/github/noony/app/timelinefx/core/Portrait.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/Portrait.java
@@ -26,17 +26,30 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
+ * A person's portrait picture. Unlike a {@link Picture}, a portrait always belongs to exactly one person.
  *
  * @author hamon
  */
 public class Portrait extends AbstractPicture {
 
+    /**
+     * Orders portraits by id.
+     */
     public static final Comparator<Portrait> COMPARATOR = Comparator.comparingLong(FriezeObject::getId);
 
+    /**
+     * Logger used by this class.
+     */
     private static final Logger LOG = Logger.getGlobal();
 
+    /**
+     * The person this portrait belongs to.
+     */
     private final Person person;
 
+    /**
+     * Single-element list containing {@link #person}, returned by {@link #getPersons()}.
+     */
     private final ArrayList<Person> persons;
 
     protected Portrait(final long aPortraitID, Person aPerson, String aFilePath, int aWidth, int aHeight, long aTimestamp) {
@@ -89,6 +102,9 @@ public class Portrait extends AbstractPicture {
         return getAbsolutePath().compareTo(other.getAbsolutePath());
     }
 
+    /**
+     * @return the person this portrait belongs to
+     */
     public Person getPerson() {
         return person;
     }

--- a/src/main/java/com/github/noony/app/timelinefx/core/Portrait.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/Portrait.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core;
 
 import java.time.LocalDate;
@@ -35,23 +36,24 @@ public class Portrait extends AbstractPicture {
     private static final Logger LOG = Logger.getGlobal();
 
     private final Person person;
+
     private final ArrayList<Person> persons;
 
-    protected Portrait(long aPortraitID, Person aPerson, String aFilePath, int aWidth, int aHeight, long aTimestamp) {
+    protected Portrait(final long aPortraitID, Person aPerson, String aFilePath, int aWidth, int aHeight, long aTimestamp) {
         super(aPortraitID, aFilePath, aFilePath, aWidth, aHeight, aTimestamp);
         person = aPerson;
         persons = new ArrayList<>(1);
         persons.add(person);
     }
 
-    protected Portrait(long aPortraitID, Person aPerson, String aFilePath, int aWidth, int aHeight, LocalDate aDate) {
+    protected Portrait(final long aPortraitID, Person aPerson, String aFilePath, int aWidth, int aHeight, LocalDate aDate) {
         super(aPortraitID, aFilePath, aFilePath, aWidth, aHeight, aDate);
         person = aPerson;
         persons = new ArrayList<>(1);
         persons.add(person);
     }
 
-    protected Portrait(long aPortraitID, Person aPerson, String aFilePath, int aWidth, int aHeight) {
+    protected Portrait(final long aPortraitID, Person aPerson, String aFilePath, int aWidth, int aHeight) {
         this(aPortraitID, aPerson, aFilePath, aWidth, aHeight, DEFAULT_TIMESTAMP);
     }
 
@@ -61,13 +63,13 @@ public class Portrait extends AbstractPicture {
     }
 
     @Override
-    public boolean addPerson(Person aPerson) {
+    public boolean addPerson(final Person aPerson) {
         LOG.log(Level.INFO, "No person can be added to a portrait. ({0}, {1})", new Object[]{this, aPerson});
         return false;
     }
 
     @Override
-    public boolean removePerson(Person aPerson) {
+    public boolean removePerson(final Person aPerson) {
         LOG.log(Level.INFO, "No person can be removed from a portrait. ({0}, {1})", new Object[]{this, aPerson});
         return false;
     }
@@ -78,7 +80,7 @@ public class Portrait extends AbstractPicture {
     }
 
     @Override
-    public int compareTo(IFileObject other) {
+    public int compareTo(final IFileObject other) {
         if (other == null) {
             return 1;
         } else if (other instanceof Portrait portrait) {
@@ -92,12 +94,12 @@ public class Portrait extends AbstractPicture {
     }
 
     @Override
-    public boolean addPlace(Place aPlace) {
+    public boolean addPlace(final Place aPlace) {
         return false;
     }
 
     @Override
-    public boolean removePlace(Place aPlace) {
+    public boolean removePlace(final Place aPlace) {
         return false;
     }
 

--- a/src/main/java/com/github/noony/app/timelinefx/core/PortraitFactory.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/PortraitFactory.java
@@ -14,9 +14,9 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core;
 
-import static com.github.noony.app.timelinefx.core.Factory.CREATION_LOGGING_LEVEL;
 import com.github.noony.app.timelinefx.utils.CustomFileUtils;
 import com.github.noony.app.timelinefx.utils.MetadataParser;
 import java.beans.PropertyChangeListener;
@@ -24,6 +24,7 @@ import java.beans.PropertyChangeSupport;
 import java.io.File;
 import java.util.List;
 import java.util.logging.Logger;
+import static com.github.noony.app.timelinefx.core.Factory.CREATION_LOGGING_LEVEL;
 
 /**
  *
@@ -36,6 +37,7 @@ public final class PortraitFactory {
     private static final Logger LOG = Logger.getGlobal();
 
     private static final Factory<Portrait> FACTORY = new Factory<>();
+
     private static final PropertyChangeSupport PROPERTY_CHANGE_SUPPORT = new PropertyChangeSupport(FACTORY);
 
     private PortraitFactory() {
@@ -46,35 +48,35 @@ public final class PortraitFactory {
         FACTORY.reset();
     }
 
-    public static Portrait getPortrait(long id) {
+    public static Portrait getPortrait(final long id) {
         return FACTORY.get(id);
     }
 
-    public static Portrait createPortrait(Person person) {
+    public static Portrait createPortrait(final Person person) {
         LOG.log(CREATION_LOGGING_LEVEL, "Creating portrait with person={0} and default picture.", new Object[]{person});
-        var filePath = person.getProject().getPortraitsAbsoluteFolder().getAbsolutePath() + File.separator + Person.DEFAULT_PICTURE_NAME;
-        var fileRelativePath = person.getProject().getPortraitsRelativeFolder() + File.separator + Person.DEFAULT_PICTURE_NAME;
-        var file = new File(filePath);
-        var picInfo = MetadataParser.parseMetadata(person.getProject(), file);
+        final var filePath = person.getProject().getPortraitsAbsoluteFolder().getAbsolutePath() + File.separator + Person.DEFAULT_PICTURE_NAME;
+        final var fileRelativePath = person.getProject().getPortraitsRelativeFolder() + File.separator + Person.DEFAULT_PICTURE_NAME;
+        final var file = new File(filePath);
+        final var picInfo = MetadataParser.parseMetadata(person.getProject(), file);
         assert picInfo != null;
-        var portrait = new Portrait(FACTORY.getNextID(), person, fileRelativePath, picInfo.getWidth(), picInfo.getHeight());
+        final var portrait = new Portrait(FACTORY.getNextID(), person, fileRelativePath, picInfo.getWidth(), picInfo.getHeight());
         FACTORY.addObject(portrait);
         PROPERTY_CHANGE_SUPPORT.firePropertyChange(PORTRAIT_CREATED, null, portrait);
         return portrait;
     }
 
-    public static Portrait createPortrait(Person person, String filePath) {
+    public static Portrait createPortrait(final Person person, String filePath) {
         LOG.log(CREATION_LOGGING_LEVEL, "Creating portrait with person={0} filePath={1}.", new Object[]{person, filePath});
-        var file = new File(CustomFileUtils.fromProjectRelativeToAbsolute(person.getProject(), filePath));
+        final var file = new File(CustomFileUtils.fromProjectRelativeToAbsolute(person.getProject(), filePath));
         var picInfo = MetadataParser.parseMetadata(person.getProject(), file);
         assert picInfo != null;
-        var portrait = new Portrait(FACTORY.getNextID(), person, filePath, picInfo.getWidth(), picInfo.getHeight());
+        final var portrait = new Portrait(FACTORY.getNextID(), person, filePath, picInfo.getWidth(), picInfo.getHeight());
         FACTORY.addObject(portrait);
         PROPERTY_CHANGE_SUPPORT.firePropertyChange(PORTRAIT_CREATED, null, portrait);
         return portrait;
     }
 
-    public static Portrait createPortrait(long id, Person person, String filePath) {
+    public static Portrait createPortrait(final long id, Person person, String filePath) {
         LOG.log(CREATION_LOGGING_LEVEL, "Creating portrait with id={0} person={1} filePath={2}.", new Object[]{id, person, filePath});
         if (!FACTORY.isIdAvailable(id)) {
             throw new IllegalArgumentException("Trying to create portrait " + filePath + " with existing id=" + id + " (exists : " + FACTORY.get(id) + "[" + FACTORY.get(id).getId() + "])");
@@ -84,7 +86,7 @@ public final class PortraitFactory {
             throw new IllegalArgumentException("Trying to create portrait for " + person + " with missing file=" + filePath);
         }
         var picInfo = MetadataParser.parseMetadata(person.getProject(), file);
-        var portrait = new Portrait(id, person, filePath, picInfo.getWidth(), picInfo.getHeight());
+        final var portrait = new Portrait(id, person, filePath, picInfo.getWidth(), picInfo.getHeight());
         FACTORY.addObject(portrait);
         PROPERTY_CHANGE_SUPPORT.firePropertyChange(PORTRAIT_CREATED, null, portrait);
         return portrait;
@@ -94,11 +96,11 @@ public final class PortraitFactory {
         return FACTORY.getObjects().stream().sorted(Portrait.COMPARATOR).toList();
     }
 
-    public static void addPropertyChangeListener(PropertyChangeListener listener) {
+    public static void addPropertyChangeListener(final PropertyChangeListener listener) {
         PROPERTY_CHANGE_SUPPORT.addPropertyChangeListener(listener);
     }
 
-    public static void removePropertyChangeListener(PropertyChangeListener listener) {
+    public static void removePropertyChangeListener(final PropertyChangeListener listener) {
         PROPERTY_CHANGE_SUPPORT.removePropertyChangeListener(listener);
     }
 

--- a/src/main/java/com/github/noony/app/timelinefx/core/PortraitFactory.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/PortraitFactory.java
@@ -117,7 +117,7 @@ public final class PortraitFactory {
      * @param filePath the portrait picture's project-relative file path
      * @return the created portrait
      */
-    public static Portrait createPortrait(final long id, final Person person, String filePath) {
+    public static Portrait createPortrait(final long id, final Person person, final String filePath) {
         LOG.log(CREATION_LOGGING_LEVEL, "Creating portrait with id={0} person={1} filePath={2}.", new Object[]{id, person, filePath});
         if (!FACTORY.isIdAvailable(id)) {
             throw new IllegalArgumentException("Trying to create portrait " + filePath + " with existing id=" + id + " (exists : " + FACTORY.get(id) + "[" + FACTORY.get(id).getId() + "])");

--- a/src/main/java/com/github/noony/app/timelinefx/core/PortraitFactory.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/PortraitFactory.java
@@ -27,31 +27,57 @@ import java.util.logging.Logger;
 import static com.github.noony.app.timelinefx.core.Factory.CREATION_LOGGING_LEVEL;
 
 /**
+ * Entry point for creating and retrieving {@link Portrait} instances.
  *
  * @author hamon
  */
 public final class PortraitFactory {
 
+    /**
+     * Name of the property change event fired when a portrait is created.
+     */
     public static final String PORTRAIT_CREATED = "portraitCreatedInFactory";
 
+    /**
+     * Logger used by this factory.
+     */
     private static final Logger LOG = Logger.getGlobal();
 
+    /**
+     * Registry of created portraits.
+     */
     private static final Factory<Portrait> FACTORY = new Factory<>();
 
+    /**
+     * Support object used to fire property change events.
+     */
     private static final PropertyChangeSupport PROPERTY_CHANGE_SUPPORT = new PropertyChangeSupport(FACTORY);
 
     private PortraitFactory() {
         // private utility constructor
     }
 
+    /**
+     * Resets the factory, discarding all created portraits.
+     */
     public static void reset() {
         FACTORY.reset();
     }
 
+    /**
+     * @param id a portrait's id
+     * @return the portrait with the given id, or null if none exists
+     */
     public static Portrait getPortrait(final long id) {
         return FACTORY.get(id);
     }
 
+    /**
+     * Creates a new portrait for a person using their default picture.
+     *
+     * @param person the person the portrait belongs to
+     * @return the created portrait
+     */
     public static Portrait createPortrait(final Person person) {
         LOG.log(CREATION_LOGGING_LEVEL, "Creating portrait with person={0} and default picture.", new Object[]{person});
         final var filePath = person.getProject().getPortraitsAbsoluteFolder().getAbsolutePath() + File.separator + Person.DEFAULT_PICTURE_NAME;
@@ -65,6 +91,13 @@ public final class PortraitFactory {
         return portrait;
     }
 
+    /**
+     * Creates a new portrait for a person using a specific picture file.
+     *
+     * @param person the person the portrait belongs to
+     * @param filePath the portrait picture's project-relative file path
+     * @return the created portrait
+     */
     public static Portrait createPortrait(final Person person, String filePath) {
         LOG.log(CREATION_LOGGING_LEVEL, "Creating portrait with person={0} filePath={1}.", new Object[]{person, filePath});
         final var file = new File(CustomFileUtils.fromProjectRelativeToAbsolute(person.getProject(), filePath));
@@ -76,6 +109,14 @@ public final class PortraitFactory {
         return portrait;
     }
 
+    /**
+     * Creates a new portrait with a specific id, referencing an already-existing file.
+     *
+     * @param id the id to assign to the new portrait
+     * @param person the person the portrait belongs to
+     * @param filePath the portrait picture's project-relative file path
+     * @return the created portrait
+     */
     public static Portrait createPortrait(final long id, Person person, String filePath) {
         LOG.log(CREATION_LOGGING_LEVEL, "Creating portrait with id={0} person={1} filePath={2}.", new Object[]{id, person, filePath});
         if (!FACTORY.isIdAvailable(id)) {
@@ -92,14 +133,23 @@ public final class PortraitFactory {
         return portrait;
     }
 
+    /**
+     * @return all created portraits, sorted by id
+     */
     public static List<Portrait> getPortraits() {
         return FACTORY.getObjects().stream().sorted(Portrait.COMPARATOR).toList();
     }
 
+    /**
+     * @param listener the listener to add
+     */
     public static void addPropertyChangeListener(final PropertyChangeListener listener) {
         PROPERTY_CHANGE_SUPPORT.addPropertyChangeListener(listener);
     }
 
+    /**
+     * @param listener the listener to remove
+     */
     public static void removePropertyChangeListener(final PropertyChangeListener listener) {
         PROPERTY_CHANGE_SUPPORT.removePropertyChangeListener(listener);
     }

--- a/src/main/java/com/github/noony/app/timelinefx/core/PortraitFactory.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/PortraitFactory.java
@@ -117,7 +117,7 @@ public final class PortraitFactory {
      * @param filePath the portrait picture's project-relative file path
      * @return the created portrait
      */
-    public static Portrait createPortrait(final long id, Person person, String filePath) {
+    public static Portrait createPortrait(final long id, final Person person, String filePath) {
         LOG.log(CREATION_LOGGING_LEVEL, "Creating portrait with id={0} person={1} filePath={2}.", new Object[]{id, person, filePath});
         if (!FACTORY.isIdAvailable(id)) {
             throw new IllegalArgumentException("Trying to create portrait " + filePath + " with existing id=" + id + " (exists : " + FACTORY.get(id) + "[" + FACTORY.get(id).getId() + "])");

--- a/src/main/java/com/github/noony/app/timelinefx/core/StayFactory.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/StayFactory.java
@@ -14,11 +14,12 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core;
 
-import static com.github.noony.app.timelinefx.core.Factory.CREATION_LOGGING_LEVEL;
 import java.time.LocalDate;
 import java.util.logging.Logger;
+import static com.github.noony.app.timelinefx.core.Factory.CREATION_LOGGING_LEVEL;
 
 /**
  *
@@ -27,8 +28,8 @@ import java.util.logging.Logger;
 public final class StayFactory {
 
     private static final Logger LOG = Logger.getGlobal();
-//    private static final Map<Long, StayPeriod> STAY_PERIOD_SIMPLE_TIMES = new HashMap<>();
-//    private static final Map<Long, StayPeriod> STAY_PERIOD_LOCAL_DATES = new HashMap<>();
+    //    private static final Map<Long, StayPeriod> STAY_PERIOD_SIMPLE_TIMES = new HashMap<>();
+    //    private static final Map<Long, StayPeriod> STAY_PERIOD_LOCAL_DATES = new HashMap<>();
 
 
     private static final Factory<StayPeriod> FACTORY = new Factory<>();
@@ -39,45 +40,45 @@ public final class StayFactory {
 
     public static void reset() {
         FACTORY.reset();
-//        STAY_PERIOD_SIMPLE_TIMES.clear();
-//        STAY_PERIOD_LOCAL_DATES.clear();
+        //        STAY_PERIOD_SIMPLE_TIMES.clear();
+        //        STAY_PERIOD_LOCAL_DATES.clear();
     }
 
-    public static StayPeriodSimpleTime createStayPeriodSimpleTime(Person person, double startDate, double endDate, Place aPlace) {
+    public static StayPeriodSimpleTime createStayPeriodSimpleTime(final Person person, double startDate, double endDate, Place aPlace) {
         LOG.log(CREATION_LOGGING_LEVEL, "Creating StayPeriodSimpleTime with person={0} startDate={1} endDate={2} aPlace={3}", new Object[]{person, startDate, endDate, aPlace});
-        var stay = new StayPeriodSimpleTime(FACTORY.getNextID(), person, startDate, endDate, aPlace);
+        final var stay = new StayPeriodSimpleTime(FACTORY.getNextID(), person, startDate, endDate, aPlace);
         FACTORY.addObject(stay);
         return stay;
     }
 
-    public static StayPeriodSimpleTime createStayPeriodSimpleTime(long id, Person person, double startDate, double endDate, Place aPlace) {
+    public static StayPeriodSimpleTime createStayPeriodSimpleTime(final long id, Person person, double startDate, double endDate, Place aPlace) {
         LOG.log(CREATION_LOGGING_LEVEL, "Creating StayPeriodSimpleTime with id={0} person={1} startDate={2} endDate={3} aPlace={4}", new Object[]{id, person, startDate, endDate, aPlace});
         if (!FACTORY.isIdAvailable(id)) {
             throw new IllegalArgumentException("Trying to create stay for " + person.getName() + " from " + startDate + " to " + endDate + " with existing id=" + id + " (exists : " + id + ")");
         }
-        var stay = new StayPeriodSimpleTime(id, person, startDate, endDate, aPlace);
+        final var stay = new StayPeriodSimpleTime(id, person, startDate, endDate, aPlace);
         FACTORY.addObject(stay);
         return stay;
     }
 
-    public static StayPeriodLocalDate createStayPeriodLocalDate(Person person, LocalDate startDate, LocalDate endDate, Place aPlace) {
+    public static StayPeriodLocalDate createStayPeriodLocalDate(final Person person, LocalDate startDate, LocalDate endDate, Place aPlace) {
         LOG.log(CREATION_LOGGING_LEVEL, "Creating createStayPeriodLocalDate with person={0} startDate={1} endDate={2} aPlace={3}", new Object[]{person, startDate, endDate, aPlace});
-        var stay = new StayPeriodLocalDate(FACTORY.getNextID(), person, startDate, endDate, aPlace);
+        final var stay = new StayPeriodLocalDate(FACTORY.getNextID(), person, startDate, endDate, aPlace);
         FACTORY.addObject(stay);
         return stay;
     }
 
-    public static StayPeriodLocalDate createStayPeriodLocalDate(long id, Person person, LocalDate startDate, LocalDate endDate, Place aPlace) {
+    public static StayPeriodLocalDate createStayPeriodLocalDate(final long id, Person person, LocalDate startDate, LocalDate endDate, Place aPlace) {
         LOG.log(CREATION_LOGGING_LEVEL, "Creating createStayPeriodLocalDate with id={0} person={1} startDate={2} endDate={3} aPlace={4}", new Object[]{id, person, startDate, endDate, aPlace});
         if (!FACTORY.isIdAvailable(id)) {
             throw new IllegalArgumentException("Trying to create stay for " + person.getName() + " with existing id=" + id + " (exists : " + FACTORY.get(id).getDisplayString() + ")");
         }
-        var stay = new StayPeriodLocalDate(id, person, startDate, endDate, aPlace);
+        final var stay = new StayPeriodLocalDate(id, person, startDate, endDate, aPlace);
         FACTORY.addObject(stay);
         return stay;
     }
 
-    public static StayPeriod getStay(long id) {
+    public static StayPeriod getStay(final long id) {
         return FACTORY.get(id);
     }
 

--- a/src/main/java/com/github/noony/app/timelinefx/core/StayFactory.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/StayFactory.java
@@ -63,7 +63,7 @@ public final class StayFactory {
      * @param aPlace the place stayed at
      * @return the created stay
      */
-    public static StayPeriodSimpleTime createStayPeriodSimpleTime(final Person person, final double startDate, double endDate, Place aPlace) {
+    public static StayPeriodSimpleTime createStayPeriodSimpleTime(final Person person, final double startDate, final double endDate, Place aPlace) {
         LOG.log(CREATION_LOGGING_LEVEL, "Creating StayPeriodSimpleTime with person={0} startDate={1} endDate={2} aPlace={3}", new Object[]{person, startDate, endDate, aPlace});
         final var stay = new StayPeriodSimpleTime(FACTORY.getNextID(), person, startDate, endDate, aPlace);
         FACTORY.addObject(stay);
@@ -80,7 +80,7 @@ public final class StayFactory {
      * @param aPlace the place stayed at
      * @return the created stay
      */
-    public static StayPeriodSimpleTime createStayPeriodSimpleTime(final long id, final Person person, double startDate, double endDate, Place aPlace) {
+    public static StayPeriodSimpleTime createStayPeriodSimpleTime(final long id, final Person person, final double startDate, double endDate, Place aPlace) {
         LOG.log(CREATION_LOGGING_LEVEL, "Creating StayPeriodSimpleTime with id={0} person={1} startDate={2} endDate={3} aPlace={4}", new Object[]{id, person, startDate, endDate, aPlace});
         if (!FACTORY.isIdAvailable(id)) {
             throw new IllegalArgumentException("Trying to create stay for " + person.getName() + " from " + startDate + " to " + endDate + " with existing id=" + id + " (exists : " + id + ")");
@@ -99,7 +99,7 @@ public final class StayFactory {
      * @param aPlace the place stayed at
      * @return the created stay
      */
-    public static StayPeriodLocalDate createStayPeriodLocalDate(final Person person, final LocalDate startDate, LocalDate endDate, Place aPlace) {
+    public static StayPeriodLocalDate createStayPeriodLocalDate(final Person person, final LocalDate startDate, final LocalDate endDate, Place aPlace) {
         LOG.log(CREATION_LOGGING_LEVEL, "Creating createStayPeriodLocalDate with person={0} startDate={1} endDate={2} aPlace={3}", new Object[]{person, startDate, endDate, aPlace});
         final var stay = new StayPeriodLocalDate(FACTORY.getNextID(), person, startDate, endDate, aPlace);
         FACTORY.addObject(stay);
@@ -116,7 +116,7 @@ public final class StayFactory {
      * @param aPlace the place stayed at
      * @return the created stay
      */
-    public static StayPeriodLocalDate createStayPeriodLocalDate(final long id, final Person person, LocalDate startDate, LocalDate endDate, Place aPlace) {
+    public static StayPeriodLocalDate createStayPeriodLocalDate(final long id, final Person person, final LocalDate startDate, LocalDate endDate, Place aPlace) {
         LOG.log(CREATION_LOGGING_LEVEL, "Creating createStayPeriodLocalDate with id={0} person={1} startDate={2} endDate={3} aPlace={4}", new Object[]{id, person, startDate, endDate, aPlace});
         if (!FACTORY.isIdAvailable(id)) {
             throw new IllegalArgumentException("Trying to create stay for " + person.getName() + " with existing id=" + id + " (exists : " + FACTORY.get(id).getDisplayString() + ")");

--- a/src/main/java/com/github/noony/app/timelinefx/core/StayFactory.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/StayFactory.java
@@ -63,7 +63,7 @@ public final class StayFactory {
      * @param aPlace the place stayed at
      * @return the created stay
      */
-    public static StayPeriodSimpleTime createStayPeriodSimpleTime(final Person person, double startDate, double endDate, Place aPlace) {
+    public static StayPeriodSimpleTime createStayPeriodSimpleTime(final Person person, final double startDate, double endDate, Place aPlace) {
         LOG.log(CREATION_LOGGING_LEVEL, "Creating StayPeriodSimpleTime with person={0} startDate={1} endDate={2} aPlace={3}", new Object[]{person, startDate, endDate, aPlace});
         final var stay = new StayPeriodSimpleTime(FACTORY.getNextID(), person, startDate, endDate, aPlace);
         FACTORY.addObject(stay);
@@ -80,7 +80,7 @@ public final class StayFactory {
      * @param aPlace the place stayed at
      * @return the created stay
      */
-    public static StayPeriodSimpleTime createStayPeriodSimpleTime(final long id, Person person, double startDate, double endDate, Place aPlace) {
+    public static StayPeriodSimpleTime createStayPeriodSimpleTime(final long id, final Person person, double startDate, double endDate, Place aPlace) {
         LOG.log(CREATION_LOGGING_LEVEL, "Creating StayPeriodSimpleTime with id={0} person={1} startDate={2} endDate={3} aPlace={4}", new Object[]{id, person, startDate, endDate, aPlace});
         if (!FACTORY.isIdAvailable(id)) {
             throw new IllegalArgumentException("Trying to create stay for " + person.getName() + " from " + startDate + " to " + endDate + " with existing id=" + id + " (exists : " + id + ")");
@@ -99,7 +99,7 @@ public final class StayFactory {
      * @param aPlace the place stayed at
      * @return the created stay
      */
-    public static StayPeriodLocalDate createStayPeriodLocalDate(final Person person, LocalDate startDate, LocalDate endDate, Place aPlace) {
+    public static StayPeriodLocalDate createStayPeriodLocalDate(final Person person, final LocalDate startDate, LocalDate endDate, Place aPlace) {
         LOG.log(CREATION_LOGGING_LEVEL, "Creating createStayPeriodLocalDate with person={0} startDate={1} endDate={2} aPlace={3}", new Object[]{person, startDate, endDate, aPlace});
         final var stay = new StayPeriodLocalDate(FACTORY.getNextID(), person, startDate, endDate, aPlace);
         FACTORY.addObject(stay);
@@ -116,7 +116,7 @@ public final class StayFactory {
      * @param aPlace the place stayed at
      * @return the created stay
      */
-    public static StayPeriodLocalDate createStayPeriodLocalDate(final long id, Person person, LocalDate startDate, LocalDate endDate, Place aPlace) {
+    public static StayPeriodLocalDate createStayPeriodLocalDate(final long id, final Person person, LocalDate startDate, LocalDate endDate, Place aPlace) {
         LOG.log(CREATION_LOGGING_LEVEL, "Creating createStayPeriodLocalDate with id={0} person={1} startDate={2} endDate={3} aPlace={4}", new Object[]{id, person, startDate, endDate, aPlace});
         if (!FACTORY.isIdAvailable(id)) {
             throw new IllegalArgumentException("Trying to create stay for " + person.getName() + " with existing id=" + id + " (exists : " + FACTORY.get(id).getDisplayString() + ")");

--- a/src/main/java/com/github/noony/app/timelinefx/core/StayFactory.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/StayFactory.java
@@ -22,28 +22,47 @@ import java.util.logging.Logger;
 import static com.github.noony.app.timelinefx.core.Factory.CREATION_LOGGING_LEVEL;
 
 /**
+ * Entry point for creating and retrieving {@link StayPeriod} instances.
  *
  * @author hamon
  */
 public final class StayFactory {
 
+    /**
+     * Logger used by this factory.
+     */
     private static final Logger LOG = Logger.getGlobal();
     //    private static final Map<Long, StayPeriod> STAY_PERIOD_SIMPLE_TIMES = new HashMap<>();
     //    private static final Map<Long, StayPeriod> STAY_PERIOD_LOCAL_DATES = new HashMap<>();
 
 
+    /**
+     * Registry of created stays.
+     */
     private static final Factory<StayPeriod> FACTORY = new Factory<>();
 
     private StayFactory() {
         // private utility constructor
     }
 
+    /**
+     * Resets the factory, discarding all created stays.
+     */
     public static void reset() {
         FACTORY.reset();
         //        STAY_PERIOD_SIMPLE_TIMES.clear();
         //        STAY_PERIOD_LOCAL_DATES.clear();
     }
 
+    /**
+     * Creates a new stay with numeric start/end times.
+     *
+     * @param person the person staying
+     * @param startDate the stay's start time
+     * @param endDate the stay's end time
+     * @param aPlace the place stayed at
+     * @return the created stay
+     */
     public static StayPeriodSimpleTime createStayPeriodSimpleTime(final Person person, double startDate, double endDate, Place aPlace) {
         LOG.log(CREATION_LOGGING_LEVEL, "Creating StayPeriodSimpleTime with person={0} startDate={1} endDate={2} aPlace={3}", new Object[]{person, startDate, endDate, aPlace});
         final var stay = new StayPeriodSimpleTime(FACTORY.getNextID(), person, startDate, endDate, aPlace);
@@ -51,6 +70,16 @@ public final class StayFactory {
         return stay;
     }
 
+    /**
+     * Creates a new stay with numeric start/end times and a specific id.
+     *
+     * @param id the id to assign to the new stay
+     * @param person the person staying
+     * @param startDate the stay's start time
+     * @param endDate the stay's end time
+     * @param aPlace the place stayed at
+     * @return the created stay
+     */
     public static StayPeriodSimpleTime createStayPeriodSimpleTime(final long id, Person person, double startDate, double endDate, Place aPlace) {
         LOG.log(CREATION_LOGGING_LEVEL, "Creating StayPeriodSimpleTime with id={0} person={1} startDate={2} endDate={3} aPlace={4}", new Object[]{id, person, startDate, endDate, aPlace});
         if (!FACTORY.isIdAvailable(id)) {
@@ -61,6 +90,15 @@ public final class StayFactory {
         return stay;
     }
 
+    /**
+     * Creates a new stay with calendar start/end dates.
+     *
+     * @param person the person staying
+     * @param startDate the stay's start date
+     * @param endDate the stay's end date
+     * @param aPlace the place stayed at
+     * @return the created stay
+     */
     public static StayPeriodLocalDate createStayPeriodLocalDate(final Person person, LocalDate startDate, LocalDate endDate, Place aPlace) {
         LOG.log(CREATION_LOGGING_LEVEL, "Creating createStayPeriodLocalDate with person={0} startDate={1} endDate={2} aPlace={3}", new Object[]{person, startDate, endDate, aPlace});
         final var stay = new StayPeriodLocalDate(FACTORY.getNextID(), person, startDate, endDate, aPlace);
@@ -68,6 +106,16 @@ public final class StayFactory {
         return stay;
     }
 
+    /**
+     * Creates a new stay with calendar start/end dates and a specific id.
+     *
+     * @param id the id to assign to the new stay
+     * @param person the person staying
+     * @param startDate the stay's start date
+     * @param endDate the stay's end date
+     * @param aPlace the place stayed at
+     * @return the created stay
+     */
     public static StayPeriodLocalDate createStayPeriodLocalDate(final long id, Person person, LocalDate startDate, LocalDate endDate, Place aPlace) {
         LOG.log(CREATION_LOGGING_LEVEL, "Creating createStayPeriodLocalDate with id={0} person={1} startDate={2} endDate={3} aPlace={4}", new Object[]{id, person, startDate, endDate, aPlace});
         if (!FACTORY.isIdAvailable(id)) {
@@ -78,6 +126,10 @@ public final class StayFactory {
         return stay;
     }
 
+    /**
+     * @param id a stay's id
+     * @return the stay with the given id, or null if none exists
+     */
     public static StayPeriod getStay(final long id) {
         return FACTORY.get(id);
     }

--- a/src/main/java/com/github/noony/app/timelinefx/core/StayPeriod.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/StayPeriod.java
@@ -72,7 +72,7 @@ public abstract class StayPeriod implements FriezeObject {
     private Place place;
 
     @SuppressWarnings("this-escape")
-    protected StayPeriod(final long anId, final Person aPerson, Place aPlace) {
+    protected StayPeriod(final long anId, final Person aPerson, final Place aPlace) {
         id = anId;
         propertyChangeSupport = new PropertyChangeSupport(StayPeriod.this);
         person = aPerson;
@@ -167,7 +167,7 @@ public abstract class StayPeriod implements FriezeObject {
      */
     public abstract String getDisplayString();
 
-    protected void firePropertyChange(final String eventName, final Object oldValue, Object newValue) {
+    protected void firePropertyChange(final String eventName, final Object oldValue, final Object newValue) {
         propertyChangeSupport.firePropertyChange(eventName, oldValue, newValue);
     }
 }

--- a/src/main/java/com/github/noony/app/timelinefx/core/StayPeriod.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/StayPeriod.java
@@ -72,7 +72,7 @@ public abstract class StayPeriod implements FriezeObject {
     private Place place;
 
     @SuppressWarnings("this-escape")
-    protected StayPeriod(final long anId, Person aPerson, Place aPlace) {
+    protected StayPeriod(final long anId, final Person aPerson, Place aPlace) {
         id = anId;
         propertyChangeSupport = new PropertyChangeSupport(StayPeriod.this);
         person = aPerson;
@@ -167,7 +167,7 @@ public abstract class StayPeriod implements FriezeObject {
      */
     public abstract String getDisplayString();
 
-    protected void firePropertyChange(final String eventName, Object oldValue, Object newValue) {
+    protected void firePropertyChange(final String eventName, final Object oldValue, Object newValue) {
         propertyChangeSupport.firePropertyChange(eventName, oldValue, newValue);
     }
 }

--- a/src/main/java/com/github/noony/app/timelinefx/core/StayPeriod.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/StayPeriod.java
@@ -22,27 +22,53 @@ import java.beans.PropertyChangeSupport;
 import java.util.Comparator;
 
 /**
+ * A person's stay at a place, over a period of time represented either as calendar dates
+ * ({@link StayPeriodLocalDate}) or as raw numeric values ({@link StayPeriodSimpleTime}).
  *
  * @author arnaud
  */
 public abstract class StayPeriod implements FriezeObject {
 
+    /**
+     * Orders stays by start date.
+     */
     public static final Comparator<? super StayPeriod> STAY_COMPARATOR = Comparator.comparingDouble(StayPeriod::getStartDate);
 
+    /**
+     * Name of the property change event fired when the stay's person changes.
+     */
     public static final String PERSON_CHANGED = "StayPeriod__personChanged";
 
+    /**
+     * Name of the property change event fired when the stay's place changes.
+     */
     public static final String PLACE_CHANGED = "StayPeriod__placeChanged";
 
+    /**
+     * Name of the property change event fired when the stay's start date changes.
+     */
     public static final String START_DATE_CHANGED = "StayPeriod__startDateChanged";
 
+    /**
+     * Name of the property change event fired when the stay's end date changes.
+     */
     public static final String END_DATE_CHANGED = "StayPeriod__endDateChanged";
 
+    /**
+     * Support object used to fire property change events.
+     */
     private final PropertyChangeSupport propertyChangeSupport;
 
     private final Long id;
 
+    /**
+     * The person staying.
+     */
     private Person person;
 
+    /**
+     * The place stayed at.
+     */
     private Place place;
 
     @SuppressWarnings("this-escape")
@@ -58,22 +84,37 @@ public abstract class StayPeriod implements FriezeObject {
         return id;
     }
 
+    /**
+     * @param listener the listener to add
+     */
     public void addListener(final PropertyChangeListener listener) {
         propertyChangeSupport.addPropertyChangeListener(listener);
     }
 
+    /**
+     * @param listener the listener to remove
+     */
     public void removeListener(final PropertyChangeListener listener) {
         propertyChangeSupport.removePropertyChangeListener(listener);
     }
 
+    /**
+     * @return the person staying
+     */
     public Person getPerson() {
         return person;
     }
 
+    /**
+     * @return the place stayed at
+     */
     public Place getPlace() {
         return place;
     }
 
+    /**
+     * @param aPerson the stay's new person
+     */
     public void setPerson(final Person aPerson) {
         if (aPerson == null) {
             return;
@@ -84,6 +125,9 @@ public abstract class StayPeriod implements FriezeObject {
         }
     }
 
+    /**
+     * @param aPlace the stay's new place
+     */
     public void setPlace(final Place aPlace) {
         if (aPlace == null) {
             return;
@@ -94,16 +138,34 @@ public abstract class StayPeriod implements FriezeObject {
         }
     }
 
+    /**
+     * @return the start date before the last change
+     */
     public abstract double getPreviousStartDate();
 
+    /**
+     * @return the end date before the last change
+     */
     public abstract double getPreviousEndDate();
 
+    /**
+     * @return the stay's start date
+     */
     public abstract double getStartDate();
 
+    /**
+     * @return the stay's end date
+     */
     public abstract double getEndDate();
 
+    /**
+     * @return the time format used to represent this stay's dates
+     */
     public abstract TimeFormat getTimeFormat();
 
+    /**
+     * @return a human-readable description of this stay
+     */
     public abstract String getDisplayString();
 
     protected void firePropertyChange(final String eventName, Object oldValue, Object newValue) {

--- a/src/main/java/com/github/noony/app/timelinefx/core/StayPeriod.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/StayPeriod.java
@@ -79,8 +79,7 @@ public abstract class StayPeriod implements FriezeObject {
         place = aPlace;
     }
 
-    @Override
-    public long getId() {
+    @Override public long getId() {
         return id;
     }
 

--- a/src/main/java/com/github/noony/app/timelinefx/core/StayPeriod.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/StayPeriod.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core;
 
 import java.beans.PropertyChangeListener;
@@ -29,16 +30,23 @@ public abstract class StayPeriod implements FriezeObject {
     public static final Comparator<? super StayPeriod> STAY_COMPARATOR = Comparator.comparingDouble(StayPeriod::getStartDate);
 
     public static final String PERSON_CHANGED = "StayPeriod__personChanged";
+
     public static final String PLACE_CHANGED = "StayPeriod__placeChanged";
+
     public static final String START_DATE_CHANGED = "StayPeriod__startDateChanged";
+
     public static final String END_DATE_CHANGED = "StayPeriod__endDateChanged";
+
     private final PropertyChangeSupport propertyChangeSupport;
+
     private final Long id;
+
     private Person person;
+
     private Place place;
 
     @SuppressWarnings("this-escape")
-    protected StayPeriod(long anId, Person aPerson, Place aPlace) {
+    protected StayPeriod(final long anId, Person aPerson, Place aPlace) {
         id = anId;
         propertyChangeSupport = new PropertyChangeSupport(StayPeriod.this);
         person = aPerson;
@@ -50,11 +58,11 @@ public abstract class StayPeriod implements FriezeObject {
         return id;
     }
 
-    public void addListener(PropertyChangeListener listener) {
+    public void addListener(final PropertyChangeListener listener) {
         propertyChangeSupport.addPropertyChangeListener(listener);
     }
 
-    public void removeListener(PropertyChangeListener listener) {
+    public void removeListener(final PropertyChangeListener listener) {
         propertyChangeSupport.removePropertyChangeListener(listener);
     }
 
@@ -66,7 +74,7 @@ public abstract class StayPeriod implements FriezeObject {
         return place;
     }
 
-    public void setPerson(Person aPerson) {
+    public void setPerson(final Person aPerson) {
         if (aPerson == null) {
             return;
         }
@@ -76,7 +84,7 @@ public abstract class StayPeriod implements FriezeObject {
         }
     }
 
-    public void setPlace(Place aPlace) {
+    public void setPlace(final Place aPlace) {
         if (aPlace == null) {
             return;
         }
@@ -98,7 +106,7 @@ public abstract class StayPeriod implements FriezeObject {
 
     public abstract String getDisplayString();
 
-    protected void firePropertyChange(String eventName, Object oldValue, Object newValue) {
+    protected void firePropertyChange(final String eventName, Object oldValue, Object newValue) {
         propertyChangeSupport.firePropertyChange(eventName, oldValue, newValue);
     }
 }

--- a/src/main/java/com/github/noony/app/timelinefx/core/StayPeriodLocalDate.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/StayPeriodLocalDate.java
@@ -46,7 +46,7 @@ public class StayPeriodLocalDate extends StayPeriod {
      */
     private LocalDate endDate;
 
-    protected StayPeriodLocalDate(final long id, final Person aPerson, LocalDate aStartDate, LocalDate anEndDate, Place aPlace) {
+    protected StayPeriodLocalDate(final long id, final Person aPerson, final LocalDate aStartDate, LocalDate anEndDate, Place aPlace) {
         super(id, aPerson, aPlace);
         previousStartDate = aStartDate;
         previousEndDate = anEndDate;

--- a/src/main/java/com/github/noony/app/timelinefx/core/StayPeriodLocalDate.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/StayPeriodLocalDate.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core;
 
 import java.time.LocalDate;
@@ -25,11 +26,14 @@ import java.time.LocalDate;
 public class StayPeriodLocalDate extends StayPeriod {
 
     private LocalDate previousStartDate;
+
     private LocalDate previousEndDate;
+
     private LocalDate startDate;
+
     private LocalDate endDate;
 
-    protected StayPeriodLocalDate(long id, Person aPerson, LocalDate aStartDate, LocalDate anEndDate, Place aPlace) {
+    protected StayPeriodLocalDate(final long id, Person aPerson, LocalDate aStartDate, LocalDate anEndDate, Place aPlace) {
         super(id, aPerson, aPlace);
         previousStartDate = aStartDate;
         previousEndDate = anEndDate;
@@ -62,7 +66,7 @@ public class StayPeriodLocalDate extends StayPeriod {
         return TimeFormat.LOCAL_TIME;
     }
 
-    public void setStartDate(LocalDate aStartDate) {
+    public void setStartDate(final LocalDate aStartDate) {
         if (aStartDate == null) {
             return;
         }
@@ -73,7 +77,7 @@ public class StayPeriodLocalDate extends StayPeriod {
         }
     }
 
-    public void setEndDate(LocalDate aEndDate) {
+    public void setEndDate(final LocalDate aEndDate) {
         if (aEndDate == null) {
             return;
         }

--- a/src/main/java/com/github/noony/app/timelinefx/core/StayPeriodLocalDate.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/StayPeriodLocalDate.java
@@ -54,8 +54,7 @@ public class StayPeriodLocalDate extends StayPeriod {
         endDate = anEndDate;
     }
 
-    @Override
-    public double getPreviousStartDate() {
+    @Override public double getPreviousStartDate() {
         return previousStartDate.toEpochDay();
     }
 

--- a/src/main/java/com/github/noony/app/timelinefx/core/StayPeriodLocalDate.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/StayPeriodLocalDate.java
@@ -20,17 +20,30 @@ package com.github.noony.app.timelinefx.core;
 import java.time.LocalDate;
 
 /**
+ * A {@link StayPeriod} whose start/end dates are represented as calendar dates.
  *
  * @author hamon
  */
 public class StayPeriodLocalDate extends StayPeriod {
 
+    /**
+     * The start date before the last change, used to fire change notifications.
+     */
     private LocalDate previousStartDate;
 
+    /**
+     * The end date before the last change, used to fire change notifications.
+     */
     private LocalDate previousEndDate;
 
+    /**
+     * The stay's start date.
+     */
     private LocalDate startDate;
 
+    /**
+     * The stay's end date.
+     */
     private LocalDate endDate;
 
     protected StayPeriodLocalDate(final long id, Person aPerson, LocalDate aStartDate, LocalDate anEndDate, Place aPlace) {
@@ -66,6 +79,9 @@ public class StayPeriodLocalDate extends StayPeriod {
         return TimeFormat.LOCAL_TIME;
     }
 
+    /**
+     * @param aStartDate the stay's new start date
+     */
     public void setStartDate(final LocalDate aStartDate) {
         if (aStartDate == null) {
             return;
@@ -77,6 +93,9 @@ public class StayPeriodLocalDate extends StayPeriod {
         }
     }
 
+    /**
+     * @param aEndDate the stay's new end date
+     */
     public void setEndDate(final LocalDate aEndDate) {
         if (aEndDate == null) {
             return;

--- a/src/main/java/com/github/noony/app/timelinefx/core/StayPeriodLocalDate.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/StayPeriodLocalDate.java
@@ -46,7 +46,7 @@ public class StayPeriodLocalDate extends StayPeriod {
      */
     private LocalDate endDate;
 
-    protected StayPeriodLocalDate(final long id, Person aPerson, LocalDate aStartDate, LocalDate anEndDate, Place aPlace) {
+    protected StayPeriodLocalDate(final long id, final Person aPerson, LocalDate aStartDate, LocalDate anEndDate, Place aPlace) {
         super(id, aPerson, aPlace);
         previousStartDate = aStartDate;
         previousEndDate = anEndDate;

--- a/src/main/java/com/github/noony/app/timelinefx/core/StayPeriodSimpleTime.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/StayPeriodSimpleTime.java
@@ -52,8 +52,7 @@ public class StayPeriodSimpleTime extends StayPeriod {
         endTime = anEndTime;
     }
 
-    @Override
-    public double getPreviousStartDate() {
+    @Override public double getPreviousStartDate() {
         return previousStartTime;
     }
 

--- a/src/main/java/com/github/noony/app/timelinefx/core/StayPeriodSimpleTime.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/StayPeriodSimpleTime.java
@@ -44,7 +44,7 @@ public class StayPeriodSimpleTime extends StayPeriod {
      */
     private double endTime;
 
-    protected StayPeriodSimpleTime(final Long anId, Person aPerson, double aStartTime, double anEndTime, Place aPlace) {
+    protected StayPeriodSimpleTime(final Long anId, final Person aPerson, double aStartTime, double anEndTime, Place aPlace) {
         super(anId, aPerson, aPlace);
         previousStartTime = aStartTime;
         previousEndTime = anEndTime;

--- a/src/main/java/com/github/noony/app/timelinefx/core/StayPeriodSimpleTime.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/StayPeriodSimpleTime.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core;
 
 /**
@@ -23,11 +24,14 @@ package com.github.noony.app.timelinefx.core;
 public class StayPeriodSimpleTime extends StayPeriod {
 
     private double previousStartTime;
+
     private double previousEndTime;
+
     private double startTime;
+
     private double endTime;
 
-    protected StayPeriodSimpleTime(Long anId, Person aPerson, double aStartTime, double anEndTime, Place aPlace) {
+    protected StayPeriodSimpleTime(final Long anId, Person aPerson, double aStartTime, double anEndTime, Place aPlace) {
         super(anId, aPerson, aPlace);
         previousStartTime = aStartTime;
         previousEndTime = anEndTime;
@@ -55,7 +59,7 @@ public class StayPeriodSimpleTime extends StayPeriod {
         return endTime;
     }
 
-    public void setStartDate(double aStartDate) {
+    public void setStartDate(final double aStartDate) {
         if (startTime != aStartDate) {
             previousStartTime = startTime;
             startTime = aStartDate;
@@ -63,7 +67,7 @@ public class StayPeriodSimpleTime extends StayPeriod {
         }
     }
 
-    public void setEndDate(double aEndDate) {
+    public void setEndDate(final double aEndDate) {
         if (endTime != aEndDate) {
             previousEndTime = endTime;
             endTime = aEndDate;

--- a/src/main/java/com/github/noony/app/timelinefx/core/StayPeriodSimpleTime.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/StayPeriodSimpleTime.java
@@ -44,7 +44,7 @@ public class StayPeriodSimpleTime extends StayPeriod {
      */
     private double endTime;
 
-    protected StayPeriodSimpleTime(final Long anId, final Person aPerson, double aStartTime, double anEndTime, Place aPlace) {
+    protected StayPeriodSimpleTime(final Long anId, final Person aPerson, final double aStartTime, double anEndTime, Place aPlace) {
         super(anId, aPerson, aPlace);
         previousStartTime = aStartTime;
         previousEndTime = anEndTime;

--- a/src/main/java/com/github/noony/app/timelinefx/core/StayPeriodSimpleTime.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/StayPeriodSimpleTime.java
@@ -18,17 +18,30 @@
 package com.github.noony.app.timelinefx.core;
 
 /**
+ * A {@link StayPeriod} whose start/end times are represented as raw numeric values.
  *
  * @author hamon
  */
 public class StayPeriodSimpleTime extends StayPeriod {
 
+    /**
+     * The start time before the last change, used to fire change notifications.
+     */
     private double previousStartTime;
 
+    /**
+     * The end time before the last change, used to fire change notifications.
+     */
     private double previousEndTime;
 
+    /**
+     * The stay's start time.
+     */
     private double startTime;
 
+    /**
+     * The stay's end time.
+     */
     private double endTime;
 
     protected StayPeriodSimpleTime(final Long anId, Person aPerson, double aStartTime, double anEndTime, Place aPlace) {
@@ -59,6 +72,9 @@ public class StayPeriodSimpleTime extends StayPeriod {
         return endTime;
     }
 
+    /**
+     * @param aStartDate the stay's new start time
+     */
     public void setStartDate(final double aStartDate) {
         if (startTime != aStartDate) {
             previousStartTime = startTime;
@@ -67,6 +83,9 @@ public class StayPeriodSimpleTime extends StayPeriod {
         }
     }
 
+    /**
+     * @param aEndDate the stay's new end time
+     */
     public void setEndDate(final double aEndDate) {
         if (endTime != aEndDate) {
             previousEndTime = endTime;

--- a/src/main/java/com/github/noony/app/timelinefx/core/TimeFormat.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/TimeFormat.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core;
 
 /**

--- a/src/main/java/com/github/noony/app/timelinefx/core/TimeFormat.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/TimeFormat.java
@@ -18,11 +18,15 @@
 package com.github.noony.app.timelinefx.core;
 
 /**
+ * How a date/time value is represented: as a calendar date or as a raw numeric value.
  *
  * @author arnaud
  */
 public enum TimeFormat {
-    
+
+    /**
+     * A calendar {@code LocalDate}, or a raw numeric time value.
+     */
     LOCAL_TIME, TIME_MIN
-    
+
 }

--- a/src/main/java/com/github/noony/app/timelinefx/core/TimeLineProject.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/TimeLineProject.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core;
 
 import com.github.noony.app.timelinefx.Configuration;
@@ -47,19 +48,32 @@ public final class TimeLineProject {
 
     public static final String PERSON_ADDED = "personAdded";
     public static final String PLACE_ADDED = "placeAdded";
+
     public static final String HIGH_LEVEL_PLACE_ADDED = "highLevelPlaceAdded";
+
     public static final String STAY_ADDED = "stayAdded";
+
     public static final String PERSON_REMOVED = "personRemoved";
+
     public static final String PLACE_REMOVED = "placeRemoved";
+
     public static final String STAY_REMOVED = "stayRemoved";
     //
+
     public static final String PROJECT_NAME_KEY = "projectNameKey";
+
     public static final String PROJECT_FOLDER_KEY = "projectFolderKey";
+
     public static final String PICTURES_FOLDER_KEY = "picturesFolderKey";
+
     public static final String MINIATURES_FOLDER_KEY = "miniaturesFolderKey";
+
     public static final String PORTRAIT_FOLDER_KEY = "portraitsFolderKey";
+
     public static final String DEFAULT_PORTRAIT_FOLDER = "portraits";
+
     public static final String DEFAULT_PICTURES_FOLDER = "pictures";
+
     public static final String DEFAULT_MINIATURES_FOLDER = "miniatures";
 
     private static final Logger LOG = Logger.getGlobal();
@@ -69,21 +83,29 @@ public final class TimeLineProject {
     private final String name;
 
     // Reference files
-    private File projectFolder = null;
-    private File portraitsFolder = null;
-    private File picturesFolder = null;
-    private File miniaturesFolder = null;
-    private File projectFile = null;
+    private File projectFolder;
+
+    private File portraitsFolder;
+
+    private File picturesFolder;
+
+    private File miniaturesFolder;
+
+    private File projectFile;
 
     private final List<Place> highLevelPlaces;
+
     private final Map<String, Place> allPlaces;
 
     private final List<Person> persons;
+
     private final List<StayPeriod> stays;
+
     private final List<Frieze> friezes;
+
     private final List<PictureChronology> pictureChronologies;
 
-    protected TimeLineProject(String projectName, Map<String, String> configParams) {
+    protected TimeLineProject(final String projectName, Map<String, String> configParams) {
         name = projectName;
         initFolders(configParams);
         propertyChangeSupport = new PropertyChangeSupport(TimeLineProject.this);
@@ -95,17 +117,17 @@ public final class TimeLineProject {
         pictureChronologies = new LinkedList<>();
     }
 
-    private void initFolders(Map<String, String> configParams) {
-        var projectFolderLocation = configParams.getOrDefault(PROJECT_FOLDER_KEY, Configuration.getProjectsParentFolder() + File.separator + name);
-        var portraitsFolderLocation = configParams.getOrDefault(PORTRAIT_FOLDER_KEY, DEFAULT_PORTRAIT_FOLDER);
-        var picturesFolderLocation = configParams.getOrDefault(PICTURES_FOLDER_KEY, DEFAULT_PICTURES_FOLDER);
-        var miniaturesFolderLocation = configParams.getOrDefault(MINIATURES_FOLDER_KEY, DEFAULT_MINIATURES_FOLDER);
+    private void initFolders(final Map<String, String> configParams) {
+        final var projectFolderLocation = configParams.getOrDefault(PROJECT_FOLDER_KEY, Configuration.getProjectsParentFolder() + File.separator + name);
+        final var portraitsFolderLocation = configParams.getOrDefault(PORTRAIT_FOLDER_KEY, DEFAULT_PORTRAIT_FOLDER);
+        final var picturesFolderLocation = configParams.getOrDefault(PICTURES_FOLDER_KEY, DEFAULT_PICTURES_FOLDER);
+        final var miniaturesFolderLocation = configParams.getOrDefault(MINIATURES_FOLDER_KEY, DEFAULT_MINIATURES_FOLDER);
         //
         projectFolder = new File(projectFolderLocation);
         LOG.log(Level.INFO, "Creating Project {0} in folder: {1}.", new Object[]{name, projectFolder});
         if (!projectFolder.exists()) {
             try {
-                Path path = projectFolder.toPath();
+                final Path path = projectFolder.toPath();
                 Files.createDirectories(path);
             } catch (IOException ex) {
                 LOG.log(Level.SEVERE, "Could not create project folder : {0}", new Object[]{ex});
@@ -113,21 +135,21 @@ public final class TimeLineProject {
         }
         projectFile = new File(projectFolderLocation + File.separator + name + ".xml");
         //
-        String portraitsRoot = projectFolderLocation + File.separator + portraitsFolderLocation;
+        final String portraitsRoot = projectFolderLocation + File.separator + portraitsFolderLocation;
         portraitsFolder = new File(portraitsRoot);
         if (!portraitsFolder.exists()) {
             try {
-                Path path = portraitsFolder.toPath();
+                final Path path = portraitsFolder.toPath();
                 Files.createDirectories(path);
             } catch (IOException ex) {
                 LOG.log(Level.SEVERE, "Could not create portrait folder : {0}.", new Object[]{ex});
             }
         }
-        String picturesRoot = projectFolderLocation + File.separator + picturesFolderLocation;
+        final String picturesRoot = projectFolderLocation + File.separator + picturesFolderLocation;
         picturesFolder = new File(picturesRoot);
         if (!picturesFolder.exists()) {
             try {
-                Path path = picturesFolder.toPath();
+                final Path path = picturesFolder.toPath();
                 Files.createDirectories(path);
             } catch (IOException ex) {
                 LOG.log(Level.SEVERE, "Could not create pictures folder : {0}.", new Object[]{ex});
@@ -136,7 +158,7 @@ public final class TimeLineProject {
         miniaturesFolder = new File(projectFolderLocation + File.separator + miniaturesFolderLocation);
         if (!miniaturesFolder.exists()) {
             try {
-                Path path = miniaturesFolder.toPath();
+                final Path path = miniaturesFolder.toPath();
                 Files.createDirectories(path);
             } catch (IOException ex) {
                 LOG.log(Level.SEVERE, "Could not create miniature folder : {0}.", new Object[]{ex});
@@ -150,8 +172,8 @@ public final class TimeLineProject {
         try {
             try (InputStream inputstream = getClass().getResourceAsStream(Person.DEFAULT_PICTURE_NAME)) {
                 assert inputstream != null;
-                String outputPath = portraitsFolder + File.separator + Person.DEFAULT_PICTURE_NAME;
-                File outputFile = new File(outputPath);
+                final String outputPath = portraitsFolder + File.separator + Person.DEFAULT_PICTURE_NAME;
+                final File outputFile = new File(outputPath);
                 LOG.log(Level.INFO, "> savePortraitResources :: {0}", outputPath);
                 try (FileOutputStream outputStream = new FileOutputStream(outputFile)) {
                     outputStream.write(inputstream.readAllBytes());
@@ -194,11 +216,11 @@ public final class TimeLineProject {
         return projectFile.getAbsolutePath();
     }
 
-    public void addListener(PropertyChangeListener listener) {
+    public void addListener(final PropertyChangeListener listener) {
         propertyChangeSupport.addPropertyChangeListener(listener);
     }
 
-    public void removeListener(PropertyChangeListener listener) {
+    public void removeListener(final PropertyChangeListener listener) {
         propertyChangeSupport.removePropertyChangeListener(listener);
     }
 
@@ -206,7 +228,7 @@ public final class TimeLineProject {
         return name;
     }
 
-    public boolean addPlace(Place aPlace) {
+    public boolean addPlace(final Place aPlace) {
         if (aPlace == null) {
             return false;
         } else if (aPlace.isRootPlace()) {
@@ -222,7 +244,7 @@ public final class TimeLineProject {
         }
     }
 
-    public boolean addHighLevelPlace(Place aPlace) {
+    public boolean addHighLevelPlace(final Place aPlace) {
         if (!highLevelPlaces.contains(aPlace)) {
             highLevelPlaces.add(aPlace);
             highLevelPlaces.sort(Place.COMPARATOR);
@@ -236,7 +258,7 @@ public final class TimeLineProject {
         return false;
     }
 
-    public boolean removeHighLevelPlace(Place aPlace) {
+    public boolean removeHighLevelPlace(final Place aPlace) {
         // TODO fire
         return highLevelPlaces.remove(aPlace);
     }
@@ -245,7 +267,7 @@ public final class TimeLineProject {
         return Collections.unmodifiableList(highLevelPlaces);
     }
 
-    public Place getPlaceByName(String placeName) {
+    public Place getPlaceByName(final String placeName) {
         return allPlaces.get(placeName);
     }
 
@@ -259,7 +281,7 @@ public final class TimeLineProject {
         stays.forEach(this::addStay);
     }
 
-    public void addStay(StayPeriod aStay) {
+    public void addStay(final StayPeriod aStay) {
         if (!stays.contains(aStay)) {
             stays.add(aStay);
             stays.sort(StayPeriod.STAY_COMPARATOR);
@@ -267,7 +289,7 @@ public final class TimeLineProject {
         }
     }
 
-    public void removeStay(StayPeriod aStay) {
+    public void removeStay(final StayPeriod aStay) {
         if (stays.contains(aStay)) {
             stays.remove(aStay);
             propertyChangeSupport.firePropertyChange(STAY_REMOVED, this, aStay);
@@ -278,7 +300,7 @@ public final class TimeLineProject {
         return Collections.unmodifiableList(stays);
     }
 
-    protected boolean addFrieze(Frieze frieze) {
+    protected boolean addFrieze(final Frieze frieze) {
         if (!friezes.contains(frieze)) {
             frieze.addListener(this::handleFriezeChange);
             friezes.add(frieze);
@@ -290,7 +312,7 @@ public final class TimeLineProject {
         return false;
     }
 
-    public boolean addPictureChronology(PictureChronology pictureChronology) {
+    public boolean addPictureChronology(final PictureChronology pictureChronology) {
         if (!pictureChronologies.contains(pictureChronology)) {
             pictureChronology.addListener(this::handlePicturesChronologyChange);
             pictureChronologies.add(pictureChronology);
@@ -320,7 +342,7 @@ public final class TimeLineProject {
         return allPlaces.values().stream().sorted(Place.COMPARATOR).collect(Collectors.toList());
     }
 
-    public boolean addPerson(Person aPerson) {
+    public boolean addPerson(final Person aPerson) {
         if (!persons.contains(aPerson)) {
             persons.add(aPerson);
             persons.sort(Person.COMPARATOR);
@@ -330,7 +352,7 @@ public final class TimeLineProject {
         return false;
     }
 
-    private void handleFriezeChange(PropertyChangeEvent event) {
+    private void handleFriezeChange(final PropertyChangeEvent event) {
         switch (event.getPropertyName()) {
             case Frieze.PLACE_ADDED ->
                 addPlace((Place) event.getNewValue());
@@ -349,7 +371,7 @@ public final class TimeLineProject {
         }
     }
 
-    private void handlePicturesChronologyChange(PropertyChangeEvent event) {
+    private void handlePicturesChronologyChange(final PropertyChangeEvent event) {
         switch (event.getPropertyName()) {
             case PictureChronology.PICTURE_ADDED, PictureChronology.PICTURE_REMOVED, PictureChronology.NAME_CHANGED, PictureChronology.LAYOUT_CHANGED, PictureChronology.LINK_ADDED, PictureChronology.LINK_REMOVED -> {
                 // nothing to do
@@ -359,7 +381,7 @@ public final class TimeLineProject {
         }
     }
 
-    public void removePlace(Place deletedPlace) {
+    public void removePlace(final Place deletedPlace) {
         allPlaces.remove(deletedPlace.getName());
         highLevelPlaces.remove(deletedPlace);
         //
@@ -373,19 +395,20 @@ public final class TimeLineProject {
         propertyChangeSupport.firePropertyChange(PLACE_REMOVED, this, deletedPlace);
     }
 
-    public void removePerson(Person deletedPerson) {
+    public void removePerson(final Person deletedPerson) {
         if (persons.contains(deletedPerson)) {
             persons.remove(deletedPerson);
-            List<StayPeriod> staysToRemove = stays.stream().filter(s -> s.getPerson() == deletedPerson).toList();
+            final List<StayPeriod> staysToRemove = stays.stream().filter(s -> s.getPerson() == deletedPerson).toList();
             staysToRemove.forEach(this::removeStay);
             //
             propertyChangeSupport.firePropertyChange(PERSON_REMOVED, this, deletedPerson);
         }
     }
 
-    private void removeChildrenPlaces(Place aParentPlace) {
-        List<Place> directChildren = allPlaces.values().stream()
-                .filter(place -> (place.getParent().equals(aParentPlace))).toList();
+    private void removeChildrenPlaces(final Place aParentPlace) {
+        final List<Place> directChildren = allPlaces.values().stream()
+                .filter(place -> place.getParent().equals(aParentPlace))
+                .toList();
         directChildren.forEach(child -> {
             allPlaces.remove(child.getName());
             removeStaysAt(child);
@@ -393,8 +416,8 @@ public final class TimeLineProject {
         directChildren.forEach(this::removeChildrenPlaces);
     }
 
-    private void removeStaysAt(Place aPlace) {
-        List<StayPeriod> staysToRemove = stays.stream().filter(s -> s.getPlace() == aPlace).toList();
+    private void removeStaysAt(final Place aPlace) {
+        final List<StayPeriod> staysToRemove = stays.stream().filter(s -> s.getPlace() == aPlace).toList();
         staysToRemove.forEach(this::removeStay);
     }
 

--- a/src/main/java/com/github/noony/app/timelinefx/core/TimeLineProject.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/TimeLineProject.java
@@ -41,68 +41,157 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 /**
+ * A timeline project: the top-level container for a set of places, persons, stays,
+ * friezes and picture chronologies, backed by a folder on disk.
  *
  * @author hamon
  */
 public final class TimeLineProject {
 
+    /**
+     * Name of the property change event fired when a person is added.
+     */
     public static final String PERSON_ADDED = "personAdded";
+    /**
+     * Name of the property change event fired when a place is added.
+     */
     public static final String PLACE_ADDED = "placeAdded";
 
+    /**
+     * Name of the property change event fired when a root-level place is added.
+     */
     public static final String HIGH_LEVEL_PLACE_ADDED = "highLevelPlaceAdded";
 
+    /**
+     * Name of the property change event fired when a stay is added.
+     */
     public static final String STAY_ADDED = "stayAdded";
 
+    /**
+     * Name of the property change event fired when a person is removed.
+     */
     public static final String PERSON_REMOVED = "personRemoved";
 
+    /**
+     * Name of the property change event fired when a place is removed.
+     */
     public static final String PLACE_REMOVED = "placeRemoved";
 
+    /**
+     * Name of the property change event fired when a stay is removed.
+     */
     public static final String STAY_REMOVED = "stayRemoved";
     //
 
+    /**
+     * Configuration key for the project's name.
+     */
     public static final String PROJECT_NAME_KEY = "projectNameKey";
 
+    /**
+     * Configuration key for the project's folder location.
+     */
     public static final String PROJECT_FOLDER_KEY = "projectFolderKey";
 
+    /**
+     * Configuration key for the pictures folder location.
+     */
     public static final String PICTURES_FOLDER_KEY = "picturesFolderKey";
 
+    /**
+     * Configuration key for the miniatures folder location.
+     */
     public static final String MINIATURES_FOLDER_KEY = "miniaturesFolderKey";
 
+    /**
+     * Configuration key for the portraits folder location.
+     */
     public static final String PORTRAIT_FOLDER_KEY = "portraitsFolderKey";
 
+    /**
+     * Default portraits folder name, relative to the project folder.
+     */
     public static final String DEFAULT_PORTRAIT_FOLDER = "portraits";
 
+    /**
+     * Default pictures folder name, relative to the project folder.
+     */
     public static final String DEFAULT_PICTURES_FOLDER = "pictures";
 
+    /**
+     * Default miniatures folder name, relative to the project folder.
+     */
     public static final String DEFAULT_MINIATURES_FOLDER = "miniatures";
 
+    /**
+     * Logger used by this class.
+     */
     private static final Logger LOG = Logger.getGlobal();
 
+    /**
+     * Support object used to fire property change events.
+     */
     private final PropertyChangeSupport propertyChangeSupport;
 
+    /**
+     * The project's name.
+     */
     private final String name;
 
     // Reference files
+    /**
+     * The project's folder.
+     */
     private File projectFolder;
 
+    /**
+     * The folder containing portrait pictures.
+     */
     private File portraitsFolder;
 
+    /**
+     * The folder containing pictures.
+     */
     private File picturesFolder;
 
+    /**
+     * The folder containing miniature pictures.
+     */
     private File miniaturesFolder;
 
+    /**
+     * The project's save file.
+     */
     private File projectFile;
 
+    /**
+     * The places with no parent.
+     */
     private final List<Place> highLevelPlaces;
 
+    /**
+     * All places in the project, keyed by name.
+     */
     private final Map<String, Place> allPlaces;
 
+    /**
+     * The persons in the project.
+     */
     private final List<Person> persons;
 
+    /**
+     * The stays in the project.
+     */
     private final List<StayPeriod> stays;
 
+    /**
+     * The friezes built from this project.
+     */
     private final List<Frieze> friezes;
 
+    /**
+     * The picture chronologies built from this project.
+     */
     private final List<PictureChronology> pictureChronologies;
 
     protected TimeLineProject(final String projectName, Map<String, String> configParams) {
@@ -188,6 +277,9 @@ public final class TimeLineProject {
         }
     }
 
+    /**
+     * @return the project's folder
+     */
     public File getProjectFolder() {
         return projectFolder;
     }
@@ -200,34 +292,61 @@ public final class TimeLineProject {
         return CustomFileUtils.fromAbsoluteToProjectRelative(this, portraitsFolder);
     }
 
+    /**
+     * @return the project's save file
+     */
     public File getTimelineFile() {
         return projectFile;
     }
 
+    /**
+     * @return the folder containing pictures
+     */
     public File getPicturesFolder() {
         return picturesFolder;
     }
 
+    /**
+     * @return the folder containing miniature pictures
+     */
     public File getMiniaturesFolder() {
         return miniaturesFolder;
     }
 
+    /**
+     * @return the project's save file's absolute path
+     */
     public String getProjectLocation() {
         return projectFile.getAbsolutePath();
     }
 
+    /**
+     * @param listener the listener to add
+     */
     public void addListener(final PropertyChangeListener listener) {
         propertyChangeSupport.addPropertyChangeListener(listener);
     }
 
+    /**
+     * @param listener the listener to remove
+     */
     public void removeListener(final PropertyChangeListener listener) {
         propertyChangeSupport.removePropertyChangeListener(listener);
     }
 
+    /**
+     * @return the project's name
+     */
     public String getName() {
         return name;
     }
 
+    /**
+     * Adds a place (and its ancestors) to the project.
+     *
+     * @param aPlace the place to add
+     * @return true if the place was handled (added, or already present)
+     */
     public boolean addPlace(final Place aPlace) {
         if (aPlace == null) {
             return false;
@@ -244,6 +363,10 @@ public final class TimeLineProject {
         }
     }
 
+    /**
+     * @param aPlace the root place to add
+     * @return true if the place was added, false if it was already present
+     */
     public boolean addHighLevelPlace(final Place aPlace) {
         if (!highLevelPlaces.contains(aPlace)) {
             highLevelPlaces.add(aPlace);
@@ -258,15 +381,26 @@ public final class TimeLineProject {
         return false;
     }
 
+    /**
+     * @param aPlace the root place to remove
+     * @return true if the place was removed
+     */
     public boolean removeHighLevelPlace(final Place aPlace) {
         // TODO fire
         return highLevelPlaces.remove(aPlace);
     }
 
+    /**
+     * @return an unmodifiable list of the places with no parent
+     */
     public List<Place> getHighLevelPlaces() {
         return Collections.unmodifiableList(highLevelPlaces);
     }
 
+    /**
+     * @param placeName a place's name
+     * @return the place with the given name, or null if none exists
+     */
     public Place getPlaceByName(final String placeName) {
         return allPlaces.get(placeName);
     }
@@ -281,6 +415,9 @@ public final class TimeLineProject {
         stays.forEach(this::addStay);
     }
 
+    /**
+     * @param aStay the stay to add
+     */
     public void addStay(final StayPeriod aStay) {
         if (!stays.contains(aStay)) {
             stays.add(aStay);
@@ -289,6 +426,9 @@ public final class TimeLineProject {
         }
     }
 
+    /**
+     * @param aStay the stay to remove
+     */
     public void removeStay(final StayPeriod aStay) {
         if (stays.contains(aStay)) {
             stays.remove(aStay);
@@ -296,6 +436,9 @@ public final class TimeLineProject {
         }
     }
 
+    /**
+     * @return an unmodifiable list of the stays in the project
+     */
     public List<StayPeriod> getStays() {
         return Collections.unmodifiableList(stays);
     }
@@ -312,6 +455,10 @@ public final class TimeLineProject {
         return false;
     }
 
+    /**
+     * @param pictureChronology the picture chronology to add
+     * @return true if it was added, false if it was already present
+     */
     public boolean addPictureChronology(final PictureChronology pictureChronology) {
         if (!pictureChronologies.contains(pictureChronology)) {
             pictureChronology.addListener(this::handlePicturesChronologyChange);
@@ -321,14 +468,23 @@ public final class TimeLineProject {
         return false;
     }
 
+    /**
+     * @return an unmodifiable list of the friezes built from this project
+     */
     public List<Frieze> getFriezes() {
         return Collections.unmodifiableList(friezes);
     }
 
+    /**
+     * @return an unmodifiable list of the persons in the project
+     */
     public List<Person> getPersons() {
         return Collections.unmodifiableList(persons);
     }
 
+    /**
+     * @return an unmodifiable list of the picture chronologies built from this project
+     */
     public List<PictureChronology> getPictureChronologies() {
         return Collections.unmodifiableList(pictureChronologies);
     }
@@ -342,6 +498,10 @@ public final class TimeLineProject {
         return allPlaces.values().stream().sorted(Place.COMPARATOR).collect(Collectors.toList());
     }
 
+    /**
+     * @param aPerson the person to add
+     * @return true if the person was added, false if it was already present
+     */
     public boolean addPerson(final Person aPerson) {
         if (!persons.contains(aPerson)) {
             persons.add(aPerson);
@@ -381,6 +541,9 @@ public final class TimeLineProject {
         }
     }
 
+    /**
+     * @param deletedPlace the place to remove, along with its stays and children
+     */
     public void removePlace(final Place deletedPlace) {
         allPlaces.remove(deletedPlace.getName());
         highLevelPlaces.remove(deletedPlace);
@@ -395,6 +558,9 @@ public final class TimeLineProject {
         propertyChangeSupport.firePropertyChange(PLACE_REMOVED, this, deletedPlace);
     }
 
+    /**
+     * @param deletedPerson the person to remove, along with their stays
+     */
     public void removePerson(final Person deletedPerson) {
         if (persons.contains(deletedPerson)) {
             persons.remove(deletedPerson);

--- a/src/main/java/com/github/noony/app/timelinefx/core/TimeLineProjectFactory.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/TimeLineProjectFactory.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core;
 
 import com.github.noony.app.timelinefx.save.XMLHandler;
@@ -36,27 +37,27 @@ public final class TimeLineProjectFactory {
         // private utility constructor
     }
 
-    public static TimeLineProject createProject(String name, Map<String, String> configParams) {
-        TimeLineProject timeLineProject = new TimeLineProject(name, configParams);
+    public static TimeLineProject createProject(final String name, Map<String, String> configParams) {
+        final TimeLineProject timeLineProject = new TimeLineProject(name, configParams);
         FriezeObjectFactory.reset();
         return timeLineProject;
     }
 
-    public static TimeLineProject loadProject(File aFile) {
-        File timelineFile;
+    public static TimeLineProject loadProject(final File aFile) {
+        final File timelineFile;
         if (aFile == null) {
             throw new IllegalStateException("Project File cannot be null.");
         } else if (aFile.isFile()) {
             timelineFile = aFile;
             LOG.log(Level.INFO, "Project Folder:: {0}.", new Object[]{timelineFile.getParent()});
         } else {
-            File fileFound = Arrays.stream(Objects.requireNonNull(aFile.listFiles())).filter(file -> file.getName().endsWith("xml")).findAny().orElse(null);
+            final File fileFound = Arrays.stream(Objects.requireNonNull(aFile.listFiles())).filter(file -> file.getName().endsWith("xml")).findAny().orElse(null);
             if (fileFound == null) {
                 throw new IllegalStateException("No save file was found in " + aFile);
             }
             timelineFile = fileFound;
         }
-        var timeline = XMLHandler.loadFile(timelineFile);
+        final var timeline = XMLHandler.loadFile(timelineFile);
         LOG.log(Level.FINE, "Project created: {0}", new Object[]{timeline});
         return timeline;
     }

--- a/src/main/java/com/github/noony/app/timelinefx/core/TimeLineProjectFactory.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/TimeLineProjectFactory.java
@@ -26,23 +26,40 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
+ * Entry point for creating a new {@link TimeLineProject} or loading one from disk.
  *
  * @author hamon
  */
 public final class TimeLineProjectFactory {
 
+    /**
+     * Logger used by this factory.
+     */
     private static final Logger LOG = Logger.getGlobal();
 
     private TimeLineProjectFactory() {
         // private utility constructor
     }
 
+    /**
+     * Creates a new, empty project.
+     *
+     * @param name the project's name
+     * @param configParams optional configuration overrides (folder locations, etc.)
+     * @return the created project
+     */
     public static TimeLineProject createProject(final String name, Map<String, String> configParams) {
         final TimeLineProject timeLineProject = new TimeLineProject(name, configParams);
         FriezeObjectFactory.reset();
         return timeLineProject;
     }
 
+    /**
+     * Loads a project from a save file, or from the single save file found in a folder.
+     *
+     * @param aFile the project's save file, or its containing folder
+     * @return the loaded project
+     */
     public static TimeLineProject loadProject(final File aFile) {
         final File timelineFile;
         if (aFile == null) {

--- a/src/main/java/com/github/noony/app/timelinefx/core/TimeLineProjectFactory.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/TimeLineProjectFactory.java
@@ -48,7 +48,7 @@ public final class TimeLineProjectFactory {
      * @param configParams optional configuration overrides (folder locations, etc.)
      * @return the created project
      */
-    public static TimeLineProject createProject(final String name, Map<String, String> configParams) {
+    public static TimeLineProject createProject(final String name, final Map<String, String> configParams) {
         final TimeLineProject timeLineProject = new TimeLineProject(name, configParams);
         FriezeObjectFactory.reset();
         return timeLineProject;

--- a/src/main/java/com/github/noony/app/timelinefx/core/freemap/FriezeFreeMapFactory.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/freemap/FriezeFreeMapFactory.java
@@ -65,6 +65,19 @@ public class FriezeFreeMapFactory {
         return friezeFreeMap;
     }
 
+    /**
+     * Creates a {@link FriezeFreeMap} with a fully specified content, as used when restoring one from a
+     * saved project.
+     *
+     * @param anID the id to assign to the new free map
+     * @param aFrieze the frieze the free map belongs to
+     * @param properties the free map's layout properties
+     * @param dateHandles the date handles to restore
+     * @param persons the persons to restore
+     * @param places the places to restore
+     * @param stays the stays to restore
+     * @return the created free map
+     */
     public static FriezeFreeMap createFriezeFreeMap(final long anID, Frieze aFrieze, FriezeFreeMapProperties properties,
             List<FreeMapDateHandle> dateHandles, List<FreeMapPerson> persons, List<FreeMapPlace> places, List<FreeMapStay> stays) {
         //

--- a/src/main/java/com/github/noony/app/timelinefx/core/freemap/FriezeFreeMapFactory.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/freemap/FriezeFreeMapFactory.java
@@ -78,7 +78,7 @@ public class FriezeFreeMapFactory {
      * @param stays the stays to restore
      * @return the created free map
      */
-    public static FriezeFreeMap createFriezeFreeMap(final long anID, Frieze aFrieze, FriezeFreeMapProperties properties,
+    public static FriezeFreeMap createFriezeFreeMap(final long anID, final Frieze aFrieze, FriezeFreeMapProperties properties,
             List<FreeMapDateHandle> dateHandles, List<FreeMapPerson> persons, List<FreeMapPlace> places, List<FreeMapStay> stays) {
         //
         if (!FACTORY.isIdAvailable(anID)) {

--- a/src/main/java/com/github/noony/app/timelinefx/core/freemap/FriezeFreeMapFactory.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/freemap/FriezeFreeMapFactory.java
@@ -65,14 +65,14 @@ public class FriezeFreeMapFactory {
         return friezeFreeMap;
     }
 
-    public static FriezeFreeMap createFriezeFreeMap(long anID, Frieze aFrieze, FriezeFreeMapProperties properties,
+    public static FriezeFreeMap createFriezeFreeMap(final long anID, Frieze aFrieze, FriezeFreeMapProperties properties,
             List<FreeMapDateHandle> dateHandles, List<FreeMapPerson> persons, List<FreeMapPlace> places, List<FreeMapStay> stays) {
         //
         if (!FACTORY.isIdAvailable(anID)) {
             throw new IllegalArgumentException("Trying to create a friezeFreeMap with existing id=" + anID);
         }
         LOG.log(Level.WARNING, "Creating a friezeFreeMap (id={0} with Frieze={1} with its full content.", new Object[]{anID, aFrieze});
-        var friezeFreeMap = new FriezeFreeMap(anID, aFrieze, properties, dateHandles, persons, places, stays, false);
+        final var friezeFreeMap = new FriezeFreeMap(anID, aFrieze, properties, dateHandles, persons, places, stays, false);
         FACTORY.addObject(friezeFreeMap);
         return friezeFreeMap;
     }

--- a/src/main/java/com/github/noony/app/timelinefx/core/freemap/FriezeFreeMapFactory.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/freemap/FriezeFreeMapFactory.java
@@ -78,7 +78,7 @@ public class FriezeFreeMapFactory {
      * @param stays the stays to restore
      * @return the created free map
      */
-    public static FriezeFreeMap createFriezeFreeMap(final long anID, final Frieze aFrieze, FriezeFreeMapProperties properties,
+    public static FriezeFreeMap createFriezeFreeMap(final long anID, final Frieze aFrieze, final FriezeFreeMapProperties properties,
             List<FreeMapDateHandle> dateHandles, List<FreeMapPerson> persons, List<FreeMapPlace> places, List<FreeMapStay> stays) {
         //
         if (!FACTORY.isIdAvailable(anID)) {

--- a/src/main/java/com/github/noony/app/timelinefx/core/freemap/FriezeFreeMapProperties.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/freemap/FriezeFreeMapProperties.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core.freemap;
 
 import java.util.HashMap;
@@ -33,7 +34,7 @@ public record FriezeFreeMapProperties(Dimension2D dimension, double personWidth,
         boolean portraitConnectorVisibility, double portraitRadius) {
 
     public Map<String, String> toParameterMap() {
-        var parameters = new HashMap<String, String>();
+        final var parameters = new HashMap<String, String>();
         parameters.put(FriezeFreeMap.FRIEZE_WIDTH, Double.toString(dimension.getWidth()));
         parameters.put(FriezeFreeMap.FRIEZE_HEIGHT, Double.toString(dimension.getHeight()));
         parameters.put(FriezeFreeMap.PERSONS_WIDTH, Double.toString(personWidth));
@@ -47,17 +48,17 @@ public record FriezeFreeMapProperties(Dimension2D dimension, double personWidth,
         return parameters;
     }
 
-    public static FriezeFreeMapProperties fromParameterMap(Map<String, String> parameters, FriezeFreeMapProperties defaults) {
-        var width = Double.parseDouble(parameters.getOrDefault(FriezeFreeMap.FRIEZE_WIDTH, Double.toString(defaults.dimension().getWidth())));
-        var height = Double.parseDouble(parameters.getOrDefault(FriezeFreeMap.FRIEZE_HEIGHT, Double.toString(defaults.dimension().getHeight())));
-        var personWidthValue = Double.parseDouble(parameters.getOrDefault(FriezeFreeMap.PERSONS_WIDTH, Double.toString(defaults.personWidth())));
-        var placeNameWidthValue = Double.parseDouble(parameters.getOrDefault(FriezeFreeMap.PLACE_NAMES_WIDTH, Double.toString(defaults.placeNameWidth())));
-        var fontSizeValue = Double.parseDouble(parameters.getOrDefault(FriezeFreeMap.FONT_SIZE, Double.toString(defaults.fontSize())));
-        var plotSeparationValue = Double.parseDouble(parameters.getOrDefault(FriezeFreeMap.PLOT_SEPARATION, Double.toString(defaults.plotSeparation())));
-        var plotSizeValue = Double.parseDouble(parameters.getOrDefault(FriezeFreeMap.PLOT_SIZE, Double.toString(defaults.plotSize())));
-        var plotVisibilityValue = Boolean.parseBoolean(parameters.getOrDefault(FriezeFreeMap.PLOT_VISIBILITY, Boolean.toString(defaults.plotVisibility())));
-        var portraitConnectorVisibilityValue = Boolean.parseBoolean(parameters.getOrDefault(FriezeFreeMap.PORTRAIT_CONNECTOR_VISIBILITY, Boolean.toString(defaults.portraitConnectorVisibility())));
-        var portraitRadiusValue = Double.parseDouble(parameters.getOrDefault(FriezeFreeMap.PORTRAIT_RADIUS, Double.toString(defaults.portraitRadius())));
+    public static FriezeFreeMapProperties fromParameterMap(final Map<String, String> parameters, FriezeFreeMapProperties defaults) {
+        final var width = Double.parseDouble(parameters.getOrDefault(FriezeFreeMap.FRIEZE_WIDTH, Double.toString(defaults.dimension().getWidth())));
+        final var height = Double.parseDouble(parameters.getOrDefault(FriezeFreeMap.FRIEZE_HEIGHT, Double.toString(defaults.dimension().getHeight())));
+        final var personWidthValue = Double.parseDouble(parameters.getOrDefault(FriezeFreeMap.PERSONS_WIDTH, Double.toString(defaults.personWidth())));
+        final var placeNameWidthValue = Double.parseDouble(parameters.getOrDefault(FriezeFreeMap.PLACE_NAMES_WIDTH, Double.toString(defaults.placeNameWidth())));
+        final var fontSizeValue = Double.parseDouble(parameters.getOrDefault(FriezeFreeMap.FONT_SIZE, Double.toString(defaults.fontSize())));
+        final var plotSeparationValue = Double.parseDouble(parameters.getOrDefault(FriezeFreeMap.PLOT_SEPARATION, Double.toString(defaults.plotSeparation())));
+        final var plotSizeValue = Double.parseDouble(parameters.getOrDefault(FriezeFreeMap.PLOT_SIZE, Double.toString(defaults.plotSize())));
+        final var plotVisibilityValue = Boolean.parseBoolean(parameters.getOrDefault(FriezeFreeMap.PLOT_VISIBILITY, Boolean.toString(defaults.plotVisibility())));
+        final var portraitConnectorVisibilityValue = Boolean.parseBoolean(parameters.getOrDefault(FriezeFreeMap.PORTRAIT_CONNECTOR_VISIBILITY, Boolean.toString(defaults.portraitConnectorVisibility())));
+        final var portraitRadiusValue = Double.parseDouble(parameters.getOrDefault(FriezeFreeMap.PORTRAIT_RADIUS, Double.toString(defaults.portraitRadius())));
         return new FriezeFreeMapProperties(new Dimension2D(width, height), personWidthValue, placeNameWidthValue,
                 fontSizeValue, plotSeparationValue, plotSizeValue, plotVisibilityValue, portraitConnectorVisibilityValue,
                 portraitRadiusValue);

--- a/src/main/java/com/github/noony/app/timelinefx/core/freemap/FriezeFreeMapProperties.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/freemap/FriezeFreeMapProperties.java
@@ -27,12 +27,25 @@ import javafx.geometry.Dimension2D;
  * and {@link #fromParameterMap(Map, FriezeFreeMapProperties)} keep it interoperable with the existing XML
  * save/load format, which still stores each attribute as a named string parameter.
  *
+ * @param dimension the free map's overall width/height
+ * @param personWidth the width reserved for the persons column
+ * @param placeNameWidth the width reserved for place names
+ * @param fontSize the font size used to draw place/person names
+ * @param plotSeparation the spacing between plots on a place
+ * @param plotSize the size of a single plot
+ * @param plotVisibility whether plots are drawn
+ * @param portraitConnectorVisibility whether portrait connectors are drawn
+ * @param portraitRadius the radius of a person's portrait
  * @author hamon
  */
 public record FriezeFreeMapProperties(Dimension2D dimension, double personWidth, double placeNameWidth,
         double fontSize, double plotSeparation, double plotSize, boolean plotVisibility,
         boolean portraitConnectorVisibility, double portraitRadius) {
 
+    /**
+     * @return this instance's attributes as a {@code Map<String, String>}, keyed by
+     * {@link FriezeFreeMap}'s parameter name constants, for XML persistence.
+     */
     public Map<String, String> toParameterMap() {
         final var parameters = new HashMap<String, String>();
         parameters.put(FriezeFreeMap.FRIEZE_WIDTH, Double.toString(dimension.getWidth()));
@@ -48,6 +61,13 @@ public record FriezeFreeMapProperties(Dimension2D dimension, double personWidth,
         return parameters;
     }
 
+    /**
+     * @param parameters a {@code Map<String, String>} as produced by {@link #toParameterMap()}, possibly
+     * missing some keys
+     * @param defaults the values to fall back to for any key missing from {@code parameters}
+     * @return a new instance parsed from {@code parameters}, defaulting missing/unparseable keys to
+     * {@code defaults}
+     */
     public static FriezeFreeMapProperties fromParameterMap(final Map<String, String> parameters, FriezeFreeMapProperties defaults) {
         final var width = Double.parseDouble(parameters.getOrDefault(FriezeFreeMap.FRIEZE_WIDTH, Double.toString(defaults.dimension().getWidth())));
         final var height = Double.parseDouble(parameters.getOrDefault(FriezeFreeMap.FRIEZE_HEIGHT, Double.toString(defaults.dimension().getHeight())));

--- a/src/main/java/com/github/noony/app/timelinefx/core/freemap/FriezeFreeMapProperties.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/freemap/FriezeFreeMapProperties.java
@@ -68,7 +68,7 @@ public record FriezeFreeMapProperties(Dimension2D dimension, double personWidth,
      * @return a new instance parsed from {@code parameters}, defaulting missing/unparseable keys to
      * {@code defaults}
      */
-    public static FriezeFreeMapProperties fromParameterMap(final Map<String, String> parameters, FriezeFreeMapProperties defaults) {
+    public static FriezeFreeMapProperties fromParameterMap(final Map<String, String> parameters, final FriezeFreeMapProperties defaults) {
         final var width = Double.parseDouble(parameters.getOrDefault(FriezeFreeMap.FRIEZE_WIDTH, Double.toString(defaults.dimension().getWidth())));
         final var height = Double.parseDouble(parameters.getOrDefault(FriezeFreeMap.FRIEZE_HEIGHT, Double.toString(defaults.dimension().getHeight())));
         final var personWidthValue = Double.parseDouble(parameters.getOrDefault(FriezeFreeMap.PERSONS_WIDTH, Double.toString(defaults.personWidth())));

--- a/src/main/java/com/github/noony/app/timelinefx/core/freemap/package-info.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/freemap/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2019 NoOnY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Model classes for the "free map" view of a {@link com.github.noony.app.timelinefx.core.Frieze}.
+ */
+package com.github.noony.app.timelinefx.core.freemap;

--- a/src/main/java/com/github/noony/app/timelinefx/core/package-info.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 NoOnY
+ * Copyright (C) 2019 NoOnY
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -15,24 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.github.noony.app.timelinefx.core;
-
 /**
- * Base contract for domain objects identified by a unique id within their project.
- *
- * @author hamon
+ * Core domain model: projects, friezes, places, persons, stays and pictures.
  */
-public interface FriezeObject {
-
-    /**
-     * Value used for objects that have not been assigned a real id yet.
-     */
-    final long NO_ID = -1;
-
-    /**
-     * Each IFriezeObject instance has a unique id in its project's scope
-     *
-     * @return the object unique ID
-     */
-    abstract long getId();
-}
+package com.github.noony.app.timelinefx.core;

--- a/src/test/java/com/github/noony/app/timelinefx/core/freemap/FriezeFreeMapPropertiesTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/freemap/FriezeFreeMapPropertiesTest.java
@@ -33,6 +33,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  */
 public class FriezeFreeMapPropertiesTest {
 
+    /**
+     * Default constructor.
+     */
     public FriezeFreeMapPropertiesTest() {
     }
 

--- a/src/test/java/com/github/noony/app/timelinefx/core/freemap/FriezeFreeMapPropertiesTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/freemap/FriezeFreeMapPropertiesTest.java
@@ -14,12 +14,13 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core.freemap;
 
 import java.util.HashMap;
 import java.util.Map;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Note: these tests deliberately stay at the {@link FriezeFreeMapProperties} level rather than going through
@@ -40,8 +41,8 @@ public class FriezeFreeMapPropertiesTest {
      */
     @Test
     public void testParameterMapRoundTrip() {
-        var defaults = FriezeFreeMap.DEFAULT_PROPERTIES;
-        var roundTripped = FriezeFreeMapProperties.fromParameterMap(defaults.toParameterMap(), defaults);
+        final var defaults = FriezeFreeMap.DEFAULT_PROPERTIES;
+        final var roundTripped = FriezeFreeMapProperties.fromParameterMap(defaults.toParameterMap(), defaults);
         assertEquals(defaults, roundTripped);
     }
 
@@ -50,10 +51,10 @@ public class FriezeFreeMapPropertiesTest {
      */
     @Test
     public void testFromParameterMapUsesDefaultsForMissingKeys() {
-        var defaults = FriezeFreeMap.DEFAULT_PROPERTIES;
-        Map<String, String> partialParameters = new HashMap<>();
+        final var defaults = FriezeFreeMap.DEFAULT_PROPERTIES;
+        final Map<String, String> partialParameters = new HashMap<>();
         partialParameters.put(FriezeFreeMap.FONT_SIZE, "99.0");
-        var properties = FriezeFreeMapProperties.fromParameterMap(partialParameters, defaults);
+        final var properties = FriezeFreeMapProperties.fromParameterMap(partialParameters, defaults);
         assertEquals(99.0, properties.fontSize());
         assertEquals(defaults.personWidth(), properties.personWidth());
         assertEquals(defaults.plotSeparation(), properties.plotSeparation());

--- a/src/test/java/com/github/noony/app/timelinefx/core/freemap/FriezeFreeMapPropertiesTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/freemap/FriezeFreeMapPropertiesTest.java
@@ -33,6 +33,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  */
 public class FriezeFreeMapPropertiesTest {
 
+    private static final double CUSTOM_FONT_SIZE = 99.0;
+
     /**
      * Default constructor.
      */
@@ -54,9 +56,9 @@ public class FriezeFreeMapPropertiesTest {
     @Test public void testFromParameterMapUsesDefaultsForMissingKeys() {
         final var defaults = FriezeFreeMap.DEFAULT_PROPERTIES;
         final Map<String, String> partialParameters = new HashMap<>();
-        partialParameters.put(FriezeFreeMap.FONT_SIZE, "99.0");
+        partialParameters.put(FriezeFreeMap.FONT_SIZE, Double.toString(CUSTOM_FONT_SIZE));
         final var properties = FriezeFreeMapProperties.fromParameterMap(partialParameters, defaults);
-        assertEquals(99.0, properties.fontSize());
+        assertEquals(CUSTOM_FONT_SIZE, properties.fontSize());
         assertEquals(defaults.personWidth(), properties.personWidth());
         assertEquals(defaults.plotSeparation(), properties.plotSeparation());
         assertEquals(defaults.portraitRadius(), properties.portraitRadius());

--- a/src/test/java/com/github/noony/app/timelinefx/core/freemap/FriezeFreeMapPropertiesTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/freemap/FriezeFreeMapPropertiesTest.java
@@ -42,8 +42,7 @@ public class FriezeFreeMapPropertiesTest {
     /**
      * Test that DEFAULT_PROPERTIES survives a round-trip through toParameterMap/fromParameterMap.
      */
-    @Test
-    public void testParameterMapRoundTrip() {
+    @Test public void testParameterMapRoundTrip() {
         final var defaults = FriezeFreeMap.DEFAULT_PROPERTIES;
         final var roundTripped = FriezeFreeMapProperties.fromParameterMap(defaults.toParameterMap(), defaults);
         assertEquals(defaults, roundTripped);
@@ -52,8 +51,7 @@ public class FriezeFreeMapPropertiesTest {
     /**
      * Test that fromParameterMap falls back to the supplied defaults for missing/partial keys.
      */
-    @Test
-    public void testFromParameterMapUsesDefaultsForMissingKeys() {
+    @Test public void testFromParameterMapUsesDefaultsForMissingKeys() {
         final var defaults = FriezeFreeMap.DEFAULT_PROPERTIES;
         final Map<String, String> partialParameters = new HashMap<>();
         partialParameters.put(FriezeFreeMap.FONT_SIZE, "99.0");

--- a/src/test/java/com/github/noony/app/timelinefx/core/freemap/package-info.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/freemap/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2026 NoOnY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Tests for {@link com.github.noony.app.timelinefx.core.freemap.FriezeFreeMapProperties}.
+ */
+package com.github.noony.app.timelinefx.core.freemap;


### PR DESCRIPTION
## Summary
Two rounds of Codacy cleanup on this branch, each following style → javadoc → annotations (→ magic numbers where applicable), plus follow-up fixes once the PR's live Codacy analysis surfaced side effects of the cleanup itself.

**Round 1 — `core.freemap`'s 3 files from PR #31** (36 findings):
1. `final` on flagged locals/params, import order, blank line after license header
2. `@param`/`@return` tags, `package-info.java` for main+test source trees
3. `@Test` moved onto the same line as its target method
4. Extracted the `99.0` literal in the test to a named constant

**Round 2 — the whole `com.github.noony.app.timelinefx.core` package** (31 files, ~940 pre-existing findings):
1. **Style** (~470) — `final` on locals/flagged params, blank-line separation between fields, explicit interface member modifiers, explicit-initialization removal, import ordering, misc whitespace/parenthesization
2. **Javadoc** (~460) — `package-info.java`, short factual `@param`/`@return`/summary descriptions for ~360 previously-undocumented fields/methods/classes
3. **Annotations** (9) — `@Override` moved onto the same line as its target method

**Follow-up fixes** (found by re-checking the PR's live Codacy analysis after round 2):
- Reverted the explicit interface member modifiers added in round 2: they satisfy `InterfaceMemberImpliedModifier` but directly trigger `RedundantModifier` in this repo's actual Codacy config — the two rules are contradictory here, and explicit modifiers made the new-issue count net worse.
- Two rounds of `final` on parameters that Codacy's original scan hadn't sampled per-method, but which surfaced as "new" once the surrounding lines were touched by earlier commits (42 params, then 33 more).

**Remaining, not addressed** (~47 new issues, converging but not fully resolved — same reasoning as before): a residual, still-shrinking tail of `FinalParameters` (23, same cascading-diff cause, diminishing each pass), `ImportControl` (needs a repo-wide `import-control.xml`), the "duplicate blank line" `Regexp` finding (ruleset not visible outside Codacy), `AvoidStaticImport` (matches existing test conventions), 1 residual `InterfaceMemberImpliedModifier` (unavoidable given the `RedundantModifier` conflict above), and design-adjacent rules that would change behavior or public API rather than being pure style (`DesignForExtension`, `HiddenField`, `ReturnCount`, `AvoidInlineConditionals`, `ExecutableStatementCount`, `DeclarationOrder`, plus a couple of minor `JavadocTagContinuationIndentation`/`SeparatorWrap`/`SummaryJavadoc`/`JavadocVariable` nits from the new Javadoc).

Javadoc descriptions are intentionally short and mechanical (inferred from names/usage) given the volume and that this is pre-existing code, not something written for this change.

## Test plan
- [x] `mvn compile` / `mvn test` after every commit — 15/15 tests pass throughout
- [x] `mvn package` succeeded earlier in the branch's history (Java 26 migration commits)