### PR TITLE
Avoid recursive subtree scans for direct-child lookups in V3 provider

### DIFF
--- a/src/main/java/com/github/noony/app/timelinefx/save/v3/FreeMapProviderV3.java
+++ b/src/main/java/com/github/noony/app/timelinefx/save/v3/FreeMapProviderV3.java
@@ -286,11 +286,10 @@ public class FreeMapProviderV3 {
     }
 
     private static List<FreeMapDateHandle> parseFreeMapDateHandles(Element freemapElement, long parentFreeMapID) {
-        var freemapDateHandleGrouptList = freemapElement.getElementsByTagName(FREEMAP_DATE_HANDLES_GROUP);
-        if (freemapDateHandleGrouptList.getLength() != 1) {
-            throw new IllegalStateException("Error while parsing FreeMapDateHandles: " + FREEMAP_DATE_HANDLES_GROUP + " count = " + freemapDateHandleGrouptList.getLength());
+        var freemapDateHandleGroupElement = firstDirectChildByTagName(freemapElement, FREEMAP_DATE_HANDLES_GROUP);
+        if (freemapDateHandleGroupElement == null) {
+            throw new IllegalStateException("Error while parsing FreeMapDateHandles: " + FREEMAP_DATE_HANDLES_GROUP + " count = 0");
         }
-        var freemapDateHandleGroupElement = (Element) freemapDateHandleGrouptList.item(0);
 
         List<FreeMapDateHandle> freeMapDateHandles = new LinkedList<>();
         var freemapDateHandlesElements = freemapDateHandleGroupElement.getElementsByTagName(FREEMAP_DATE_HANDLE_ELEMENT);
@@ -307,11 +306,10 @@ public class FreeMapProviderV3 {
     }
 
     private static List<Pair<FreeMapPerson, Element>> parseFreeMapPersons(Element freemapElement, long parentFreeMapID) {
-        var freemapPersonsElementList = freemapElement.getElementsByTagName(FREEMAP_PERSONS_GROUP);
-        if (freemapPersonsElementList.getLength() != 1) {
-            throw new IllegalStateException("Error while parsing FreeMapPersons: " + FREEMAP_PERSONS_GROUP + " count = " + freemapPersonsElementList.getLength());
+        var freemapPersonsElement = firstDirectChildByTagName(freemapElement, FREEMAP_PERSONS_GROUP);
+        if (freemapPersonsElement == null) {
+            throw new IllegalStateException("Error while parsing FreeMapPersons: " + FREEMAP_PERSONS_GROUP + " count = 0");
         }
-        var freemapPersonsElement = (Element) freemapPersonsElementList.item(0);
         //
         List<Pair<FreeMapPerson, Element>> freeMapPersons = new LinkedList<>();
         var freemapPersonsElements = freemapPersonsElement.getElementsByTagName(FREEMAP_PERSON_ELEMENT);
@@ -334,11 +332,10 @@ public class FreeMapProviderV3 {
 
     private static List<FreeMapStay> parseFreeMapPersonStep02(Element freemapPersonElement, FreeMapPerson freeMapPerson, Map<Long, FreeMapPlace> freeMapPlacesById) {
         // parse stays
-        var freemapStaysGrouptList = freemapPersonElement.getElementsByTagName(FREEMAP_STAYS_GROUP);
-        if (freemapStaysGrouptList.getLength() != 1) {
-            throw new IllegalStateException("Error while parsing FreemapStays: " + FREEMAP_STAYS_GROUP + " count = " + freemapStaysGrouptList.getLength());
+        var freemapStaysGroupElement = firstDirectChildByTagName(freemapPersonElement, FREEMAP_STAYS_GROUP);
+        if (freemapStaysGroupElement == null) {
+            throw new IllegalStateException("Error while parsing FreemapStays: " + FREEMAP_STAYS_GROUP + " count = 0");
         }
-        var freemapStaysGroupElement = (Element) freemapStaysGrouptList.item(0);
         //
         List<FreeMapStay> stays = new LinkedList<>();
         var freemapStaysElements = freemapStaysGroupElement.getElementsByTagName(FREEMAP_STAY_ELEMENT);
@@ -391,11 +388,10 @@ public class FreeMapProviderV3 {
 
     private static void parseFreeMapPersonStep03(Element freemapPersonElement, FreeMapPerson freeMapPerson, Map<Long, FreeMapStay> freeMapStaysById) {
         // parse portrais
-        var freemapPortraitsGrouptList = freemapPersonElement.getElementsByTagName(FREEMAP_PORTRAITS_GROUP);
-        if (freemapPortraitsGrouptList.getLength() != 1) {
-            throw new IllegalStateException("Error while parsing FreemapPortraits: " + FREEMAP_PORTRAITS_GROUP + " count = " + freemapPortraitsGrouptList.getLength());
+        var freemapPortraitsGroupElement = firstDirectChildByTagName(freemapPersonElement, FREEMAP_PORTRAITS_GROUP);
+        if (freemapPortraitsGroupElement == null) {
+            throw new IllegalStateException("Error while parsing FreemapPortraits: " + FREEMAP_PORTRAITS_GROUP + " count = 0");
         }
-        var freemapPortraitsGroupElement = (Element) freemapPortraitsGrouptList.item(0);
         //
         var freemapPortraitsElements = freemapPortraitsGroupElement.getElementsByTagName(PORTRAIT_ELEMENT);
         for (int i = 0; i < freemapPortraitsElements.getLength(); i++) {
@@ -430,19 +426,17 @@ public class FreeMapProviderV3 {
     }
 
     private static PortraitLink parsePortraitLink(Element freeMapPortraitElement, FreeMapPortrait aFreeMapPortrait, Map<Long, FreeMapStay> freeMapStaysById) {
-        var portraitLinkElements = freeMapPortraitElement.getElementsByTagName(FREEMAP_PORTRAIT_LINK_ELEMENT);
-        if (portraitLinkElements.getLength() != 1) {
-            throw new IllegalStateException("Not 1 " + FREEMAP_PORTRAIT_LINK_ELEMENT + " in freeMapPortraitElement but" + portraitLinkElements.getLength() + ".");
+        var portraitLinkElement = firstDirectChildByTagName(freeMapPortraitElement, FREEMAP_PORTRAIT_LINK_ELEMENT);
+        if (portraitLinkElement == null) {
+            throw new IllegalStateException("Not 1 " + FREEMAP_PORTRAIT_LINK_ELEMENT + " in freeMapPortraitElement but 0.");
         }
-        var portraitLinkElement = (Element) portraitLinkElements.item(0);
         var anID = Long.parseLong(portraitLinkElement.getAttribute(ID_ATR));
         //
         //
-        var connectorElements = freeMapPortraitElement.getElementsByTagName(FREEMAP_CONNECTOR_ELEMENT);
-        if (connectorElements.getLength() != 1) {
-            throw new IllegalStateException("Not 1 " + FREEMAP_CONNECTOR_ELEMENT + " in freeMapPortraitElement but" + connectorElements.getLength() + ".");
+        var stayConnectorElement = firstDirectChildByTagName(portraitLinkElement, FREEMAP_CONNECTOR_ELEMENT);
+        if (stayConnectorElement == null) {
+            throw new IllegalStateException("Not 1 " + FREEMAP_CONNECTOR_ELEMENT + " in freeMapPortraitElement but 0.");
         }
-        var stayConnectorElement = (Element) connectorElements.item(0);
         var stayConnector = parseConnectorElement(stayConnectorElement, freeMapStaysById);
         //
         var portraitLink = FreeMapLinkFactory.createPortraitLink(anID, aFreeMapPortrait, stayConnector);
@@ -451,11 +445,10 @@ public class FreeMapProviderV3 {
     }
 
     private static List<FreeMapPlace> parseFreeMapPlaces(Element freemapElement, long parentFreeMapID, FriezeFreeMapProperties freeMapProperties, Map<Long, FreeMapPerson> freeMapPersonsById) {
-        var freemapPlacesElementList = freemapElement.getElementsByTagName(FREEMAP_PLACES_GROUP);
-        if (freemapPlacesElementList.getLength() != 1) {
-            throw new IllegalStateException("Error while parsing FreeMapPlaces: " + FREEMAP_PERSONS_GROUP + " count = " + freemapPlacesElementList.getLength());
+        var freemapPlacesElement = firstDirectChildByTagName(freemapElement, FREEMAP_PLACES_GROUP);
+        if (freemapPlacesElement == null) {
+            throw new IllegalStateException("Error while parsing FreeMapPlaces: " + FREEMAP_PERSONS_GROUP + " count = 0");
         }
-        var freemapPlacesElement = (Element) freemapPlacesElementList.item(0);
         //
         List<FreeMapPlace> freeMapPlaces = new LinkedList<>();
         var freemapPlacesElements = freemapPlacesElement.getElementsByTagName(FREEMAP_PLACE_ELEMENT);

--- a/src/main/java/com/github/noony/app/timelinefx/save/v3/TimeProjectProviderV3.java
+++ b/src/main/java/com/github/noony/app/timelinefx/save/v3/TimeProjectProviderV3.java
@@ -313,6 +313,24 @@ public class TimeProjectProviderV3 implements TimelineProjectProvider {
         return true;
     }
 
+    /**
+     * Finds the first direct child element with the given tag name, without recursing into
+     * descendants (unlike {@link Element#getElementsByTagName(String)}, which walks the whole subtree).
+     *
+     * @param parent the element whose direct children are searched
+     * @param tagName the tag name to look for
+     * @return the first matching direct child, or {@code null} if none exists
+     */
+    protected static Element firstDirectChildByTagName(final Element parent, final String tagName) {
+        var children = parent.getChildNodes();
+        for (int i = 0; i < children.getLength(); i++) {
+            if (children.item(i) instanceof Element child && child.getTagName().equals(tagName)) {
+                return child;
+            }
+        }
+        return null;
+    }
+
     private static List<Place> parsePlaces(Element placesRootElement, Place parentPlace) {
         List<Place> places = new LinkedList<>();
         NodeList placeElements = placesRootElement.getChildNodes();
@@ -513,18 +531,18 @@ public class TimeProjectProviderV3 implements TimelineProjectProvider {
         // <frieze name="SW 1-2">
         var name = friezeElement.getAttribute(NAME_ATR);
         var id = Long.parseLong(friezeElement.getAttribute(ID_ATR));
-        var stayGroups = friezeElement.getElementsByTagName(STAYS_REF_GROUP);
-        var stays = parseStaysInFreize((Element) stayGroups.item(0));
+        var staysElement = firstDirectChildByTagName(friezeElement, STAYS_REF_GROUP);
+        if (staysElement == null) {
+            throw new IllegalStateException("Wrong number of STAYS_GROUP : 0");
+        }
+        var stays = parseStaysInFreize(staysElement);
         var frieze = FriezeFactory.createFrieze(id, project, name, stays);
-        if (stayGroups.getLength() != 1) {
-            throw new IllegalStateException("Wrong number of STAYS_GROUP : " + stayGroups.getLength());
-        }
         //
-        var freemapGroups = friezeElement.getElementsByTagName(FreeMapProviderV3.FREEMAPS_GROUP);
-        if (freemapGroups.getLength() != 1) {
-            throw new IllegalStateException("Wrong number of FREEMAPS_GROUP : " + freemapGroups.getLength());
+        var freemapsElement = firstDirectChildByTagName(friezeElement, FreeMapProviderV3.FREEMAPS_GROUP);
+        if (freemapsElement == null) {
+            throw new IllegalStateException("Wrong number of FREEMAPS_GROUP : 0");
         }
-        FreeMapProviderV3.parseFreeMaps((Element) freemapGroups.item(0), frieze);
+        FreeMapProviderV3.parseFreeMaps(freemapsElement, frieze);
         //
         return frieze;
     }


### PR DESCRIPTION
## Summary

`Element.getElementsByTagName(tag)` recurses into the entire subtree, even when the target is known to be a direct child. In the V3 loader, several "find the single X group" lookups used it on parent elements that also contain large, unrelated sibling subtrees (e.g. looking up a freemap's date-handles group re-walked the persons/places groups too; looking up a frieze's stays group re-walked its entire freemaps subtree).

- Added `firstDirectChildByTagName(Element, String)` (single pass over `getChildNodes()`, no recursion) to `TimeProjectProviderV3`.
- Applied it at the 8 call sites where the save-side code guarantees the target is a direct child: frieze → stays-ref-group / freemaps-group; freemap → date-handles-group / persons-group / places-group; freemap-person → stays-group / portraits-group; freemap-portrait → portrait-link (and, one level further, portrait-link → connector, since that one is nested two levels under the portrait, not a direct child).

Left untouched the call sites that need a genuine subtree/descendant search or that collect every match rather than a single one (e.g. `parseFreeMapParameters`, the per-item lists inside an already-narrow group container) — those don't have the same "re-scan everything else in the freemap" problem.

No behavior change on valid project files; the same `IllegalStateException`s are still thrown when a required group is missing.

Builds on #35 (same investigation, same files).

## Test plan
- [x] `mvn compile`
- [x] `mvn test` (all green)
- [ ] Manual load of a real project file to sanity-check friezes/freemaps still resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)