### PR TITLE
Fix residual Codacy findings in core package

### DIFF
--- a/src/main/java/com/github/noony/app/timelinefx/core/AbstractPicture.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/AbstractPicture.java
@@ -97,7 +97,7 @@ public abstract class AbstractPicture implements IPicture {
     private LocalDate date;
 
     @SuppressWarnings("this-escape")
-    protected AbstractPicture(final long anID, final String aName, final String aFilePath, int aWidth, int aHeight, LocalDate aDate) {
+    protected AbstractPicture(final long anID, final String aName, final String aFilePath, final int aWidth, int aHeight, LocalDate aDate) {
         id = anID;
         propertyChangeSupport = new PropertyChangeSupport(AbstractPicture.this);
         persons = new LinkedList<>();
@@ -114,7 +114,7 @@ public abstract class AbstractPicture implements IPicture {
     }
 
     @SuppressWarnings("this-escape")
-    protected AbstractPicture(final long anID, final String aName, final String aFilePath, int aWidth, int aHeight, double aTimestamp) {
+    protected AbstractPicture(final long anID, final String aName, final String aFilePath, final int aWidth, int aHeight, double aTimestamp) {
         id = anID;
         propertyChangeSupport = new PropertyChangeSupport(AbstractPicture.this);
         persons = new LinkedList<>();
@@ -369,7 +369,7 @@ public abstract class AbstractPicture implements IPicture {
      * @param aPerson the person to move down in the persons list
      */
     public void movePersonDown(final Person aPerson) {
-        int index = persons.indexOf(aPerson);
+        final int index = persons.indexOf(aPerson);
         if (index != 1 && index < persons.size() - 1) {
             Collections.swap(persons, index + 1, index);
             propertyChangeSupport.firePropertyChange(PERSONS_REORDED, this, index);

--- a/src/main/java/com/github/noony/app/timelinefx/core/AbstractPicture.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/AbstractPicture.java
@@ -100,7 +100,7 @@ public abstract class AbstractPicture implements IPicture {
     private LocalDate date;
 
     @SuppressWarnings("this-escape")
-    protected AbstractPicture(final long anID, final String aName, final String aFilePath, final int aWidth, final int aHeight, LocalDate aDate) {
+    protected AbstractPicture(final long anID, final String aName, final String aFilePath, final int aWidth, final int aHeight, final LocalDate aDate) {
         id = anID;
         propertyChangeSupport = new PropertyChangeSupport(AbstractPicture.this);
         persons = new LinkedList<>();
@@ -117,7 +117,7 @@ public abstract class AbstractPicture implements IPicture {
     }
 
     @SuppressWarnings("this-escape")
-    protected AbstractPicture(final long anID, final String aName, final String aFilePath, final int aWidth, final int aHeight, double aTimestamp) {
+    protected AbstractPicture(final long anID, final String aName, final String aFilePath, final int aWidth, final int aHeight, final double aTimestamp) {
         id = anID;
         propertyChangeSupport = new PropertyChangeSupport(AbstractPicture.this);
         persons = new LinkedList<>();

--- a/src/main/java/com/github/noony/app/timelinefx/core/AbstractPicture.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/AbstractPicture.java
@@ -100,7 +100,7 @@ public abstract class AbstractPicture implements IPicture {
     private LocalDate date;
 
     @SuppressWarnings("this-escape")
-    protected AbstractPicture(final long anID, final String aName, final String aFilePath, final int aWidth, int aHeight, LocalDate aDate) {
+    protected AbstractPicture(final long anID, final String aName, final String aFilePath, final int aWidth, final int aHeight, LocalDate aDate) {
         id = anID;
         propertyChangeSupport = new PropertyChangeSupport(AbstractPicture.this);
         persons = new LinkedList<>();
@@ -117,7 +117,7 @@ public abstract class AbstractPicture implements IPicture {
     }
 
     @SuppressWarnings("this-escape")
-    protected AbstractPicture(final long anID, final String aName, final String aFilePath, final int aWidth, int aHeight, double aTimestamp) {
+    protected AbstractPicture(final long anID, final String aName, final String aFilePath, final int aWidth, final int aHeight, double aTimestamp) {
         id = anID;
         propertyChangeSupport = new PropertyChangeSupport(AbstractPicture.this);
         persons = new LinkedList<>();

--- a/src/main/java/com/github/noony/app/timelinefx/core/AbstractPicture.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/AbstractPicture.java
@@ -99,7 +99,8 @@ public abstract class AbstractPicture implements IPicture {
      */
     private LocalDate date;
 
-    @SuppressWarnings("this-escape") protected AbstractPicture(final long anID, final String aName, final String aFilePath, final int aWidth, int aHeight, LocalDate aDate) {
+    @SuppressWarnings("this-escape")
+    protected AbstractPicture(final long anID, final String aName, final String aFilePath, final int aWidth, int aHeight, LocalDate aDate) {
         id = anID;
         propertyChangeSupport = new PropertyChangeSupport(AbstractPicture.this);
         persons = new LinkedList<>();

--- a/src/main/java/com/github/noony/app/timelinefx/core/AbstractPicture.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/AbstractPicture.java
@@ -47,6 +47,9 @@ public abstract class AbstractPicture implements IPicture {
      */
     private final PropertyChangeSupport propertyChangeSupport;
 
+    /**
+     * This picture's unique id.
+     */
     private final Long id;
 
     /**
@@ -355,6 +358,8 @@ public abstract class AbstractPicture implements IPicture {
     }
 
     /**
+     * Moves a person up in the persons list.
+     *
      * @param aPerson the person to move up in the persons list
      */
     public void movePersonUp(final Person aPerson) {

--- a/src/main/java/com/github/noony/app/timelinefx/core/AbstractPicture.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/AbstractPicture.java
@@ -99,8 +99,7 @@ public abstract class AbstractPicture implements IPicture {
      */
     private LocalDate date;
 
-    @SuppressWarnings("this-escape")
-    protected AbstractPicture(final long anID, final String aName, final String aFilePath, final int aWidth, int aHeight, LocalDate aDate) {
+    @SuppressWarnings("this-escape") protected AbstractPicture(final long anID, final String aName, final String aFilePath, final int aWidth, int aHeight, LocalDate aDate) {
         id = anID;
         propertyChangeSupport = new PropertyChangeSupport(AbstractPicture.this);
         persons = new LinkedList<>();
@@ -137,8 +136,7 @@ public abstract class AbstractPicture implements IPicture {
         return id;
     }
 
-    @Override
-    public String getName() {
+    @Override public String getName() {
         return name;
     }
 

--- a/src/main/java/com/github/noony/app/timelinefx/core/AnchorSide.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/AnchorSide.java
@@ -25,8 +25,24 @@ package com.github.noony.app.timelinefx.core;
 public enum AnchorSide {
 
     /**
-     * The four cardinal sides, or no anchoring.
+     * The top side.
      */
-    TOP, BOTTOM, LEFT, RIGHT, NONE
+    TOP,
+    /**
+     * The bottom side.
+     */
+    BOTTOM,
+    /**
+     * The left side.
+     */
+    LEFT,
+    /**
+     * The right side.
+     */
+    RIGHT,
+    /**
+     * No anchoring.
+     */
+    NONE
 
 }

--- a/src/main/java/com/github/noony/app/timelinefx/core/DateObject.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/DateObject.java
@@ -108,8 +108,7 @@ public final class DateObject implements IDateObject {
         return timeFormat;
     }
 
-    @Override
-    public void setTimeFormat(final TimeFormat aTimeFormat) {
+    @Override public void setTimeFormat(final TimeFormat aTimeFormat) {
         timeFormat = aTimeFormat;
         switch (timeFormat) {
             case LOCAL_TIME ->

--- a/src/main/java/com/github/noony/app/timelinefx/core/Event.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/Event.java
@@ -90,6 +90,8 @@ public class Event {
     }
 
     /**
+     * Returns this event's raw numeric time value.
+     *
      * @return this event's raw numeric time value
      */
     public long getDate() {

--- a/src/main/java/com/github/noony/app/timelinefx/core/Factory.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/Factory.java
@@ -33,7 +33,7 @@ import java.util.logging.Logger;
 public class Factory<T extends FriezeObject> {
 
     /**
-     * Default logging level to be used when creating an object in a Factory
+     * Default logging level to be used when creating an object in a Factory.
      */
     public static final Level CREATION_LOGGING_LEVEL = Level.FINE;
 
@@ -83,6 +83,7 @@ public class Factory<T extends FriezeObject> {
     }
 
     /**
+     * Returns the next available unique id.
      *
      * @return the next available unique id
      */

--- a/src/main/java/com/github/noony/app/timelinefx/core/Frieze.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/Frieze.java
@@ -450,7 +450,7 @@ public final class Frieze implements FriezeObject {
      * @param aPerson the person whose selection changed
      * @param selected whether the person is now selected
      */
-    public void updatePeopleSelection(final Person aPerson, boolean selected) {
+    public void updatePeopleSelection(final Person aPerson, final boolean selected) {
         LOG.log(Level.INFO, "updatePeopleSelection p:{0}, isSelected:{1}", new Object[]{aPerson, selected});
         if (selected) {
             addPerson(aPerson);

--- a/src/main/java/com/github/noony/app/timelinefx/core/Frieze.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/Frieze.java
@@ -126,6 +126,9 @@ public final class Frieze implements FriezeObject {
      */
     private static final Logger LOG = Logger.getGlobal();
 
+    /**
+     * This frieze's unique id.
+     */
     private final Long id;
 
     /**
@@ -214,11 +217,20 @@ public final class Frieze implements FriezeObject {
     private double maxDateWindow = maxDate;
     //
 
+    /**
+     * The lowest date allowed in the visible date window.
+     */
     private double constraintMinDate = Double.NEGATIVE_INFINITY;
 
+    /**
+     * The highest date allowed in the visible date window.
+     */
     private double constraintMaxDate = Double.POSITIVE_INFINITY;
     //
 
+    /**
+     * How selecting a person or place in this frieze propagates to related items.
+     */
     private ItemSelectionPropagation itemSelectionPropagation = ItemSelectionPropagation.RECURSIVE;
 
     protected Frieze(final long anID, final TimeLineProject aProject, final String friezeName, final List<StayPeriod> staysToConsider) {
@@ -262,6 +274,8 @@ public final class Frieze implements FriezeObject {
     }
 
     /**
+     * Sets this frieze's name.
+     *
      * @param aName this frieze's new name
      */
     public void setName(final String aName) {
@@ -299,12 +313,22 @@ public final class Frieze implements FriezeObject {
         }
     }
 
+    /**
+     * Adds several stays to this frieze.
+     *
+     * @param stays the stays to add
+     */
     public void addAllStays(final StayPeriod... stays) {
         for (StayPeriod s : stays) {
             addStay(s);
         }
     }
 
+    /**
+     * Adds several stays to this frieze.
+     *
+     * @param stays the stays to add
+     */
     public void addAllStays(final Collection<? extends StayPeriod> stays) {
         stays.forEach(this::addStay);
     }
@@ -364,12 +388,22 @@ public final class Frieze implements FriezeObject {
         maxDate = stayPeriods.stream().mapToDouble(StayPeriod::getEndDate).max().orElse(DEFAULT_MAX_DATE);
     }
 
+    /**
+     * Removes several stays from this frieze.
+     *
+     * @param stays the stays to remove
+     */
     public void removeAllStays(final StayPeriod... stays) {
         for (StayPeriod s : stays) {
             removeStay(s);
         }
     }
 
+    /**
+     * Removes several stays from this frieze.
+     *
+     * @param stays the stays to remove
+     */
     public void removeAllStays(final Collection<? extends StayPeriod> stays) {
         stays.forEach(this::removeStay);
     }
@@ -411,6 +445,12 @@ public final class Frieze implements FriezeObject {
         }
     }
 
+    /**
+     * Updates a person's selection state in this frieze.
+     *
+     * @param aPerson the person whose selection changed
+     * @param selected whether the person is now selected
+     */
     public void updatePeopleSelection(final Person aPerson, boolean selected) {
         LOG.log(Level.INFO, "updatePeopleSelection p:{0}, isSelected:{1}", new Object[]{aPerson, selected});
         if (selected) {
@@ -438,6 +478,12 @@ public final class Frieze implements FriezeObject {
         }
     }
 
+    /**
+     * Updates a person's selection state in this frieze.
+     *
+     * @param aPerson the person whose selection changed
+     * @param selected whether the person is now selected
+     */
     public void updatePersonSelection(final Person aPerson, final boolean selected) {
         LOG.log(Level.INFO, "Updating frieze for person: {0}, selected{1}.", new Object[]{aPerson, selected});
         if (selected) {

--- a/src/main/java/com/github/noony/app/timelinefx/core/Frieze.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/Frieze.java
@@ -31,7 +31,7 @@ import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
-import static javafx.application.Platform.runLater;
+import javafx.application.Platform;
 
 /**
  * A subset of a project's places, persons and stays, laid out over a shared time window.
@@ -44,6 +44,7 @@ public final class Frieze implements FriezeObject {
      * Prefix used to namespace this class's property change event names.
      */
     public static final String CLASS_NAME = "Frieze";
+
     /**
      * Name of the property change event fired when the visible date window changes.
      */
@@ -126,6 +127,7 @@ public final class Frieze implements FriezeObject {
     private static final Logger LOG = Logger.getGlobal();
 
     private final Long id;
+
     /**
      * The project this frieze belongs to.
      */
@@ -211,12 +213,15 @@ public final class Frieze implements FriezeObject {
      */
     private double maxDateWindow = maxDate;
     //
+
     private double constraintMinDate = Double.NEGATIVE_INFINITY;
+
     private double constraintMaxDate = Double.POSITIVE_INFINITY;
     //
+
     private ItemSelectionPropagation itemSelectionPropagation = ItemSelectionPropagation.RECURSIVE;
 
-    protected Frieze(final long anID, final TimeLineProject aProject, final String friezeName, List<StayPeriod> staysToConsider) {
+    protected Frieze(final long anID, final TimeLineProject aProject, final String friezeName, final List<StayPeriod> staysToConsider) {
         id = anID;
         project = aProject;
         name = friezeName;
@@ -278,7 +283,7 @@ public final class Frieze implements FriezeObject {
         return project;
     }
 
-    private void addPerson(Person aPerson) {
+    private void addPerson(final Person aPerson) {
         if (!persons.contains(aPerson)) {
             persons.add(aPerson);
             final var stays = project.getStays().stream().filter(s -> s.getPerson() == aPerson).toList();
@@ -290,17 +295,17 @@ public final class Frieze implements FriezeObject {
             // notify place added
             // may be needed before adding stays for some variable updates
             propertyChangeSupport.firePropertyChange(PERSON_ADDED, this, aPerson);
-            runLater(() -> stays.forEach(this::addStay));
+            Platform.runLater(() -> stays.forEach(this::addStay));
         }
     }
 
-    public void addAllStays(StayPeriod... stays) {
+    public void addAllStays(final StayPeriod... stays) {
         for (StayPeriod s : stays) {
             addStay(s);
         }
     }
 
-    public void addAllStays(Collection<? extends StayPeriod> stays) {
+    public void addAllStays(final Collection<? extends StayPeriod> stays) {
         stays.forEach(this::addStay);
     }
 
@@ -309,14 +314,14 @@ public final class Frieze implements FriezeObject {
      *
      * @param stay a stay to be represented in this Frieze
      */
-    public void addStay(StayPeriod stay) {
+    public void addStay(final StayPeriod stay) {
         if (!stayPeriods.contains(stay)) {
             stayPeriods.add(stay);
             //
             stay.addListener(stayChangesListener);
             //
-            var place = stay.getPlace();
-            var person = stay.getPerson();
+            final var place = stay.getPlace();
+            final var person = stay.getPerson();
             // add place
             if (!places.contains(place)) {
                 places.add(place);
@@ -359,13 +364,13 @@ public final class Frieze implements FriezeObject {
         maxDate = stayPeriods.stream().mapToDouble(StayPeriod::getEndDate).max().orElse(DEFAULT_MAX_DATE);
     }
 
-    public void removeAllStays(StayPeriod... stays) {
+    public void removeAllStays(final StayPeriod... stays) {
         for (StayPeriod s : stays) {
             removeStay(s);
         }
     }
 
-    public void removeAllStays(Collection<? extends StayPeriod> stays) {
+    public void removeAllStays(final Collection<? extends StayPeriod> stays) {
         stays.forEach(this::removeStay);
     }
 
@@ -406,7 +411,7 @@ public final class Frieze implements FriezeObject {
         }
     }
 
-    public void updatePeopleSelection(Person aPerson, boolean selected) {
+    public void updatePeopleSelection(final Person aPerson, boolean selected) {
         LOG.log(Level.INFO, "updatePeopleSelection p:{0}, isSelected:{1}", new Object[]{aPerson, selected});
         if (selected) {
             addPerson(aPerson);
@@ -647,16 +652,16 @@ public final class Frieze implements FriezeObject {
             case TimeLineProject.PERSON_ADDED, TimeLineProject.STAY_ADDED -> {
                 // Nothing to do
             }
-//            case TimeLineProject.STAY_ADDED ->
-//                addStay((StayPeriod) event.getNewValue());
+            //            case TimeLineProject.STAY_ADDED ->
+            //                addStay((StayPeriod) event.getNewValue());
             case TimeLineProject.STAY_REMOVED ->
                 removeStay((StayPeriod) event.getNewValue());
             case TimeLineProject.PLACE_REMOVED -> {
-                var placeRemoved = (Place) event.getNewValue();
+                final var placeRemoved = (Place) event.getNewValue();
                 removePlace(placeRemoved);
             }
             case TimeLineProject.PERSON_REMOVED -> {
-                var personRemoved = (Person) event.getNewValue();
+                final var personRemoved = (Person) event.getNewValue();
                 removePerson(personRemoved);
             }
             default ->
@@ -677,7 +682,7 @@ public final class Frieze implements FriezeObject {
                 // First update the relevant dates before notifying of the stay change
                 updateDatesOnRemoval((long) event.getOldValue(), false);
                 updateDatesOnCreation((long) event.getNewValue(), false);
-                var stay = (StayPeriod) event.getSource();
+                final var stay = (StayPeriod) event.getSource();
                 propertyChangeSupport.firePropertyChange(STAY_UPDATED, this, stay);
             }
             default ->
@@ -698,7 +703,7 @@ public final class Frieze implements FriezeObject {
 
     private boolean removePerson(final Person personRemoved) {
         LOG.log(Level.INFO, "Removing person: {0} from {1}.", new Object[]{personRemoved, this});
-        var removed = persons.remove(personRemoved);
+        final var removed = persons.remove(personRemoved);
         if (!removed) {
             return false;
         }

--- a/src/main/java/com/github/noony/app/timelinefx/core/Frieze.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/Frieze.java
@@ -257,8 +257,7 @@ public final class Frieze implements FriezeObject {
         staysToConsider.stream().forEachOrdered(Frieze.this::addStay);
     }
 
-    @Override
-    public long getId() {
+    @Override public long getId() {
         return id;
     }
 

--- a/src/main/java/com/github/noony/app/timelinefx/core/Frieze.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/Frieze.java
@@ -514,7 +514,7 @@ public final class Frieze implements FriezeObject {
      * @param listener the listener to remove
      */
     public void removeListener(final PropertyChangeListener listener) {
-        propertyChangeSupport.addPropertyChangeListener(listener);
+        propertyChangeSupport.removePropertyChangeListener(listener);
     }
 
     /**

--- a/src/main/java/com/github/noony/app/timelinefx/core/FriezeFactory.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/FriezeFactory.java
@@ -19,7 +19,6 @@ package com.github.noony.app.timelinefx.core;
 
 import java.util.List;
 import java.util.logging.Logger;
-import static com.github.noony.app.timelinefx.core.Factory.CREATION_LOGGING_LEVEL;
 
 /**
  * Entry point for creating and retrieving {@link Frieze} instances.
@@ -73,7 +72,7 @@ public final class FriezeFactory {
      * @return the created frieze
      */
     public static Frieze createFrieze(final TimeLineProject aProject, final String friezeName, final List<StayPeriod> staysToConsider) {
-        LOG.log(CREATION_LOGGING_LEVEL, "Creating a frieze with TimeLineProject={0} friezeName={1} staysToConsider={2} ", new Object[]{aProject.getName(), friezeName, staysToConsider});
+        LOG.log(Factory.CREATION_LOGGING_LEVEL, "Creating a frieze with TimeLineProject={0} friezeName={1} staysToConsider={2} ", new Object[]{aProject.getName(), friezeName, staysToConsider});
         final var frieze = new Frieze(FACTORY.getNextID(), aProject, friezeName, staysToConsider);
         FACTORY.addObject(frieze);
         return frieze;
@@ -88,11 +87,11 @@ public final class FriezeFactory {
      * @param staysToConsider the stays to include in the frieze
      * @return the created frieze
      */
-    public static Frieze createFrieze(final long anID, final TimeLineProject aProject, final String friezeName, List<StayPeriod> staysToConsider) {
+    public static Frieze createFrieze(final long anID, final TimeLineProject aProject, final String friezeName, final List<StayPeriod> staysToConsider) {
         if (!FACTORY.isIdAvailable(anID)) {
             throw new IllegalArgumentException("trying to create a frieze " + friezeName + " with existing id=" + anID);
         }
-        LOG.log(CREATION_LOGGING_LEVEL, "Creating a frieze (id={0} with TimeLineProject={1} friezeName={2} staysToConsider={3} ", new Object[]{anID, aProject.getName(), friezeName, staysToConsider});
+        LOG.log(Factory.CREATION_LOGGING_LEVEL, "Creating a frieze (id={0} with TimeLineProject={1} friezeName={2} staysToConsider={3} ", new Object[]{anID, aProject.getName(), friezeName, staysToConsider});
         final var frieze = new Frieze(anID, aProject, friezeName, staysToConsider);
         FACTORY.addObject(frieze);
         return frieze;
@@ -106,7 +105,7 @@ public final class FriezeFactory {
      * @return the created frieze
      */
     public static Frieze createFrieze(final TimeLineProject aProject, final String friezeName) {
-        LOG.log(CREATION_LOGGING_LEVEL, "Creating a frieze with TimeLineProject={0} friezeName={1}", new Object[]{aProject.getName(), friezeName});
+        LOG.log(Factory.CREATION_LOGGING_LEVEL, "Creating a frieze with TimeLineProject={0} friezeName={1}", new Object[]{aProject.getName(), friezeName});
         final var frieze = new Frieze(FACTORY.getNextID(), aProject, friezeName);
         FACTORY.addObject(frieze);
         return frieze;

--- a/src/main/java/com/github/noony/app/timelinefx/core/FriezeFactory.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/FriezeFactory.java
@@ -49,6 +49,8 @@ public final class FriezeFactory {
     }
 
     /**
+     * Returns all the friezes created so far.
+     *
      * @return all the friezes created so far
      */
     public static List<Frieze> getFriezes() {

--- a/src/main/java/com/github/noony/app/timelinefx/core/FriezeObject.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/FriezeObject.java
@@ -30,7 +30,7 @@ public interface FriezeObject {
     long NO_ID = -1;
 
     /**
-     * Each IFriezeObject instance has a unique id in its project's scope
+     * Each IFriezeObject instance has a unique id in its project's scope.
      *
      * @return the object unique ID
      */

--- a/src/main/java/com/github/noony/app/timelinefx/core/FriezeObjectFactory.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/FriezeObjectFactory.java
@@ -32,7 +32,7 @@ public final class FriezeObjectFactory {
     /**
      * Resets all the factories and restarts the unique ID counter to 0.
      */
-    public static final void reset() {
+    public static void reset() {
         //
         PlaceFactory.reset();
         PersonFactory.reset();

--- a/src/main/java/com/github/noony/app/timelinefx/core/IDateObject.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/IDateObject.java
@@ -40,7 +40,7 @@ public interface IDateObject {
     DateTimeFormatter DEFAULT_DATE_TIME_FORMATTER = DateTimeFormatter.ISO_DATE_TIME;
 
     /**
-     * The default time stamp
+     * The default time stamp.
      */
     long DEFAULT_TIMESTAMP = 0;
 
@@ -50,7 +50,6 @@ public interface IDateObject {
     String DATE_CHANGED = "pictureDateChanged";
 
     /**
-     *
      * @return the TimeFormat used by the instance
      */
     TimeFormat getTimeFormat();

--- a/src/main/java/com/github/noony/app/timelinefx/core/IDrawableObject.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/IDrawableObject.java
@@ -25,6 +25,7 @@ package com.github.noony.app.timelinefx.core;
 public interface IDrawableObject {
 
     /**
+     * Returns the object's width.
      *
      * @return the object's width
      */

--- a/src/main/java/com/github/noony/app/timelinefx/core/IFileObject.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/IFileObject.java
@@ -25,6 +25,8 @@ package com.github.noony.app.timelinefx.core;
 public interface IFileObject extends FriezeObject {
 
     /**
+     * Returns the object's display name.
+     *
      * @return the object's display name
      */
     String getName();

--- a/src/main/java/com/github/noony/app/timelinefx/core/IPicture.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/IPicture.java
@@ -28,7 +28,7 @@ import java.util.List;
 public interface IPicture extends IDateObject, IFileObject, IDrawableObject {
 
     /**
-     * Name of the property change event for name change
+     * Name of the property change event for name change.
      */
     String NAME_CHANGED = "pictureNameChanged";
 

--- a/src/main/java/com/github/noony/app/timelinefx/core/ItemSelectionPropagation.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/ItemSelectionPropagation.java
@@ -24,7 +24,11 @@ package com.github.noony.app.timelinefx.core;
  */
 public enum ItemSelectionPropagation {
     /**
-     * Selection does not propagate, or propagates to related items.
+     * Selection does not propagate to related items.
      */
-    NONE, RECURSIVE
+    NONE,
+    /**
+     * Selection propagates to related items.
+     */
+    RECURSIVE
 }

--- a/src/main/java/com/github/noony/app/timelinefx/core/Person.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/Person.java
@@ -44,22 +44,27 @@ public final class Person implements FriezeObject {
      * Name of the property change event fired when this person's selection changes.
      */
     public static final String SELECTION_CHANGED = "selectionChanged";
+
     /**
      * Name of the property change event fired when this person's visibility changes.
      */
     public static final String VISIBILITY_CHANGED = "visibilityChanged";
+
     /**
      * Name of the property change event fired when this person's name changes.
      */
     public static final String NAME_CHANGED = "nameChanged";
+
     /**
      * Name of the property change event fired when this person's date of birth changes.
      */
     public static final String DATE_OF_BIRTH_CHANGED = "dateOfBirthChanged";
+
     /**
      * Name of the property change event fired when this person's date of death changes.
      */
     public static final String DATE_OF_DEATH_CHANGED = "dateOfDeathChanged";
+
     /**
      * Name of the property change event fired when this person's color changes.
      */
@@ -105,6 +110,7 @@ public final class Person implements FriezeObject {
      */
     private final PropertyChangeSupport propertyChangeSupport;
     //
+
     private final Long id;
     //
 
@@ -171,7 +177,7 @@ public final class Person implements FriezeObject {
      */
     private boolean visible;
 
-    protected Person(final TimeLineProject aProject, final Long personId, final String personName, Color aColor, LocalDate aDoB, LocalDate aDoD) {
+    protected Person(final TimeLineProject aProject, final Long personId, final String personName, final Color aColor, LocalDate aDoB, LocalDate aDoD) {
         id = personId;
         project = aProject;
         portraits = new LinkedList<>();
@@ -185,7 +191,7 @@ public final class Person implements FriezeObject {
         visible = true;
     }
 
-    protected Person(final TimeLineProject aProject, final Long personId, final String personName, Color aColor, long aToB, long aToD) {
+    protected Person(final TimeLineProject aProject, final Long personId, final String personName, final Color aColor, long aToB, long aToD) {
         id = personId;
         project = aProject;
         portraits = new LinkedList<>();
@@ -263,7 +269,7 @@ public final class Person implements FriezeObject {
         return Collections.unmodifiableList(portraits);
     }
 
-    public Portrait getPortrait(long aPortraiID) {
+    public Portrait getPortrait(final long aPortraiID) {
         return portraits.stream().filter(p -> p.getId() == aPortraiID).findAny().orElse(null);
     }
 

--- a/src/main/java/com/github/noony/app/timelinefx/core/Person.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/Person.java
@@ -199,7 +199,7 @@ public final class Person implements FriezeObject {
         visible = true;
     }
 
-    protected Person(final TimeLineProject aProject, final Long personId, final String personName, final Color aColor, long aToB, long aToD) {
+    protected Person(final TimeLineProject aProject, final Long personId, final String personName, final Color aColor, final long aToB, long aToD) {
         id = personId;
         project = aProject;
         portraits = new LinkedList<>();

--- a/src/main/java/com/github/noony/app/timelinefx/core/Person.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/Person.java
@@ -106,6 +106,11 @@ public final class Person implements FriezeObject {
     private static final long DEFAULT_TIME = -1;
 
     /**
+     * Prefix of the exception message thrown for an unrecognized time format.
+     */
+    private static final String UNSUPPORTED_TIME_MODE_MESSAGE = "Unsupported time mode : ";
+
+    /**
      * Support object used to fire property change events.
      */
     private final PropertyChangeSupport propertyChangeSupport;
@@ -393,7 +398,7 @@ public final class Person implements FriezeObject {
                 return timeOfBirth;
             }
             default ->
-                throw new UnsupportedOperationException("Unsupported time mode : " + timeFormat);
+                throw new UnsupportedOperationException(UNSUPPORTED_TIME_MODE_MESSAGE + timeFormat);
         }
     }
 
@@ -413,7 +418,7 @@ public final class Person implements FriezeObject {
                 return timeOfDeath;
             }
             default ->
-                throw new UnsupportedOperationException("Unsupported time mode : " + timeFormat);
+                throw new UnsupportedOperationException(UNSUPPORTED_TIME_MODE_MESSAGE + timeFormat);
         }
     }
 

--- a/src/main/java/com/github/noony/app/timelinefx/core/Person.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/Person.java
@@ -111,6 +111,9 @@ public final class Person implements FriezeObject {
     private final PropertyChangeSupport propertyChangeSupport;
     //
 
+    /**
+     * This person's unique id.
+     */
     private final Long id;
     //
 
@@ -214,6 +217,8 @@ public final class Person implements FriezeObject {
     }
 
     /**
+     * Returns the project this person belongs to.
+     *
      * @return the project this person belongs to
      */
     public TimeLineProject getProject() {
@@ -269,6 +274,12 @@ public final class Person implements FriezeObject {
         return Collections.unmodifiableList(portraits);
     }
 
+    /**
+     * Returns this person's portrait with the given id.
+     *
+     * @param aPortraiID a portrait's id
+     * @return the matching portrait, or null if none exists
+     */
     public Portrait getPortrait(final long aPortraiID) {
         return portraits.stream().filter(p -> p.getId() == aPortraiID).findAny().orElse(null);
     }

--- a/src/main/java/com/github/noony/app/timelinefx/core/Person.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/Person.java
@@ -507,8 +507,7 @@ public final class Person implements FriezeObject {
         return visible;
     }
 
-    @Override
-    public String toString() {
+    @Override public String toString() {
         return name;
     }
 

--- a/src/main/java/com/github/noony/app/timelinefx/core/Person.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/Person.java
@@ -199,7 +199,7 @@ public final class Person implements FriezeObject {
         visible = true;
     }
 
-    protected Person(final TimeLineProject aProject, final Long personId, final String personName, final Color aColor, final long aToB, long aToD) {
+    protected Person(final TimeLineProject aProject, final Long personId, final String personName, final Color aColor, final long aToB, final long aToD) {
         id = personId;
         project = aProject;
         portraits = new LinkedList<>();

--- a/src/main/java/com/github/noony/app/timelinefx/core/PersonFactory.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/PersonFactory.java
@@ -20,7 +20,6 @@ package com.github.noony.app.timelinefx.core;
 import java.util.List;
 import java.util.logging.Logger;
 import javafx.scene.paint.Color;
-import static com.github.noony.app.timelinefx.core.Factory.CREATION_LOGGING_LEVEL;
 
 /**
  * Entry point for creating and retrieving {@link Person} instances.
@@ -66,7 +65,7 @@ public final class PersonFactory {
      * @return the created person
      */
     public static Person createPerson(final TimeLineProject project, final String personName) {
-        LOG.log(CREATION_LOGGING_LEVEL, "Creating person with personName={0}  ", new Object[]{personName});
+        LOG.log(Factory.CREATION_LOGGING_LEVEL, "Creating person with personName={0}  ", new Object[]{personName});
         final var person = new Person(project, FACTORY.getNextID(), personName);
         FACTORY.addObject(person);
         return person;
@@ -81,7 +80,7 @@ public final class PersonFactory {
      * @return the created person
      */
     public static Person createPerson(final TimeLineProject project, final String personName, final Color color) {
-        LOG.log(CREATION_LOGGING_LEVEL, "Creating person with personName={0} color={1} ", new Object[]{personName, color});
+        LOG.log(Factory.CREATION_LOGGING_LEVEL, "Creating person with personName={0} color={1} ", new Object[]{personName, color});
         final var person = new Person(project, FACTORY.getNextID(), personName, color, null, null);
         FACTORY.addObject(person);
         return person;
@@ -96,8 +95,8 @@ public final class PersonFactory {
      * @param color the person's color
      * @return the created person
      */
-    public static Person createPerson(final TimeLineProject project, final long id, final String personName, Color color) {
-        LOG.log(CREATION_LOGGING_LEVEL, "Creating person with id={0} personName={1} color={2}", new Object[]{id, personName, color});
+    public static Person createPerson(final TimeLineProject project, final long id, final String personName, final Color color) {
+        LOG.log(Factory.CREATION_LOGGING_LEVEL, "Creating person with id={0} personName={1} color={2}", new Object[]{id, personName, color});
         if (!FACTORY.isIdAvailable(id)) {
             throw new IllegalArgumentException("trying to create person " + personName + " with existing id=" + id + " (exists : " + FACTORY.get(id) + "[" + FACTORY.get(id).getId() + "])");
         }

--- a/src/main/java/com/github/noony/app/timelinefx/core/PersonFactory.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/PersonFactory.java
@@ -50,6 +50,8 @@ public final class PersonFactory {
     }
 
     /**
+     * Returns the person with the given id.
+     *
      * @param id a person's id
      * @return the person with the given id, or null if none exists
      */

--- a/src/main/java/com/github/noony/app/timelinefx/core/Picture.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/Picture.java
@@ -31,7 +31,7 @@ public class Picture extends AbstractPicture {
      */
     private final TimeLineProject project;
 
-    protected Picture(final TimeLineProject aProject, final long id, final String pictureName, LocalDate pictureCreationDate, String picturePath, int pictureWidth, int pictureHeight) {
+    protected Picture(final TimeLineProject aProject, final long id, final String pictureName, final LocalDate pictureCreationDate, String picturePath, int pictureWidth, int pictureHeight) {
         super(id, pictureName, picturePath, pictureWidth, pictureHeight, pictureCreationDate);
         project = aProject;
     }

--- a/src/main/java/com/github/noony/app/timelinefx/core/Picture.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/Picture.java
@@ -40,8 +40,7 @@ public class Picture extends AbstractPicture {
         return project;
     }
 
-    @Override
-    public String toString() {
+    @Override public String toString() {
         return "Pic[" + getName() + "]";
     }
 

--- a/src/main/java/com/github/noony/app/timelinefx/core/PictureFactory.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/PictureFactory.java
@@ -67,6 +67,8 @@ public final class PictureFactory {
     }
 
     /**
+     * Returns all created pictures.
+     *
      * @return all created pictures
      */
     public static List<Picture> getPictures() {

--- a/src/main/java/com/github/noony/app/timelinefx/core/PictureFactory.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/PictureFactory.java
@@ -27,7 +27,6 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.apache.commons.io.FileUtils;
-import static com.github.noony.app.timelinefx.core.Factory.CREATION_LOGGING_LEVEL;
 
 /**
  * Entry point for creating and retrieving {@link Picture} instances.
@@ -91,13 +90,13 @@ public final class PictureFactory {
      * @return the created picture
      */
     public static Picture createPicture(final TimeLineProject project, final File originalPictureFile, final String pictureName) {
-        LOG.log(CREATION_LOGGING_LEVEL, "Creating picture with pictureName={0} file={1}", new Object[]{pictureName, originalPictureFile});
+        LOG.log(Factory.CREATION_LOGGING_LEVEL, "Creating picture with pictureName={0} file={1}", new Object[]{pictureName, originalPictureFile});
         final File pictureFile;
         pictureFile = new File(project.getPicturesFolder(), originalPictureFile.getName());
         if (!pictureFile.exists()) {
             try {
                 FileUtils.copyFile(originalPictureFile, pictureFile);
-                LOG.log(CREATION_LOGGING_LEVEL, "Copying picture file to: {0}", new Object[]{pictureFile});
+                LOG.log(Factory.CREATION_LOGGING_LEVEL, "Copying picture file to: {0}", new Object[]{pictureFile});
             } catch (IOException ex) {
                 LOG.log(Level.SEVERE, "Error while copying picture file to: {0} : {1}", new Object[]{pictureFile, ex});
             }
@@ -122,8 +121,8 @@ public final class PictureFactory {
      * @param pictureHeight the picture's height
      * @return the created picture
      */
-    public static Picture createPicture(final TimeLineProject project, final long id, final String pictureName, LocalDateTime pictureCreationDate, String picturePath, int pictureWidth, int pictureHeight) {
-        LOG.log(CREATION_LOGGING_LEVEL, "Creating picture with id={0} pictureName={1}", new Object[]{id, pictureName});
+    public static Picture createPicture(final TimeLineProject project, final long id, final String pictureName, final LocalDateTime pictureCreationDate, String picturePath, int pictureWidth, int pictureHeight) {
+        LOG.log(Factory.CREATION_LOGGING_LEVEL, "Creating picture with id={0} pictureName={1}", new Object[]{id, pictureName});
         if (!FACTORY.isIdAvailable(id)) {
             throw new IllegalArgumentException("Trying to create picture " + pictureName + " with existing id=" + id + " :: " + FACTORY.get(id));
         }

--- a/src/main/java/com/github/noony/app/timelinefx/core/PictureFactory.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/PictureFactory.java
@@ -123,7 +123,7 @@ public final class PictureFactory {
      * @param pictureHeight the picture's height
      * @return the created picture
      */
-    public static Picture createPicture(final TimeLineProject project, final long id, final String pictureName, final LocalDateTime pictureCreationDate, String picturePath, int pictureWidth, int pictureHeight) {
+    public static Picture createPicture(final TimeLineProject project, final long id, final String pictureName, final LocalDateTime pictureCreationDate, final String picturePath, int pictureWidth, int pictureHeight) {
         LOG.log(Factory.CREATION_LOGGING_LEVEL, "Creating picture with id={0} pictureName={1}", new Object[]{id, pictureName});
         if (!FACTORY.isIdAvailable(id)) {
             throw new IllegalArgumentException("Trying to create picture " + pictureName + " with existing id=" + id + " :: " + FACTORY.get(id));

--- a/src/main/java/com/github/noony/app/timelinefx/core/PictureFactory.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/PictureFactory.java
@@ -123,7 +123,7 @@ public final class PictureFactory {
      * @param pictureHeight the picture's height
      * @return the created picture
      */
-    public static Picture createPicture(final TimeLineProject project, final long id, final String pictureName, final LocalDateTime pictureCreationDate, final String picturePath, int pictureWidth, int pictureHeight) {
+    public static Picture createPicture(final TimeLineProject project, final long id, final String pictureName, final LocalDateTime pictureCreationDate, final String picturePath, final int pictureWidth, int pictureHeight) {
         LOG.log(Factory.CREATION_LOGGING_LEVEL, "Creating picture with id={0} pictureName={1}", new Object[]{id, pictureName});
         if (!FACTORY.isIdAvailable(id)) {
             throw new IllegalArgumentException("Trying to create picture " + pictureName + " with existing id=" + id + " :: " + FACTORY.get(id));

--- a/src/main/java/com/github/noony/app/timelinefx/core/PictureInfo.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/PictureInfo.java
@@ -43,18 +43,18 @@ public class PictureInfo {
     /**
      * Creates picture metadata with the given fields.
      *
-     * @param name the picture's name
-     * @param path the picture file's path
-     * @param creationDate the picture's creation date
-     * @param width the picture's width
-     * @param height the picture's height
+     * @param aName the picture's name
+     * @param aPath the picture file's path
+     * @param aCreationDate the picture's creation date
+     * @param aWidth the picture's width
+     * @param aHeight the picture's height
      */
-    public PictureInfo(final String name, final String path, final LocalDateTime creationDate, final int width, int height) {
-        this.name = name;
-        this.path = path;
-        this.creationDate = creationDate;
-        this.width = width;
-        this.height = height;
+    public PictureInfo(final String aName, final String aPath, final LocalDateTime aCreationDate, final int aWidth, final int aHeight) {
+        name = aName;
+        path = aPath;
+        creationDate = aCreationDate;
+        width = aWidth;
+        height = aHeight;
     }
 
     /**

--- a/src/main/java/com/github/noony/app/timelinefx/core/PictureInfo.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/PictureInfo.java
@@ -47,7 +47,7 @@ public class PictureInfo {
      * @param width the picture's width
      * @param height the picture's height
      */
-    public PictureInfo(final String name, final String path, final LocalDateTime creationDate, int width, int height) {
+    public PictureInfo(final String name, final String path, final LocalDateTime creationDate, final int width, int height) {
         this.name = name;
         this.path = path;
         this.creationDate = creationDate;

--- a/src/main/java/com/github/noony/app/timelinefx/core/PictureInfo.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/PictureInfo.java
@@ -41,6 +41,8 @@ public class PictureInfo {
     private final int height;
 
     /**
+     * Creates picture metadata with the given fields.
+     *
      * @param name the picture's name
      * @param path the picture file's path
      * @param creationDate the picture's creation date

--- a/src/main/java/com/github/noony/app/timelinefx/core/Place.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/Place.java
@@ -59,6 +59,9 @@ public final class Place implements FriezeObject {
      */
     private static final Logger LOG = Logger.getGlobal();
 
+    /**
+     * This place's unique id.
+     */
     private final Long id;
 
     /**
@@ -131,6 +134,8 @@ public final class Place implements FriezeObject {
     }
 
     /**
+     * Adds a listener notified of this place's changes.
+     *
      * @param listener the listener to add
      */
     public void addPropertyChangeListener(final PropertyChangeListener listener) {
@@ -270,6 +275,12 @@ public final class Place implements FriezeObject {
     }
 
 
+    /**
+     * Checks whether this place's level is lower than or equal to another place's level.
+     *
+     * @param anotherPlace the place to compare with, may be null
+     * @return true if this place's level is lower than or equal to {@code anotherPlace}'s, or if {@code anotherPlace} is null
+     */
     public boolean isLowerThanOrLeveled(final Place anotherPlace) {
         if (level == null) {
             return false;
@@ -280,6 +291,12 @@ public final class Place implements FriezeObject {
         }
     }
 
+    /**
+     * Checks whether this place contains another place, directly or through a nested child.
+     *
+     * @param anotherPlace the place to check, may be null
+     * @return true if {@code anotherPlace} is this place or one of its descendants
+     */
     public boolean encompasses(final Place anotherPlace) {
         if (anotherPlace == null || level.getLevelValue() < anotherPlace.level.getLevelValue()) {
             return false;

--- a/src/main/java/com/github/noony/app/timelinefx/core/Place.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/Place.java
@@ -14,7 +14,6 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-
 package com.github.noony.app.timelinefx.core;
 
 import java.beans.PropertyChangeListener;
@@ -26,6 +25,7 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javafx.scene.paint.Color;
+import lombok.NonNull;
 
 /**
  * A named location, optionally nested under a parent place (e.g. a town within a country).
@@ -92,6 +92,7 @@ public final class Place implements FriezeObject {
     /**
      * This place's nesting level.
      */
+    @NonNull
     private PlaceLevel level;
 
     /**
@@ -120,14 +121,19 @@ public final class Place implements FriezeObject {
         id = placeId;
         name = placeName;
         parent = parentPlace;
-        level = placeLevel;
+        if (placeLevel == null) {
+            level = PlaceLevel.ROOT;
+            isRootPlace = true;
+        } else {
+            level = placeLevel;
+            isRootPlace = parentPlace == null || PlaceFactory.PLACES_PLACE.equals(parentPlace);
+        }
         places = new LinkedList<>();
         color = aColor;
         //
         if (parentPlace != null) {
             parentPlace.addPlace(Place.this);
         }
-        isRootPlace = parentPlace == null || PlaceFactory.PLACES_PLACE.equals(parentPlace);
         propertyChangeSupport = new PropertyChangeSupport(Place.this);
         selected = false;
         if (!isLowerThanOrLeveled(parent)) {
@@ -148,7 +154,8 @@ public final class Place implements FriezeObject {
         this(placeId, placeName, placeLevel, parentPlace, DEFAULT_COLOR);
     }
 
-    @Override public long getId() {
+    @Override
+    public long getId() {
         return id;
     }
 
@@ -281,7 +288,8 @@ public final class Place implements FriezeObject {
         propertyChangeSupport.firePropertyChange(CONTENT_CHANGED, null, this);
     }
 
-    @Override public String toString() {
+    @Override
+    public String toString() {
         return name;
     }
 
@@ -292,7 +300,6 @@ public final class Place implements FriezeObject {
         return selected;
     }
 
-
     /**
      * Checks whether this place's level is lower than or equal to another place's level.
      *
@@ -300,9 +307,7 @@ public final class Place implements FriezeObject {
      * @return true if this place's level is lower than or equal to {@code anotherPlace}'s, or if {@code anotherPlace} is null
      */
     public boolean isLowerThanOrLeveled(final Place anotherPlace) {
-        if (level == null) {
-            return false;
-        } else if (anotherPlace == null) {
+        if (anotherPlace == null) {
             return true;
         } else {
             return level.getLevelValue() <= anotherPlace.level.getLevelValue();

--- a/src/main/java/com/github/noony/app/timelinefx/core/Place.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/Place.java
@@ -60,6 +60,11 @@ public final class Place implements FriezeObject {
     private static final Logger LOG = Logger.getGlobal();
 
     /**
+     * Fragment used to render a place's level in exception messages.
+     */
+    private static final String LEVEL_MESSAGE_FRAGMENT = "' (lvl ";
+
+    /**
      * This place's unique id.
      */
     private final Long id;
@@ -121,7 +126,7 @@ public final class Place implements FriezeObject {
         propertyChangeSupport = new PropertyChangeSupport(Place.this);
         selected = false;
         if (!isLowerThanOrLeveled(parent)) {
-            throw new IllegalStateException("For place '" + name + "' (lvl " + level + ") is greater or equal than its parent place '" + (parent != null ? parent.name : "null") + "' (lvl " + (parent != null ? parent.level : "null") + ")");
+            throw new IllegalStateException("For place '" + name + LEVEL_MESSAGE_FRAGMENT + level + ") is greater or equal than its parent place '" + (parent != null ? parent.name : "null") + LEVEL_MESSAGE_FRAGMENT + (parent != null ? parent.level : "null") + ")");
         }
     }
 

--- a/src/main/java/com/github/noony/app/timelinefx/core/Place.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/Place.java
@@ -92,8 +92,7 @@ public final class Place implements FriezeObject {
     /**
      * This place's nesting level.
      */
-    @NonNull
-    private PlaceLevel level;
+    @NonNull private PlaceLevel level;
 
     /**
      * Whether this place has no parent (or its parent is the implicit root place).

--- a/src/main/java/com/github/noony/app/timelinefx/core/Place.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/Place.java
@@ -65,6 +65,11 @@ public final class Place implements FriezeObject {
     private static final String LEVEL_MESSAGE_FRAGMENT = "' (lvl ";
 
     /**
+     * Placeholder used in exception messages when there is no parent place to describe.
+     */
+    private static final String NULL_PLACEHOLDER = "null";
+
+    /**
      * This place's unique id.
      */
     private final Long id;
@@ -111,7 +116,7 @@ public final class Place implements FriezeObject {
     private boolean selected;
     //
 
-    protected Place(final long placeId, final String placeName, final PlaceLevel placeLevel, final Place parentPlace, Color aColor) {
+    protected Place(final long placeId, final String placeName, final PlaceLevel placeLevel, final Place parentPlace, final Color aColor) {
         id = placeId;
         name = placeName;
         parent = parentPlace;
@@ -126,7 +131,16 @@ public final class Place implements FriezeObject {
         propertyChangeSupport = new PropertyChangeSupport(Place.this);
         selected = false;
         if (!isLowerThanOrLeveled(parent)) {
-            throw new IllegalStateException("For place '" + name + LEVEL_MESSAGE_FRAGMENT + level + ") is greater or equal than its parent place '" + (parent != null ? parent.name : "null") + LEVEL_MESSAGE_FRAGMENT + (parent != null ? parent.level : "null") + ")");
+            final String parentName;
+            final Object parentLevel;
+            if (parent == null) {
+                parentName = NULL_PLACEHOLDER;
+                parentLevel = NULL_PLACEHOLDER;
+            } else {
+                parentName = parent.name;
+                parentLevel = parent.level;
+            }
+            throw new IllegalStateException("For place '" + name + LEVEL_MESSAGE_FRAGMENT + level + ") is greater or equal than its parent place '" + parentName + LEVEL_MESSAGE_FRAGMENT + parentLevel + ")");
         }
     }
 

--- a/src/main/java/com/github/noony/app/timelinefx/core/Place.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/Place.java
@@ -262,8 +262,7 @@ public final class Place implements FriezeObject {
         propertyChangeSupport.firePropertyChange(CONTENT_CHANGED, null, this);
     }
 
-    @Override
-    public String toString() {
+    @Override public String toString() {
         return name;
     }
 

--- a/src/main/java/com/github/noony/app/timelinefx/core/Place.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/Place.java
@@ -38,6 +38,7 @@ public final class Place implements FriezeObject {
      * Name of the property change event fired when this place's selection changes.
      */
     public static final String SELECTION_CHANGED = "selectionChanged";
+
     /**
      * Name of the property change event fired when this place's content (name, level, color, parent) changes.
      */
@@ -59,6 +60,7 @@ public final class Place implements FriezeObject {
     private static final Logger LOG = Logger.getGlobal();
 
     private final Long id;
+
     /**
      * The places directly nested under this one.
      */
@@ -101,7 +103,7 @@ public final class Place implements FriezeObject {
     private boolean selected;
     //
 
-    protected Place(final long placeId, final String placeName, final PlaceLevel placeLevel, Place parentPlace, Color aColor) {
+    protected Place(final long placeId, final String placeName, final PlaceLevel placeLevel, final Place parentPlace, Color aColor) {
         id = placeId;
         name = placeName;
         parent = parentPlace;
@@ -120,7 +122,7 @@ public final class Place implements FriezeObject {
         }
     }
 
-    protected Place(final long placeId, final String placeName, final PlaceLevel placeLevel, Place parentPlace) {
+    protected Place(final long placeId, final String placeName, final PlaceLevel placeLevel, final Place parentPlace) {
         this(placeId, placeName, placeLevel, parentPlace, DEFAULT_COLOR);
     }
 
@@ -220,7 +222,7 @@ public final class Place implements FriezeObject {
         return Collections.unmodifiableList(places);
     }
 
-    private boolean addPlace(Place place) {
+    private boolean addPlace(final Place place) {
         if (place.getLevel().getLevelValue() < level.getLevelValue()) {
             places.add(place);
             propertyChangeSupport.firePropertyChange(CONTENT_CHANGED, null, this);
@@ -268,7 +270,7 @@ public final class Place implements FriezeObject {
     }
 
 
-    public final boolean isLowerThanOrLeveled(Place anotherPlace) {
+    public boolean isLowerThanOrLeveled(final Place anotherPlace) {
         if (level == null) {
             return false;
         } else if (anotherPlace == null) {
@@ -278,7 +280,7 @@ public final class Place implements FriezeObject {
         }
     }
 
-    public final boolean encompasses(Place anotherPlace) {
+    public boolean encompasses(final Place anotherPlace) {
         if (anotherPlace == null || level.getLevelValue() < anotherPlace.level.getLevelValue()) {
             return false;
         }

--- a/src/main/java/com/github/noony/app/timelinefx/core/PlaceFactory.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/PlaceFactory.java
@@ -34,7 +34,7 @@ public final class PlaceFactory {
     /**
      * The implicit root place all top-level places are attached to.
      */
-    public static final Place PLACES_PLACE = new Place(-1, "PLACES", PlaceLevel.UNIVERSE, null);
+    public static final Place PLACES_PLACE = new Place(-1, "PLACES", PlaceLevel.ROOT, null);
 
     /**
      * Logger used by this factory.

--- a/src/main/java/com/github/noony/app/timelinefx/core/PlaceFactory.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/PlaceFactory.java
@@ -136,7 +136,7 @@ public final class PlaceFactory {
      * @param color the place's color
      * @return the created place
      */
-    public static Place createPlace(final long id, final String placeName, final PlaceLevel placeLevel, final Place parentPlace, Color color) {
+    public static Place createPlace(final long id, final String placeName, final PlaceLevel placeLevel, final Place parentPlace, final Color color) {
         if (!FACTORY.isIdAvailable(id)) {
             throw new IllegalArgumentException("trying to create place " + placeName + " with existing id=" + id);
         }

--- a/src/main/java/com/github/noony/app/timelinefx/core/PlaceFactory.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/PlaceFactory.java
@@ -64,6 +64,8 @@ public final class PlaceFactory {
     }
 
     /**
+     * Returns all created places, sorted by name.
+     *
      * @return all created places, sorted by name
      */
     public static List<Place> getPlaces() {

--- a/src/main/java/com/github/noony/app/timelinefx/core/PlaceFactory.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/PlaceFactory.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import javafx.scene.paint.Color;
-import static com.github.noony.app.timelinefx.core.Factory.CREATION_LOGGING_LEVEL;
 
 /**
  * Entry point for creating and retrieving {@link Place} instances.
@@ -95,7 +94,7 @@ public final class PlaceFactory {
      * @return the created place
      */
     public static Place createPlace(final String placeName, final PlaceLevel placeLevel, final Place parentPlace) {
-        LOG.log(CREATION_LOGGING_LEVEL, "Creating place with placeName={0} placeLevel={1} parentPlace={2} ", new Object[]{placeName, placeLevel, parentPlace});
+        LOG.log(Factory.CREATION_LOGGING_LEVEL, "Creating place with placeName={0} placeLevel={1} parentPlace={2} ", new Object[]{placeName, placeLevel, parentPlace});
         final var trueParentPlace = parentPlace != null ? parentPlace : PLACES_PLACE;
         final var place = new Place(FACTORY.getNextID(), placeName, placeLevel, trueParentPlace);
         if (place.isRootPlace()) {
@@ -114,9 +113,9 @@ public final class PlaceFactory {
      * @param color the place's color
      * @return the created place
      */
-    public static Place createPlace(final String placeName, final PlaceLevel placeLevel, final Place parentPlace, Color color) {
-        LOG.log(CREATION_LOGGING_LEVEL, "Creating place with placeName={0} placeLevel={1} parentPlace={2} color={3} ", new Object[]{placeName, placeLevel, parentPlace, color});
-        var trueParentPlace = parentPlace != null ? parentPlace : PLACES_PLACE;
+    public static Place createPlace(final String placeName, final PlaceLevel placeLevel, final Place parentPlace, final Color color) {
+        LOG.log(Factory.CREATION_LOGGING_LEVEL, "Creating place with placeName={0} placeLevel={1} parentPlace={2} color={3} ", new Object[]{placeName, placeLevel, parentPlace, color});
+        final var trueParentPlace = parentPlace != null ? parentPlace : PLACES_PLACE;
         final var place = new Place(FACTORY.getNextID(), placeName, placeLevel, trueParentPlace, color);
         if (place.isRootPlace()) {
             addRootPlace(place);
@@ -135,11 +134,11 @@ public final class PlaceFactory {
      * @param color the place's color
      * @return the created place
      */
-    public static Place createPlace(final long id, final String placeName, final PlaceLevel placeLevel, Place parentPlace, Color color) {
+    public static Place createPlace(final long id, final String placeName, final PlaceLevel placeLevel, final Place parentPlace, Color color) {
         if (!FACTORY.isIdAvailable(id)) {
             throw new IllegalArgumentException("trying to create place " + placeName + " with existing id=" + id);
         }
-        LOG.log(CREATION_LOGGING_LEVEL, "Creating place (id={0} with placeName={1} placeLevel={2} parentPlace={3} ", new Object[]{id, placeName, placeLevel, parentPlace});
+        LOG.log(Factory.CREATION_LOGGING_LEVEL, "Creating place (id={0} with placeName={1} placeLevel={2} parentPlace={3} ", new Object[]{id, placeName, placeLevel, parentPlace});
         var trueParentPlace = parentPlace != null ? parentPlace : PLACES_PLACE;
         final var place = new Place(id, placeName, placeLevel, trueParentPlace, color);
         if (place.isRootPlace()) {

--- a/src/main/java/com/github/noony/app/timelinefx/core/PlaceLevel.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/PlaceLevel.java
@@ -25,9 +25,53 @@ package com.github.noony.app.timelinefx.core;
 public enum PlaceLevel {
 
     /**
-     * The available levels, ordered from smallest to largest.
+     * A single address.
      */
-    ADDRESS(10), TOWN(20), DEPARTMENT(30), REGION(40), COUNTRY(50), CONTINENT(60), PLANET(70), ORBIT(75), SYSTEM(80), INTER_SYSTEM_SPACE(90), GALAXY(100), UNIVERSE(1000);
+    ADDRESS(10),
+    /**
+     * A town.
+     */
+    TOWN(20),
+    /**
+     * A department.
+     */
+    DEPARTMENT(30),
+    /**
+     * A region.
+     */
+    REGION(40),
+    /**
+     * A country.
+     */
+    COUNTRY(50),
+    /**
+     * A continent.
+     */
+    CONTINENT(60),
+    /**
+     * A planet.
+     */
+    PLANET(70),
+    /**
+     * An orbit around a planet.
+     */
+    ORBIT(75),
+    /**
+     * A star system.
+     */
+    SYSTEM(80),
+    /**
+     * The space between star systems.
+     */
+    INTER_SYSTEM_SPACE(90),
+    /**
+     * A galaxy.
+     */
+    GALAXY(100),
+    /**
+     * The whole universe.
+     */
+    UNIVERSE(1000);
 
     /**
      * The numeric value used to compare levels.
@@ -39,6 +83,8 @@ public enum PlaceLevel {
     }
 
     /**
+     * Returns this level's numeric value.
+     *
      * @return this level's numeric value
      */
     public int getLevelValue() {

--- a/src/main/java/com/github/noony/app/timelinefx/core/PlaceLevel.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/PlaceLevel.java
@@ -78,8 +78,8 @@ public enum PlaceLevel {
      */
     private final int level;
 
-    PlaceLevel(final int level) {
-        this.level = level;
+    PlaceLevel(final int aLevel) {
+        level = aLevel;
     }
 
     /**

--- a/src/main/java/com/github/noony/app/timelinefx/core/PlaceLevel.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/PlaceLevel.java
@@ -18,7 +18,7 @@
 package com.github.noony.app.timelinefx.core;
 
 /**
- * The nesting level of a {@link Place}, from the smallest (address) to the largest (universe).
+ * The nesting level of a {@link Place}, from the smallest (address) to the largest (root).
  *
  * @author hamon
  */
@@ -71,7 +71,11 @@ public enum PlaceLevel {
     /**
      * The whole universe.
      */
-    UNIVERSE(1000);
+    UNIVERSE(1000),
+    /**
+     * The implicit root level above everything else, used as the default level.
+     */
+    ROOT(1_000_000);
 
     /**
      * The numeric value used to compare levels.

--- a/src/main/java/com/github/noony/app/timelinefx/core/Portrait.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/Portrait.java
@@ -14,7 +14,6 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-
 package com.github.noony.app.timelinefx.core;
 
 import java.time.LocalDate;
@@ -30,7 +29,7 @@ import java.util.logging.Logger;
  *
  * @author hamon
  */
-public class Portrait extends AbstractPicture {
+public final class Portrait extends AbstractPicture {
 
     /**
      * Orders portraits by id.
@@ -70,11 +69,13 @@ public class Portrait extends AbstractPicture {
         this(aPortraitID, aPerson, aFilePath, aWidth, aHeight, DEFAULT_TIMESTAMP);
     }
 
-    @Override public List<Person> getPersons() {
+    @Override
+    public List<Person> getPersons() {
         return Collections.unmodifiableList(persons);
     }
 
-    @Override public boolean addPerson(final Person aPerson) {
+    @Override
+    public boolean addPerson(final Person aPerson) {
         LOG.log(Level.INFO, "No person can be added to a portrait. ({0}, {1})", new Object[]{this, aPerson});
         return false;
     }

--- a/src/main/java/com/github/noony/app/timelinefx/core/Portrait.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/Portrait.java
@@ -74,8 +74,7 @@ public class Portrait extends AbstractPicture {
         return Collections.unmodifiableList(persons);
     }
 
-    @Override
-    public boolean addPerson(final Person aPerson) {
+    @Override public boolean addPerson(final Person aPerson) {
         LOG.log(Level.INFO, "No person can be added to a portrait. ({0}, {1})", new Object[]{this, aPerson});
         return false;
     }

--- a/src/main/java/com/github/noony/app/timelinefx/core/Portrait.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/Portrait.java
@@ -102,6 +102,8 @@ public class Portrait extends AbstractPicture {
     }
 
     /**
+     * Returns the person this portrait belongs to.
+     *
      * @return the person this portrait belongs to
      */
     public Person getPerson() {

--- a/src/main/java/com/github/noony/app/timelinefx/core/PortraitFactory.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/PortraitFactory.java
@@ -24,7 +24,6 @@ import java.beans.PropertyChangeSupport;
 import java.io.File;
 import java.util.List;
 import java.util.logging.Logger;
-import static com.github.noony.app.timelinefx.core.Factory.CREATION_LOGGING_LEVEL;
 
 /**
  * Entry point for creating and retrieving {@link Portrait} instances.
@@ -79,7 +78,7 @@ public final class PortraitFactory {
      * @return the created portrait
      */
     public static Portrait createPortrait(final Person person) {
-        LOG.log(CREATION_LOGGING_LEVEL, "Creating portrait with person={0} and default picture.", new Object[]{person});
+        LOG.log(Factory.CREATION_LOGGING_LEVEL, "Creating portrait with person={0} and default picture.", new Object[]{person});
         final var filePath = person.getProject().getPortraitsAbsoluteFolder().getAbsolutePath() + File.separator + Person.DEFAULT_PICTURE_NAME;
         final var fileRelativePath = person.getProject().getPortraitsRelativeFolder() + File.separator + Person.DEFAULT_PICTURE_NAME;
         final var file = new File(filePath);
@@ -98,10 +97,10 @@ public final class PortraitFactory {
      * @param filePath the portrait picture's project-relative file path
      * @return the created portrait
      */
-    public static Portrait createPortrait(final Person person, String filePath) {
-        LOG.log(CREATION_LOGGING_LEVEL, "Creating portrait with person={0} filePath={1}.", new Object[]{person, filePath});
+    public static Portrait createPortrait(final Person person, final String filePath) {
+        LOG.log(Factory.CREATION_LOGGING_LEVEL, "Creating portrait with person={0} filePath={1}.", new Object[]{person, filePath});
         final var file = new File(CustomFileUtils.fromProjectRelativeToAbsolute(person.getProject(), filePath));
-        var picInfo = MetadataParser.parseMetadata(person.getProject(), file);
+        final var picInfo = MetadataParser.parseMetadata(person.getProject(), file);
         assert picInfo != null;
         final var portrait = new Portrait(FACTORY.getNextID(), person, filePath, picInfo.getWidth(), picInfo.getHeight());
         FACTORY.addObject(portrait);
@@ -118,11 +117,11 @@ public final class PortraitFactory {
      * @return the created portrait
      */
     public static Portrait createPortrait(final long id, final Person person, final String filePath) {
-        LOG.log(CREATION_LOGGING_LEVEL, "Creating portrait with id={0} person={1} filePath={2}.", new Object[]{id, person, filePath});
+        LOG.log(Factory.CREATION_LOGGING_LEVEL, "Creating portrait with id={0} person={1} filePath={2}.", new Object[]{id, person, filePath});
         if (!FACTORY.isIdAvailable(id)) {
             throw new IllegalArgumentException("Trying to create portrait " + filePath + " with existing id=" + id + " (exists : " + FACTORY.get(id) + "[" + FACTORY.get(id).getId() + "])");
         }
-        var file = new File(CustomFileUtils.fromProjectRelativeToAbsolute(person.getProject(), filePath));
+        final var file = new File(CustomFileUtils.fromProjectRelativeToAbsolute(person.getProject(), filePath));
         if (!file.exists()) {
             throw new IllegalArgumentException("Trying to create portrait for " + person + " with missing file=" + filePath);
         }

--- a/src/main/java/com/github/noony/app/timelinefx/core/PortraitFactory.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/PortraitFactory.java
@@ -64,6 +64,8 @@ public final class PortraitFactory {
     }
 
     /**
+     * Returns the portrait with the given id.
+     *
      * @param id a portrait's id
      * @return the portrait with the given id, or null if none exists
      */

--- a/src/main/java/com/github/noony/app/timelinefx/core/StayFactory.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/StayFactory.java
@@ -84,7 +84,7 @@ public final class StayFactory {
      * @param aPlace the place stayed at
      * @return the created stay
      */
-    public static StayPeriodSimpleTime createStayPeriodSimpleTime(final long id, final Person person, final double startDate, final double endDate, Place aPlace) {
+    public static StayPeriodSimpleTime createStayPeriodSimpleTime(final long id, final Person person, final double startDate, final double endDate, final Place aPlace) {
         LOG.log(Factory.CREATION_LOGGING_LEVEL, "Creating StayPeriodSimpleTime with id={0} person={1} startDate={2} endDate={3} aPlace={4}", new Object[]{id, person, startDate, endDate, aPlace});
         if (!FACTORY.isIdAvailable(id)) {
             throw new IllegalArgumentException(TRYING_TO_CREATE_STAY_MESSAGE + person.getName() + " from " + startDate + " to " + endDate + " with existing id=" + id + " (exists : " + id + ")");
@@ -120,7 +120,7 @@ public final class StayFactory {
      * @param aPlace the place stayed at
      * @return the created stay
      */
-    public static StayPeriodLocalDate createStayPeriodLocalDate(final long id, final Person person, final LocalDate startDate, final LocalDate endDate, Place aPlace) {
+    public static StayPeriodLocalDate createStayPeriodLocalDate(final long id, final Person person, final LocalDate startDate, final LocalDate endDate, final Place aPlace) {
         LOG.log(Factory.CREATION_LOGGING_LEVEL, "Creating createStayPeriodLocalDate with id={0} person={1} startDate={2} endDate={3} aPlace={4}", new Object[]{id, person, startDate, endDate, aPlace});
         if (!FACTORY.isIdAvailable(id)) {
             throw new IllegalArgumentException(TRYING_TO_CREATE_STAY_MESSAGE + person.getName() + " with existing id=" + id + " (exists : " + FACTORY.get(id).getDisplayString() + ")");

--- a/src/main/java/com/github/noony/app/timelinefx/core/StayFactory.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/StayFactory.java
@@ -126,6 +126,8 @@ public final class StayFactory {
     }
 
     /**
+     * Returns the stay with the given id.
+     *
      * @param id a stay's id
      * @return the stay with the given id, or null if none exists
      */

--- a/src/main/java/com/github/noony/app/timelinefx/core/StayFactory.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/StayFactory.java
@@ -31,8 +31,6 @@ public final class StayFactory {
      * Logger used by this factory.
      */
     private static final Logger LOG = Logger.getGlobal();
-    //    private static final Map<Long, StayPeriod> STAY_PERIOD_SIMPLE_TIMES = new HashMap<>();
-    //    private static final Map<Long, StayPeriod> STAY_PERIOD_LOCAL_DATES = new HashMap<>();
 
 
     /**
@@ -49,6 +47,10 @@ public final class StayFactory {
      * Fragment used to render the conflicting id in exception messages.
      */
     private static final String EXISTING_ID_MESSAGE_FRAGMENT = " with existing id=";
+    /**
+     * Fragment used to render the exixiting conflicting id in exception messages.
+     */
+    private static final String EXISTING_ID_MESSAGE_FRAGMENT_PART_2 = " (exists : ";
 
     private StayFactory() {
         // private utility constructor
@@ -59,8 +61,6 @@ public final class StayFactory {
      */
     public static void reset() {
         FACTORY.reset();
-        //        STAY_PERIOD_SIMPLE_TIMES.clear();
-        //        STAY_PERIOD_LOCAL_DATES.clear();
     }
 
     /**
@@ -92,7 +92,7 @@ public final class StayFactory {
     public static StayPeriodSimpleTime createStayPeriodSimpleTime(final long id, final Person person, final double startDate, final double endDate, final Place aPlace) {
         LOG.log(Factory.CREATION_LOGGING_LEVEL, "Creating StayPeriodSimpleTime with id={0} person={1} startDate={2} endDate={3} aPlace={4}", new Object[]{id, person, startDate, endDate, aPlace});
         if (!FACTORY.isIdAvailable(id)) {
-            throw new IllegalArgumentException(TRYING_TO_CREATE_STAY_MESSAGE + person.getName() + " from " + startDate + " to " + endDate + EXISTING_ID_MESSAGE_FRAGMENT + id + " (exists : " + id + ")");
+            throw new IllegalArgumentException(TRYING_TO_CREATE_STAY_MESSAGE + person.getName() + " from " + startDate + " to " + endDate + EXISTING_ID_MESSAGE_FRAGMENT + id + EXISTING_ID_MESSAGE_FRAGMENT_PART_2 + id + ")");
         }
         final var stay = new StayPeriodSimpleTime(id, person, startDate, endDate, aPlace);
         FACTORY.addObject(stay);
@@ -128,7 +128,7 @@ public final class StayFactory {
     public static StayPeriodLocalDate createStayPeriodLocalDate(final long id, final Person person, final LocalDate startDate, final LocalDate endDate, final Place aPlace) {
         LOG.log(Factory.CREATION_LOGGING_LEVEL, "Creating createStayPeriodLocalDate with id={0} person={1} startDate={2} endDate={3} aPlace={4}", new Object[]{id, person, startDate, endDate, aPlace});
         if (!FACTORY.isIdAvailable(id)) {
-            throw new IllegalArgumentException(TRYING_TO_CREATE_STAY_MESSAGE + person.getName() + EXISTING_ID_MESSAGE_FRAGMENT + id + " (exists : " + FACTORY.get(id).getDisplayString() + ")");
+            throw new IllegalArgumentException(TRYING_TO_CREATE_STAY_MESSAGE + person.getName() + EXISTING_ID_MESSAGE_FRAGMENT + id + EXISTING_ID_MESSAGE_FRAGMENT_PART_2 + FACTORY.get(id).getDisplayString() + ")");
         }
         final var stay = new StayPeriodLocalDate(id, person, startDate, endDate, aPlace);
         FACTORY.addObject(stay);

--- a/src/main/java/com/github/noony/app/timelinefx/core/StayFactory.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/StayFactory.java
@@ -40,6 +40,11 @@ public final class StayFactory {
      */
     private static final Factory<StayPeriod> FACTORY = new Factory<>();
 
+    /**
+     * Prefix of the exception message thrown when creating a stay with an already-used id.
+     */
+    private static final String TRYING_TO_CREATE_STAY_MESSAGE = "Trying to create stay for ";
+
     private StayFactory() {
         // private utility constructor
     }
@@ -82,7 +87,7 @@ public final class StayFactory {
     public static StayPeriodSimpleTime createStayPeriodSimpleTime(final long id, final Person person, final double startDate, final double endDate, Place aPlace) {
         LOG.log(Factory.CREATION_LOGGING_LEVEL, "Creating StayPeriodSimpleTime with id={0} person={1} startDate={2} endDate={3} aPlace={4}", new Object[]{id, person, startDate, endDate, aPlace});
         if (!FACTORY.isIdAvailable(id)) {
-            throw new IllegalArgumentException("Trying to create stay for " + person.getName() + " from " + startDate + " to " + endDate + " with existing id=" + id + " (exists : " + id + ")");
+            throw new IllegalArgumentException(TRYING_TO_CREATE_STAY_MESSAGE + person.getName() + " from " + startDate + " to " + endDate + " with existing id=" + id + " (exists : " + id + ")");
         }
         final var stay = new StayPeriodSimpleTime(id, person, startDate, endDate, aPlace);
         FACTORY.addObject(stay);
@@ -118,7 +123,7 @@ public final class StayFactory {
     public static StayPeriodLocalDate createStayPeriodLocalDate(final long id, final Person person, final LocalDate startDate, final LocalDate endDate, Place aPlace) {
         LOG.log(Factory.CREATION_LOGGING_LEVEL, "Creating createStayPeriodLocalDate with id={0} person={1} startDate={2} endDate={3} aPlace={4}", new Object[]{id, person, startDate, endDate, aPlace});
         if (!FACTORY.isIdAvailable(id)) {
-            throw new IllegalArgumentException("Trying to create stay for " + person.getName() + " with existing id=" + id + " (exists : " + FACTORY.get(id).getDisplayString() + ")");
+            throw new IllegalArgumentException(TRYING_TO_CREATE_STAY_MESSAGE + person.getName() + " with existing id=" + id + " (exists : " + FACTORY.get(id).getDisplayString() + ")");
         }
         final var stay = new StayPeriodLocalDate(id, person, startDate, endDate, aPlace);
         FACTORY.addObject(stay);

--- a/src/main/java/com/github/noony/app/timelinefx/core/StayFactory.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/StayFactory.java
@@ -45,6 +45,11 @@ public final class StayFactory {
      */
     private static final String TRYING_TO_CREATE_STAY_MESSAGE = "Trying to create stay for ";
 
+    /**
+     * Fragment used to render the conflicting id in exception messages.
+     */
+    private static final String EXISTING_ID_MESSAGE_FRAGMENT = " with existing id=";
+
     private StayFactory() {
         // private utility constructor
     }
@@ -87,7 +92,7 @@ public final class StayFactory {
     public static StayPeriodSimpleTime createStayPeriodSimpleTime(final long id, final Person person, final double startDate, final double endDate, final Place aPlace) {
         LOG.log(Factory.CREATION_LOGGING_LEVEL, "Creating StayPeriodSimpleTime with id={0} person={1} startDate={2} endDate={3} aPlace={4}", new Object[]{id, person, startDate, endDate, aPlace});
         if (!FACTORY.isIdAvailable(id)) {
-            throw new IllegalArgumentException(TRYING_TO_CREATE_STAY_MESSAGE + person.getName() + " from " + startDate + " to " + endDate + " with existing id=" + id + " (exists : " + id + ")");
+            throw new IllegalArgumentException(TRYING_TO_CREATE_STAY_MESSAGE + person.getName() + " from " + startDate + " to " + endDate + EXISTING_ID_MESSAGE_FRAGMENT + id + " (exists : " + id + ")");
         }
         final var stay = new StayPeriodSimpleTime(id, person, startDate, endDate, aPlace);
         FACTORY.addObject(stay);
@@ -123,7 +128,7 @@ public final class StayFactory {
     public static StayPeriodLocalDate createStayPeriodLocalDate(final long id, final Person person, final LocalDate startDate, final LocalDate endDate, final Place aPlace) {
         LOG.log(Factory.CREATION_LOGGING_LEVEL, "Creating createStayPeriodLocalDate with id={0} person={1} startDate={2} endDate={3} aPlace={4}", new Object[]{id, person, startDate, endDate, aPlace});
         if (!FACTORY.isIdAvailable(id)) {
-            throw new IllegalArgumentException(TRYING_TO_CREATE_STAY_MESSAGE + person.getName() + " with existing id=" + id + " (exists : " + FACTORY.get(id).getDisplayString() + ")");
+            throw new IllegalArgumentException(TRYING_TO_CREATE_STAY_MESSAGE + person.getName() + EXISTING_ID_MESSAGE_FRAGMENT + id + " (exists : " + FACTORY.get(id).getDisplayString() + ")");
         }
         final var stay = new StayPeriodLocalDate(id, person, startDate, endDate, aPlace);
         FACTORY.addObject(stay);

--- a/src/main/java/com/github/noony/app/timelinefx/core/StayFactory.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/StayFactory.java
@@ -47,10 +47,16 @@ public final class StayFactory {
      * Fragment used to render the conflicting id in exception messages.
      */
     private static final String EXISTING_ID_MESSAGE_FRAGMENT = " with existing id=";
+
     /**
      * Fragment used to render the exixiting conflicting id in exception messages.
      */
     private static final String EXISTING_ID_MESSAGE_FRAGMENT_PART_2 = " (exists : ";
+
+    /**
+     * Closing parenthesis used at the end of exception messages.
+     */
+    private static final String CLOSING_PARENTHESIS = ")";
 
     private StayFactory() {
         // private utility constructor
@@ -92,7 +98,7 @@ public final class StayFactory {
     public static StayPeriodSimpleTime createStayPeriodSimpleTime(final long id, final Person person, final double startDate, final double endDate, final Place aPlace) {
         LOG.log(Factory.CREATION_LOGGING_LEVEL, "Creating StayPeriodSimpleTime with id={0} person={1} startDate={2} endDate={3} aPlace={4}", new Object[]{id, person, startDate, endDate, aPlace});
         if (!FACTORY.isIdAvailable(id)) {
-            throw new IllegalArgumentException(TRYING_TO_CREATE_STAY_MESSAGE + person.getName() + " from " + startDate + " to " + endDate + EXISTING_ID_MESSAGE_FRAGMENT + id + EXISTING_ID_MESSAGE_FRAGMENT_PART_2 + id + ")");
+            throw new IllegalArgumentException(TRYING_TO_CREATE_STAY_MESSAGE + person.getName() + " from " + startDate + " to " + endDate + EXISTING_ID_MESSAGE_FRAGMENT + id + EXISTING_ID_MESSAGE_FRAGMENT_PART_2 + id + CLOSING_PARENTHESIS);
         }
         final var stay = new StayPeriodSimpleTime(id, person, startDate, endDate, aPlace);
         FACTORY.addObject(stay);
@@ -128,7 +134,7 @@ public final class StayFactory {
     public static StayPeriodLocalDate createStayPeriodLocalDate(final long id, final Person person, final LocalDate startDate, final LocalDate endDate, final Place aPlace) {
         LOG.log(Factory.CREATION_LOGGING_LEVEL, "Creating createStayPeriodLocalDate with id={0} person={1} startDate={2} endDate={3} aPlace={4}", new Object[]{id, person, startDate, endDate, aPlace});
         if (!FACTORY.isIdAvailable(id)) {
-            throw new IllegalArgumentException(TRYING_TO_CREATE_STAY_MESSAGE + person.getName() + EXISTING_ID_MESSAGE_FRAGMENT + id + EXISTING_ID_MESSAGE_FRAGMENT_PART_2 + FACTORY.get(id).getDisplayString() + ")");
+            throw new IllegalArgumentException(TRYING_TO_CREATE_STAY_MESSAGE + person.getName() + EXISTING_ID_MESSAGE_FRAGMENT + id + EXISTING_ID_MESSAGE_FRAGMENT_PART_2 + FACTORY.get(id).getDisplayString() + CLOSING_PARENTHESIS);
         }
         final var stay = new StayPeriodLocalDate(id, person, startDate, endDate, aPlace);
         FACTORY.addObject(stay);

--- a/src/main/java/com/github/noony/app/timelinefx/core/StayFactory.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/StayFactory.java
@@ -19,7 +19,6 @@ package com.github.noony.app.timelinefx.core;
 
 import java.time.LocalDate;
 import java.util.logging.Logger;
-import static com.github.noony.app.timelinefx.core.Factory.CREATION_LOGGING_LEVEL;
 
 /**
  * Entry point for creating and retrieving {@link StayPeriod} instances.
@@ -63,8 +62,8 @@ public final class StayFactory {
      * @param aPlace the place stayed at
      * @return the created stay
      */
-    public static StayPeriodSimpleTime createStayPeriodSimpleTime(final Person person, final double startDate, final double endDate, Place aPlace) {
-        LOG.log(CREATION_LOGGING_LEVEL, "Creating StayPeriodSimpleTime with person={0} startDate={1} endDate={2} aPlace={3}", new Object[]{person, startDate, endDate, aPlace});
+    public static StayPeriodSimpleTime createStayPeriodSimpleTime(final Person person, final double startDate, final double endDate, final Place aPlace) {
+        LOG.log(Factory.CREATION_LOGGING_LEVEL, "Creating StayPeriodSimpleTime with person={0} startDate={1} endDate={2} aPlace={3}", new Object[]{person, startDate, endDate, aPlace});
         final var stay = new StayPeriodSimpleTime(FACTORY.getNextID(), person, startDate, endDate, aPlace);
         FACTORY.addObject(stay);
         return stay;
@@ -80,8 +79,8 @@ public final class StayFactory {
      * @param aPlace the place stayed at
      * @return the created stay
      */
-    public static StayPeriodSimpleTime createStayPeriodSimpleTime(final long id, final Person person, final double startDate, double endDate, Place aPlace) {
-        LOG.log(CREATION_LOGGING_LEVEL, "Creating StayPeriodSimpleTime with id={0} person={1} startDate={2} endDate={3} aPlace={4}", new Object[]{id, person, startDate, endDate, aPlace});
+    public static StayPeriodSimpleTime createStayPeriodSimpleTime(final long id, final Person person, final double startDate, final double endDate, Place aPlace) {
+        LOG.log(Factory.CREATION_LOGGING_LEVEL, "Creating StayPeriodSimpleTime with id={0} person={1} startDate={2} endDate={3} aPlace={4}", new Object[]{id, person, startDate, endDate, aPlace});
         if (!FACTORY.isIdAvailable(id)) {
             throw new IllegalArgumentException("Trying to create stay for " + person.getName() + " from " + startDate + " to " + endDate + " with existing id=" + id + " (exists : " + id + ")");
         }
@@ -99,8 +98,8 @@ public final class StayFactory {
      * @param aPlace the place stayed at
      * @return the created stay
      */
-    public static StayPeriodLocalDate createStayPeriodLocalDate(final Person person, final LocalDate startDate, final LocalDate endDate, Place aPlace) {
-        LOG.log(CREATION_LOGGING_LEVEL, "Creating createStayPeriodLocalDate with person={0} startDate={1} endDate={2} aPlace={3}", new Object[]{person, startDate, endDate, aPlace});
+    public static StayPeriodLocalDate createStayPeriodLocalDate(final Person person, final LocalDate startDate, final LocalDate endDate, final Place aPlace) {
+        LOG.log(Factory.CREATION_LOGGING_LEVEL, "Creating createStayPeriodLocalDate with person={0} startDate={1} endDate={2} aPlace={3}", new Object[]{person, startDate, endDate, aPlace});
         final var stay = new StayPeriodLocalDate(FACTORY.getNextID(), person, startDate, endDate, aPlace);
         FACTORY.addObject(stay);
         return stay;
@@ -116,8 +115,8 @@ public final class StayFactory {
      * @param aPlace the place stayed at
      * @return the created stay
      */
-    public static StayPeriodLocalDate createStayPeriodLocalDate(final long id, final Person person, final LocalDate startDate, LocalDate endDate, Place aPlace) {
-        LOG.log(CREATION_LOGGING_LEVEL, "Creating createStayPeriodLocalDate with id={0} person={1} startDate={2} endDate={3} aPlace={4}", new Object[]{id, person, startDate, endDate, aPlace});
+    public static StayPeriodLocalDate createStayPeriodLocalDate(final long id, final Person person, final LocalDate startDate, final LocalDate endDate, Place aPlace) {
+        LOG.log(Factory.CREATION_LOGGING_LEVEL, "Creating createStayPeriodLocalDate with id={0} person={1} startDate={2} endDate={3} aPlace={4}", new Object[]{id, person, startDate, endDate, aPlace});
         if (!FACTORY.isIdAvailable(id)) {
             throw new IllegalArgumentException("Trying to create stay for " + person.getName() + " with existing id=" + id + " (exists : " + FACTORY.get(id).getDisplayString() + ")");
         }

--- a/src/main/java/com/github/noony/app/timelinefx/core/StayPeriod.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/StayPeriod.java
@@ -74,7 +74,8 @@ public abstract class StayPeriod implements FriezeObject {
      */
     private Place place;
 
-    @SuppressWarnings("this-escape") protected StayPeriod(final long anId, final Person aPerson, final Place aPlace) {
+    @SuppressWarnings("this-escape")
+    protected StayPeriod(final long anId, final Person aPerson, final Place aPlace) {
         id = anId;
         propertyChangeSupport = new PropertyChangeSupport(StayPeriod.this);
         person = aPerson;

--- a/src/main/java/com/github/noony/app/timelinefx/core/StayPeriod.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/StayPeriod.java
@@ -59,6 +59,9 @@ public abstract class StayPeriod implements FriezeObject {
      */
     private final PropertyChangeSupport propertyChangeSupport;
 
+    /**
+     * This stay's unique id.
+     */
     private final Long id;
 
     /**
@@ -84,6 +87,8 @@ public abstract class StayPeriod implements FriezeObject {
     }
 
     /**
+     * Adds a listener notified of this stay's changes.
+     *
      * @param listener the listener to add
      */
     public void addListener(final PropertyChangeListener listener) {

--- a/src/main/java/com/github/noony/app/timelinefx/core/StayPeriod.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/StayPeriod.java
@@ -74,8 +74,7 @@ public abstract class StayPeriod implements FriezeObject {
      */
     private Place place;
 
-    @SuppressWarnings("this-escape")
-    protected StayPeriod(final long anId, final Person aPerson, final Place aPlace) {
+    @SuppressWarnings("this-escape") protected StayPeriod(final long anId, final Person aPerson, final Place aPlace) {
         id = anId;
         propertyChangeSupport = new PropertyChangeSupport(StayPeriod.this);
         person = aPerson;

--- a/src/main/java/com/github/noony/app/timelinefx/core/StayPeriodLocalDate.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/StayPeriodLocalDate.java
@@ -79,6 +79,8 @@ public class StayPeriodLocalDate extends StayPeriod {
     }
 
     /**
+     * Sets this stay's start date.
+     *
      * @param aStartDate the stay's new start date
      */
     public void setStartDate(final LocalDate aStartDate) {

--- a/src/main/java/com/github/noony/app/timelinefx/core/StayPeriodLocalDate.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/StayPeriodLocalDate.java
@@ -58,8 +58,7 @@ public class StayPeriodLocalDate extends StayPeriod {
         return previousStartDate.toEpochDay();
     }
 
-    @Override
-    public double getPreviousEndDate() {
+    @Override public double getPreviousEndDate() {
         return previousEndDate.toEpochDay();
     }
 

--- a/src/main/java/com/github/noony/app/timelinefx/core/StayPeriodLocalDate.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/StayPeriodLocalDate.java
@@ -46,7 +46,7 @@ public class StayPeriodLocalDate extends StayPeriod {
      */
     private LocalDate endDate;
 
-    protected StayPeriodLocalDate(final long id, final Person aPerson, final LocalDate aStartDate, LocalDate anEndDate, Place aPlace) {
+    protected StayPeriodLocalDate(final long id, final Person aPerson, final LocalDate aStartDate, final LocalDate anEndDate, Place aPlace) {
         super(id, aPerson, aPlace);
         previousStartDate = aStartDate;
         previousEndDate = anEndDate;

--- a/src/main/java/com/github/noony/app/timelinefx/core/StayPeriodSimpleTime.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/StayPeriodSimpleTime.java
@@ -44,7 +44,7 @@ public class StayPeriodSimpleTime extends StayPeriod {
      */
     private double endTime;
 
-    protected StayPeriodSimpleTime(final Long anId, final Person aPerson, final double aStartTime, double anEndTime, Place aPlace) {
+    protected StayPeriodSimpleTime(final Long anId, final Person aPerson, final double aStartTime, final double anEndTime, Place aPlace) {
         super(anId, aPerson, aPlace);
         previousStartTime = aStartTime;
         previousEndTime = anEndTime;

--- a/src/main/java/com/github/noony/app/timelinefx/core/StayPeriodSimpleTime.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/StayPeriodSimpleTime.java
@@ -72,6 +72,8 @@ public class StayPeriodSimpleTime extends StayPeriod {
     }
 
     /**
+     * Sets this stay's start time.
+     *
      * @param aStartDate the stay's new start time
      */
     public void setStartDate(final double aStartDate) {

--- a/src/main/java/com/github/noony/app/timelinefx/core/StayPeriodSimpleTime.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/StayPeriodSimpleTime.java
@@ -56,8 +56,7 @@ public class StayPeriodSimpleTime extends StayPeriod {
         return previousStartTime;
     }
 
-    @Override
-    public double getPreviousEndDate() {
+    @Override public double getPreviousEndDate() {
         return previousEndTime;
     }
 

--- a/src/main/java/com/github/noony/app/timelinefx/core/TimeFormat.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/TimeFormat.java
@@ -25,8 +25,12 @@ package com.github.noony.app.timelinefx.core;
 public enum TimeFormat {
 
     /**
-     * A calendar {@code LocalDate}, or a raw numeric time value.
+     * A calendar {@code LocalDate}.
      */
-    LOCAL_TIME, TIME_MIN
+    LOCAL_TIME,
+    /**
+     * A raw numeric time value.
+     */
+    TIME_MIN
 
 }

--- a/src/main/java/com/github/noony/app/timelinefx/core/TimeLineProject.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/TimeLineProject.java
@@ -218,9 +218,12 @@ public final class TimeLineProject {
     }
 
     private void initFolders(final Map<String, String> configParams) {
-        final var projectFolderLocation = configParams.containsKey(PROJECT_FOLDER_KEY)
-                ? configParams.get(PROJECT_FOLDER_KEY)
-                : Configuration.getProjectsParentFolder() + File.separator + name;
+        final String projectFolderLocation;
+        if (configParams.containsKey(PROJECT_FOLDER_KEY)) {
+            projectFolderLocation = configParams.get(PROJECT_FOLDER_KEY);
+        } else {
+            projectFolderLocation = Configuration.getProjectsParentFolder() + File.separator + name;
+        }
         final var portraitsFolderLocation = configParams.getOrDefault(PORTRAIT_FOLDER_KEY, DEFAULT_PORTRAIT_FOLDER);
         final var picturesFolderLocation = configParams.getOrDefault(PICTURES_FOLDER_KEY, DEFAULT_PICTURES_FOLDER);
         final var miniaturesFolderLocation = configParams.getOrDefault(MINIATURES_FOLDER_KEY, DEFAULT_MINIATURES_FOLDER);

--- a/src/main/java/com/github/noony/app/timelinefx/core/TimeLineProject.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/TimeLineProject.java
@@ -279,16 +279,28 @@ public final class TimeLineProject {
     }
 
     /**
+     * Returns the project's folder.
+     *
      * @return the project's folder
      */
     public File getProjectFolder() {
         return projectFolder;
     }
 
+    /**
+     * Returns the project's portraits folder, as an absolute path.
+     *
+     * @return the project's portraits folder
+     */
     public File getPortraitsAbsoluteFolder() {
         return portraitsFolder;
     }
 
+    /**
+     * Returns the project's portraits folder, as a path relative to the project's folder.
+     *
+     * @return the project's portraits folder, relative to the project's folder
+     */
     public String getPortraitsRelativeFolder() {
         return CustomFileUtils.fromAbsoluteToProjectRelative(this, portraitsFolder);
     }
@@ -406,12 +418,22 @@ public final class TimeLineProject {
         return allPlaces.get(placeName);
     }
 
+    /**
+     * Adds several stays to this project.
+     *
+     * @param stays the stays to add
+     */
     public void addAllStays(final StayPeriod... stays) {
         for (StayPeriod s : stays) {
             addStay(s);
         }
     }
 
+    /**
+     * Adds several stays to this project.
+     *
+     * @param stays the stays to add
+     */
     public void addAllStays(final Collection<? extends StayPeriod> stays) {
         stays.forEach(this::addStay);
     }

--- a/src/main/java/com/github/noony/app/timelinefx/core/TimeLineProject.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/TimeLineProject.java
@@ -431,10 +431,10 @@ public final class TimeLineProject {
     /**
      * Adds several stays to this project.
      *
-     * @param stays the stays to add
+     * @param staysToAdd the stays to add
      */
-    public void addAllStays(final StayPeriod... stays) {
-        for (StayPeriod s : stays) {
+    public void addAllStays(final StayPeriod... staysToAdd) {
+        for (StayPeriod s : staysToAdd) {
             addStay(s);
         }
     }
@@ -442,10 +442,10 @@ public final class TimeLineProject {
     /**
      * Adds several stays to this project.
      *
-     * @param stays the stays to add
+     * @param staysToAdd the stays to add
      */
-    public void addAllStays(final Collection<? extends StayPeriod> stays) {
-        stays.forEach(this::addStay);
+    public void addAllStays(final Collection<? extends StayPeriod> staysToAdd) {
+        staysToAdd.forEach(this::addStay);
     }
 
     /**

--- a/src/main/java/com/github/noony/app/timelinefx/core/TimeLineProject.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/TimeLineProject.java
@@ -218,7 +218,9 @@ public final class TimeLineProject {
     }
 
     private void initFolders(final Map<String, String> configParams) {
-        final var projectFolderLocation = configParams.getOrDefault(PROJECT_FOLDER_KEY, Configuration.getProjectsParentFolder() + File.separator + name);
+        final var projectFolderLocation = configParams.containsKey(PROJECT_FOLDER_KEY)
+                ? configParams.get(PROJECT_FOLDER_KEY)
+                : Configuration.getProjectsParentFolder() + File.separator + name;
         final var portraitsFolderLocation = configParams.getOrDefault(PORTRAIT_FOLDER_KEY, DEFAULT_PORTRAIT_FOLDER);
         final var picturesFolderLocation = configParams.getOrDefault(PICTURES_FOLDER_KEY, DEFAULT_PICTURES_FOLDER);
         final var miniaturesFolderLocation = configParams.getOrDefault(MINIATURES_FOLDER_KEY, DEFAULT_MINIATURES_FOLDER);

--- a/src/main/java/com/github/noony/app/timelinefx/core/TimeLineProject.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/TimeLineProject.java
@@ -52,6 +52,7 @@ public final class TimeLineProject {
      * Name of the property change event fired when a person is added.
      */
     public static final String PERSON_ADDED = "personAdded";
+
     /**
      * Name of the property change event fired when a place is added.
      */
@@ -194,7 +195,7 @@ public final class TimeLineProject {
      */
     private final List<PictureChronology> pictureChronologies;
 
-    protected TimeLineProject(final String projectName, Map<String, String> configParams) {
+    protected TimeLineProject(final String projectName, final Map<String, String> configParams) {
         name = projectName;
         initFolders(configParams);
         propertyChangeSupport = new PropertyChangeSupport(TimeLineProject.this);
@@ -405,13 +406,13 @@ public final class TimeLineProject {
         return allPlaces.get(placeName);
     }
 
-    public void addAllStays(StayPeriod... stays) {
+    public void addAllStays(final StayPeriod... stays) {
         for (StayPeriod s : stays) {
             addStay(s);
         }
     }
 
-    public void addAllStays(Collection<? extends StayPeriod> stays) {
+    public void addAllStays(final Collection<? extends StayPeriod> stays) {
         stays.forEach(this::addStay);
     }
 
@@ -572,9 +573,9 @@ public final class TimeLineProject {
     }
 
     private void removeChildrenPlaces(final Place aParentPlace) {
-        final List<Place> directChildren = allPlaces.values().stream()
-                .filter(place -> place.getParent().equals(aParentPlace))
-                .toList();
+        final List<Place> directChildren = allPlaces.values().stream().
+                filter(place -> place.getParent().equals(aParentPlace)).
+                toList();
         directChildren.forEach(child -> {
             allPlaces.remove(child.getName());
             removeStaysAt(child);

--- a/src/main/java/com/github/noony/app/timelinefx/core/TimeLineProject.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/TimeLineProject.java
@@ -130,6 +130,16 @@ public final class TimeLineProject {
     private static final Logger LOG = Logger.getGlobal();
 
     /**
+     * Log message used when an exception is caught while saving a resource.
+     */
+    private static final String EXCEPTION_LOG_MESSAGE = "> Exception :: {0}";
+
+    /**
+     * Separator used between a class name and an unsupported event in exception messages.
+     */
+    private static final String CLASS_EVENT_SEPARATOR = " :: ";
+
+    /**
      * Support object used to fire property change events.
      */
     private final PropertyChangeSupport propertyChangeSupport;
@@ -271,10 +281,10 @@ public final class TimeLineProject {
             }
         } catch (FileNotFoundException ex) {
             LOG.log(Level.SEVERE, "Resource file not found :: {0}", new Object[]{Person.DEFAULT_PICTURE_NAME});
-            LOG.log(Level.SEVERE, "> Exception :: {0}", new Object[]{ex});
+            LOG.log(Level.SEVERE, EXCEPTION_LOG_MESSAGE, new Object[]{ex});
         } catch (IOException ex) {
             LOG.log(Level.SEVERE, "Exception while saving resource :: {0}", new Object[]{Person.DEFAULT_PICTURE_NAME});
-            LOG.log(Level.SEVERE, "> Exception :: {0}", new Object[]{ex});
+            LOG.log(Level.SEVERE, EXCEPTION_LOG_MESSAGE, new Object[]{ex});
         }
     }
 
@@ -550,7 +560,7 @@ public final class TimeLineProject {
                 // ignored since removal from one Frieze does not mean deleted
             }
             default ->
-                throw new UnsupportedOperationException(this.getClass().getSimpleName() + " :: " + event);
+                throw new UnsupportedOperationException(this.getClass().getSimpleName() + CLASS_EVENT_SEPARATOR + event);
         }
     }
 
@@ -560,7 +570,7 @@ public final class TimeLineProject {
                 // nothing to do
             }
             default ->
-                throw new UnsupportedOperationException(this.getClass().getSimpleName() + " :: " + event);
+                throw new UnsupportedOperationException(this.getClass().getSimpleName() + CLASS_EVENT_SEPARATOR + event);
         }
     }
 

--- a/src/main/java/com/github/noony/app/timelinefx/utils/MetadataParser.java
+++ b/src/main/java/com/github/noony/app/timelinefx/utils/MetadataParser.java
@@ -9,7 +9,6 @@ import com.github.noony.app.timelinefx.core.PictureInfo;
 import com.github.noony.app.timelinefx.core.TimeLineProject;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -47,13 +46,12 @@ public class MetadataParser {
         int xRes = DEFAULT_RESOLUTION;
         int yRes = DEFAULT_RESOLUTION;
 
-        try {
+        try (var imageStream = new FileInputStream(filePath)) {
             // Using the Javafx API to get resolution
-            var imageStream = new FileInputStream(filePath);
             var image = new Image(imageStream);
             xRes = (int) image.getWidth();
             yRes = (int) image.getHeight();
-        } catch (FileNotFoundException ex) {
+        } catch (IOException ex) {
             LOG.log(Level.SEVERE, "Exception while loading image :: {0}", new Object[]{ex});
         }
 

--- a/src/test/java/com/github/noony/app/timelinefx/core/AnchorSideTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/AnchorSideTest.java
@@ -24,7 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 /**
  * @author solun
  */
-public class AnchorSideTest {
+public final class AnchorSideTest {
 
     public AnchorSideTest() {
     }

--- a/src/test/java/com/github/noony/app/timelinefx/core/AnchorSideTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/AnchorSideTest.java
@@ -23,10 +23,15 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
+ * Unit tests for {@link AnchorSide}.
+ *
  * @author solun
  */
 public final class AnchorSideTest {
 
+    /**
+     * Default constructor.
+     */
     public AnchorSideTest() {
     }
 

--- a/src/test/java/com/github/noony/app/timelinefx/core/AnchorSideTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/AnchorSideTest.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core;
 
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/github/noony/app/timelinefx/core/AnchorSideTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/AnchorSideTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2026 NoOnY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.github.noony.app.timelinefx.core;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * @author solun
+ */
+public class AnchorSideTest {
+
+    public AnchorSideTest() {
+    }
+
+    /**
+     * Test of values method, of class AnchorSide.
+     */
+    @Test
+    public void testValues() {
+        assertArrayEquals(new AnchorSide[]{AnchorSide.TOP, AnchorSide.BOTTOM, AnchorSide.LEFT, AnchorSide.RIGHT, AnchorSide.NONE}, AnchorSide.values());
+    }
+
+    /**
+     * Test of valueOf method, of class AnchorSide.
+     */
+    @Test
+    public void testValueOf() {
+        assertSame(AnchorSide.TOP, AnchorSide.valueOf("TOP"));
+        assertEquals("NONE", AnchorSide.NONE.name());
+    }
+
+}

--- a/src/test/java/com/github/noony/app/timelinefx/core/DateObjectTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/DateObjectTest.java
@@ -25,10 +25,15 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
+ * Unit tests for {@link DateObject}.
+ *
  * @author solun
  */
 public final class DateObjectTest {
 
+    /**
+     * Default constructor.
+     */
     public DateObjectTest() {
     }
 

--- a/src/test/java/com/github/noony/app/timelinefx/core/DateObjectTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/DateObjectTest.java
@@ -26,7 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * @author solun
  */
-public class DateObjectTest {
+public final class DateObjectTest {
 
     public DateObjectTest() {
     }

--- a/src/test/java/com/github/noony/app/timelinefx/core/DateObjectTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/DateObjectTest.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core;
 
 import java.time.LocalDate;

--- a/src/test/java/com/github/noony/app/timelinefx/core/DateObjectTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/DateObjectTest.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright (C) 2026 NoOnY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.github.noony.app.timelinefx.core;
+
+import java.time.LocalDate;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @author solun
+ */
+public class DateObjectTest {
+
+    public DateObjectTest() {
+    }
+
+    /**
+     * Test of the calendar-date constructor, of class DateObject.
+     */
+    @Test
+    public void testLocalDateConstructor() {
+        final var aDate = LocalDate.of(2023, 1, 2);
+        final var instance = new DateObject(aDate);
+        assertEquals(TimeFormat.LOCAL_TIME, instance.getTimeFormat());
+        assertEquals(aDate, instance.getDate());
+        assertEquals(aDate.toEpochDay(), instance.getAbsoluteTime());
+    }
+
+    /**
+     * Test of the calendar-date constructor with a null date, of class DateObject: falls back to LocalDate.MIN.
+     */
+    @Test
+    public void testLocalDateConstructorWithNull() {
+        final var instance = new DateObject((LocalDate) null);
+        assertEquals(LocalDate.MIN, instance.getDate());
+    }
+
+    /**
+     * Test of the raw-timestamp constructor, of class DateObject.
+     */
+    @Test
+    public void testTimestampConstructor() {
+        final var instance = new DateObject(42.0);
+        assertEquals(TimeFormat.TIME_MIN, instance.getTimeFormat());
+        assertEquals(42.0, instance.getTimestamp());
+        assertEquals(42.0, instance.getAbsoluteTime());
+        assertNull(instance.getDate());
+    }
+
+    /**
+     * Test of the copy constructor, of class DateObject, copying a LOCAL_TIME instance.
+     */
+    @Test
+    public void testCopyConstructorLocalTime() {
+        final var original = new DateObject(LocalDate.of(2023, 1, 2));
+        final var copy = new DateObject(original);
+        assertEquals(original.getTimeFormat(), copy.getTimeFormat());
+        assertEquals(original.getDate(), copy.getDate());
+    }
+
+    /**
+     * Test of the copy constructor, of class DateObject, copying a TIME_MIN instance.
+     */
+    @Test
+    public void testCopyConstructorTimeMin() {
+        final var original = new DateObject(42.0);
+        final var copy = new DateObject(original);
+        assertEquals(original.getTimeFormat(), copy.getTimeFormat());
+        assertEquals(original.getTimestamp(), copy.getTimestamp());
+    }
+
+    /**
+     * Test of setDate(LocalDate) method, of class DateObject.
+     */
+    @Test
+    public void testSetDate() {
+        final var instance = new DateObject(LocalDate.of(2023, 1, 2));
+        final var newDate = LocalDate.of(2024, 5, 6);
+        instance.setDate(newDate);
+        assertEquals(newDate, instance.getDate());
+    }
+
+    /**
+     * Test of setDate(IDateObject) method, of class DateObject.
+     */
+    @Test
+    public void testSetDateFromDateObject() {
+        final var instance = new DateObject(42.0);
+        final var other = new DateObject(LocalDate.of(2023, 1, 2));
+        instance.setDate(other);
+        assertEquals(TimeFormat.LOCAL_TIME, instance.getTimeFormat());
+        assertEquals(other.getDate(), instance.getDate());
+    }
+
+    /**
+     * Test of setTimestamp method, of class DateObject.
+     */
+    @Test
+    public void testSetTimestamp() {
+        final var instance = new DateObject(LocalDate.of(2023, 1, 2));
+        instance.setTimestamp(99.0);
+        assertEquals(TimeFormat.TIME_MIN, instance.getTimeFormat());
+        assertEquals(99.0, instance.getTimestamp());
+    }
+
+    /**
+     * Test of setValue method, of class DateObject, with a LOCAL_TIME instance.
+     */
+    @Test
+    public void testSetValueLocalTime() {
+        final var instance = new DateObject(LocalDate.of(2023, 1, 2));
+        instance.setValue("2024-05-06");
+        assertEquals(LocalDate.of(2024, 5, 6), instance.getDate());
+    }
+
+    /**
+     * Test of setValue method, of class DateObject, with a TIME_MIN instance.
+     */
+    @Test
+    public void testSetValueTimeMin() {
+        final var instance = new DateObject(0.0);
+        instance.setValue("12.5");
+        assertEquals(12.5, instance.getTimestamp());
+    }
+
+    /**
+     * Test of setValue method, of class DateObject, ignoring a null value.
+     */
+    @Test
+    public void testSetValueNull() {
+        final var instance = new DateObject(LocalDate.of(2023, 1, 2));
+        instance.setValue(null);
+        assertEquals(LocalDate.of(2023, 1, 2), instance.getDate());
+    }
+
+    /**
+     * Test of getAbsoluteTimeAsString method, of class DateObject.
+     */
+    @Test
+    public void testGetAbsoluteTimeAsString() {
+        final var instance = new DateObject(12.5);
+        assertFalse(instance.getAbsoluteTimeAsString().isEmpty());
+    }
+
+    /**
+     * Test of addPropertyChangeListener/removePropertyChangeListener methods, of class DateObject.
+     */
+    @Test
+    public void testPropertyChangeListener() {
+        final var instance = new DateObject(LocalDate.of(2023, 1, 2));
+        final var fired = new boolean[]{false};
+        final java.beans.PropertyChangeListener listener = e -> fired[0] = true;
+        instance.addPropertyChangeListener(listener);
+        instance.setDate(LocalDate.of(2024, 5, 6));
+        assertTrue(fired[0]);
+        //
+        fired[0] = false;
+        instance.removePropertyChangeListener(listener);
+        instance.setDate(LocalDate.of(2025, 1, 1));
+        assertFalse(fired[0]);
+    }
+
+}

--- a/src/test/java/com/github/noony/app/timelinefx/core/EventTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/EventTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2026 NoOnY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.github.noony.app.timelinefx.core;
+
+import java.time.LocalDate;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @author solun
+ */
+public class EventTest {
+
+    public EventTest() {
+    }
+
+    /**
+     * Test of the raw-timestamp constructor and getters, of class Event.
+     */
+    @Test
+    public void testRawTimestampEvent() {
+        final var instance = new Event("testRawTimestampEvent", 42L);
+        assertEquals("testRawTimestampEvent", instance.getName());
+        assertEquals(42L, instance.getDate());
+        assertEquals(TimeFormat.TIME_MIN, instance.getTimeFormat());
+        assertNull(instance.getLocalDate());
+    }
+
+    /**
+     * Test of the calendar-date constructor and getters, of class Event.
+     */
+    @Test
+    public void testLocalDateEvent() {
+        final var aDate = LocalDate.of(2023, 1, 2);
+        final var instance = new Event("testLocalDateEvent", aDate);
+        assertEquals("testLocalDateEvent", instance.getName());
+        assertEquals(aDate, instance.getLocalDate());
+        assertEquals(aDate.toEpochDay(), instance.getDate());
+        assertEquals(TimeFormat.LOCAL_TIME, instance.getTimeFormat());
+    }
+
+    /**
+     * Test of getPersons and getPlaces methods, of class Event: both start out empty.
+     */
+    @Test
+    public void testPersonsAndPlacesStartEmpty() {
+        final var instance = new Event("testPersonsAndPlacesStartEmpty", 0L);
+        assertTrue(instance.getPersons().isEmpty());
+        assertTrue(instance.getPlaces().isEmpty());
+    }
+
+}

--- a/src/test/java/com/github/noony/app/timelinefx/core/EventTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/EventTest.java
@@ -25,7 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * @author solun
  */
-public class EventTest {
+public final class EventTest {
 
     public EventTest() {
     }

--- a/src/test/java/com/github/noony/app/timelinefx/core/EventTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/EventTest.java
@@ -24,10 +24,15 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
+ * Unit tests for {@link Event}.
+ *
  * @author solun
  */
 public final class EventTest {
 
+    /**
+     * Default constructor.
+     */
     public EventTest() {
     }
 

--- a/src/test/java/com/github/noony/app/timelinefx/core/EventTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/EventTest.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core;
 
 import java.time.LocalDate;

--- a/src/test/java/com/github/noony/app/timelinefx/core/FactoryTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/FactoryTest.java
@@ -34,17 +34,29 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 public final class FactoryTest {
 
+    /**
+     * The factory instance under test.
+     */
     private Factory<Place> instance;
 
+    /**
+     * Default constructor.
+     */
     public FactoryTest() {
     }
 
+    /**
+     * Sets up test fixtures before each test.
+     */
     @BeforeEach
     public void setUp() {
         PlaceFactory.reset();
         instance = new Factory<>();
     }
 
+    /**
+     * Tears down test fixtures after each test.
+     */
     @AfterEach
     public void tearDown() {
         PlaceFactory.reset();

--- a/src/test/java/com/github/noony/app/timelinefx/core/FactoryTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/FactoryTest.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core;
 
 import org.junit.jupiter.api.AfterEach;

--- a/src/test/java/com/github/noony/app/timelinefx/core/FactoryTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/FactoryTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) 2026 NoOnY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.github.noony.app.timelinefx.core;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Note: exercised with {@link Place} as the concrete {@link FriezeObject}, since it does not require a
+ * {@link TimeLineProject}.
+ *
+ * @author solun
+ */
+public class FactoryTest {
+
+    private Factory<Place> instance;
+
+    public FactoryTest() {
+    }
+
+    @BeforeEach
+    public void setUp() {
+        PlaceFactory.reset();
+        instance = new Factory<>();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        PlaceFactory.reset();
+    }
+
+    /**
+     * Test of getNextID method, of class Factory.
+     */
+    @Test
+    public void testGetNextID() {
+        assertEquals(0L, instance.getNextID());
+        assertEquals(1L, instance.getNextID());
+    }
+
+    /**
+     * Test of addObject and get methods, of class Factory.
+     */
+    @Test
+    public void testAddObjectAndGet() {
+        final var place = PlaceFactory.createPlace(7L, "testAddObjectAndGet", PlaceLevel.PLANET, null, null);
+        instance.addObject(place);
+        assertEquals(place, instance.get(7L));
+    }
+
+    /**
+     * Test of get method, of class Factory, with an unknown id.
+     */
+    @Test
+    public void testGetUnknownId() {
+        assertNull(instance.get(999L));
+    }
+
+    /**
+     * Test of addObject method, of class Factory, rejecting a duplicate id.
+     */
+    @Test
+    public void testAddObjectDuplicateId() {
+        final var place = PlaceFactory.createPlace(7L, "testAddObjectDuplicateId", PlaceLevel.PLANET, null, null);
+        instance.addObject(place);
+        assertThrows(IllegalStateException.class, () -> instance.addObject(place));
+    }
+
+    /**
+     * Test of isIdAvailable method, of class Factory.
+     */
+    @Test
+    public void testIsIdAvailable() {
+        assertTrue(instance.isIdAvailable(7L));
+        final var place = PlaceFactory.createPlace(7L, "testIsIdAvailable", PlaceLevel.PLANET, null, null);
+        instance.addObject(place);
+        assertFalse(instance.isIdAvailable(7L));
+    }
+
+    /**
+     * Test of getObjects method, of class Factory.
+     */
+    @Test
+    public void testGetObjects() {
+        assertTrue(instance.getObjects().isEmpty());
+        final var place = PlaceFactory.createPlace(7L, "testGetObjects", PlaceLevel.PLANET, null, null);
+        instance.addObject(place);
+        assertEquals(1, instance.getObjects().size());
+        assertTrue(instance.getObjects().contains(place));
+    }
+
+    /**
+     * Test of reset method, of class Factory.
+     */
+    @Test
+    public void testReset() {
+        final var place = PlaceFactory.createPlace(7L, "testReset", PlaceLevel.PLANET, null, null);
+        instance.addObject(place);
+        instance.reset();
+        assertTrue(instance.getObjects().isEmpty());
+        assertEquals(0L, instance.getNextID());
+    }
+
+}

--- a/src/test/java/com/github/noony/app/timelinefx/core/FactoryTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/FactoryTest.java
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  *
  * @author solun
  */
-public class FactoryTest {
+public final class FactoryTest {
 
     private Factory<Place> instance;
 

--- a/src/test/java/com/github/noony/app/timelinefx/core/FriezeFactoryTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/FriezeFactoryTest.java
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.io.TempDir;
 /**
  * @author solun
  */
-public class FriezeFactoryTest {
+public final class FriezeFactoryTest {
 
     @TempDir
     private Path tempDir;

--- a/src/test/java/com/github/noony/app/timelinefx/core/FriezeFactoryTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/FriezeFactoryTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C) 2026 NoOnY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.github.noony.app.timelinefx.core;
+
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * @author solun
+ */
+public class FriezeFactoryTest {
+
+    @TempDir
+    private Path tempDir;
+
+    private TimeLineProject project;
+
+    public FriezeFactoryTest() {
+    }
+
+    @BeforeEach
+    public void setUp() {
+        FriezeFactory.reset();
+        final var configParams = Map.of(TimeLineProject.PROJECT_FOLDER_KEY, tempDir.toString());
+        project = TimeLineProjectFactory.createProject("FriezeFactoryTest", configParams);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        FriezeFactory.reset();
+    }
+
+    /**
+     * Test of createFrieze and getFrieze methods, of class FriezeFactory.
+     */
+    @Test
+    public void testCreateFriezeAndGetFrieze() {
+        final var frieze = FriezeFactory.createFrieze(project, "testCreateFriezeAndGetFrieze");
+        assertEquals(frieze, FriezeFactory.getFrieze(frieze.getId()));
+        assertEquals(project, frieze.getProject());
+    }
+
+    /**
+     * Test of createFrieze method, of class FriezeFactory, with an explicit stays list.
+     */
+    @Test
+    public void testCreateFriezeWithStays() {
+        final var frieze = FriezeFactory.createFrieze(project, "testCreateFriezeWithStays", Collections.emptyList());
+        assertTrue(frieze.getStayPeriods().isEmpty());
+    }
+
+    /**
+     * Test of createFrieze method, of class FriezeFactory, with a specific id.
+     */
+    @Test
+    public void testCreateFriezeWithId() {
+        final var frieze = FriezeFactory.createFrieze(42L, project, "testCreateFriezeWithId", Collections.emptyList());
+        assertEquals(42L, frieze.getId());
+    }
+
+    /**
+     * Test of createFrieze method, of class FriezeFactory, rejecting a duplicate id.
+     */
+    @Test
+    public void testCreateFriezeDuplicateId() {
+        FriezeFactory.createFrieze(42L, project, "testCreateFriezeDuplicateIdA", Collections.emptyList());
+        assertThrows(IllegalArgumentException.class,
+                () -> FriezeFactory.createFrieze(42L, project, "testCreateFriezeDuplicateIdB", Collections.emptyList()));
+    }
+
+    /**
+     * Test of getFrieze method, of class FriezeFactory, with an unknown id.
+     */
+    @Test
+    public void testGetFriezeUnknownId() {
+        assertNull(FriezeFactory.getFrieze(999L));
+    }
+
+    /**
+     * Test of getFriezes method, of class FriezeFactory.
+     */
+    @Test
+    public void testGetFriezes() {
+        final var frieze = FriezeFactory.createFrieze(project, "testGetFriezes");
+        assertTrue(FriezeFactory.getFriezes().contains(frieze));
+    }
+
+    /**
+     * Test of reset method, of class FriezeFactory.
+     */
+    @Test
+    public void testReset() {
+        FriezeFactory.createFrieze(project, "testReset");
+        FriezeFactory.reset();
+        assertTrue(FriezeFactory.getFriezes().isEmpty());
+    }
+
+}

--- a/src/test/java/com/github/noony/app/timelinefx/core/FriezeFactoryTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/FriezeFactoryTest.java
@@ -30,18 +30,32 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
+ * Unit tests for {@link FriezeFactory}.
+ *
  * @author solun
  */
 public final class FriezeFactoryTest {
 
+    /**
+     * Temporary directory used to create a test project without touching the real user directories.
+     */
     @TempDir
     private Path tempDir;
 
+    /**
+     * The project used in these tests.
+     */
     private TimeLineProject project;
 
+    /**
+     * Default constructor.
+     */
     public FriezeFactoryTest() {
     }
 
+    /**
+     * Sets up test fixtures before each test.
+     */
     @BeforeEach
     public void setUp() {
         FriezeFactory.reset();
@@ -49,6 +63,9 @@ public final class FriezeFactoryTest {
         project = TimeLineProjectFactory.createProject("FriezeFactoryTest", configParams);
     }
 
+    /**
+     * Tears down test fixtures after each test.
+     */
     @AfterEach
     public void tearDown() {
         FriezeFactory.reset();

--- a/src/test/java/com/github/noony/app/timelinefx/core/FriezeFactoryTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/FriezeFactoryTest.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core;
 
 import java.nio.file.Path;
@@ -22,11 +23,11 @@ import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import org.junit.jupiter.api.io.TempDir;
 
 /**
  * @author solun

--- a/src/test/java/com/github/noony/app/timelinefx/core/FriezeObjectFactoryTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/FriezeObjectFactoryTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2026 NoOnY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.github.noony.app.timelinefx.core;
+
+import java.nio.file.Path;
+import java.time.LocalDateTime;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * @author solun
+ */
+public class FriezeObjectFactoryTest {
+
+    @TempDir
+    private Path tempDir;
+
+    public FriezeObjectFactoryTest() {
+    }
+
+    @BeforeEach
+    public void setUp() {
+        FriezeObjectFactory.reset();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        FriezeObjectFactory.reset();
+    }
+
+    /**
+     * Test of reset method, of class FriezeObjectFactory: resets every core factory.
+     */
+    @Test
+    public void testReset() {
+        final var configParams = Map.of(TimeLineProject.PROJECT_FOLDER_KEY, tempDir.toString());
+        final var project = TimeLineProjectFactory.createProject("FriezeObjectFactoryTest", configParams);
+        PlaceFactory.createPlace("testReset", PlaceLevel.PLANET, null);
+        PersonFactory.createPerson(project, "testReset");
+        PictureFactory.createPicture(project, 0L, "testReset", LocalDateTime.now(), "pictures/foo.png", 640, 480);
+        //
+        FriezeObjectFactory.reset();
+        //
+        assertTrue(PlaceFactory.getPlaces().isEmpty());
+        assertTrue(PersonFactory.getPERSONS().isEmpty());
+        assertTrue(PictureFactory.getPictures().isEmpty());
+    }
+
+}

--- a/src/test/java/com/github/noony/app/timelinefx/core/FriezeObjectFactoryTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/FriezeObjectFactoryTest.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core;
 
 import java.nio.file.Path;
@@ -22,8 +23,8 @@ import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.io.TempDir;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author solun

--- a/src/test/java/com/github/noony/app/timelinefx/core/FriezeObjectFactoryTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/FriezeObjectFactoryTest.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.io.TempDir;
 /**
  * @author solun
  */
-public class FriezeObjectFactoryTest {
+public final class FriezeObjectFactoryTest {
 
     @TempDir
     private Path tempDir;

--- a/src/test/java/com/github/noony/app/timelinefx/core/FriezeObjectFactoryTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/FriezeObjectFactoryTest.java
@@ -27,21 +27,35 @@ import org.junit.jupiter.api.io.TempDir;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
+ * Unit tests for {@link FriezeObjectFactory}.
+ *
  * @author solun
  */
 public final class FriezeObjectFactoryTest {
 
+    /**
+     * Temporary directory used to create a test project without touching the real user directories.
+     */
     @TempDir
     private Path tempDir;
 
+    /**
+     * Default constructor.
+     */
     public FriezeObjectFactoryTest() {
     }
 
+    /**
+     * Sets up test fixtures before each test.
+     */
     @BeforeEach
     public void setUp() {
         FriezeObjectFactory.reset();
     }
 
+    /**
+     * Tears down test fixtures after each test.
+     */
     @AfterEach
     public void tearDown() {
         FriezeObjectFactory.reset();

--- a/src/test/java/com/github/noony/app/timelinefx/core/FriezeTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/FriezeTest.java
@@ -47,20 +47,41 @@ public final class FriezeTest {
         }
     }
 
+    /**
+     * Temporary directory used to create a test project without touching the real user directories.
+     */
     @TempDir
     private Path tempDir;
 
+    /**
+     * The project used in these tests.
+     */
     private TimeLineProject project;
 
+    /**
+     * A person used in these tests.
+     */
     private Person person;
 
+    /**
+     * A place used in these tests.
+     */
     private Place place;
 
+    /**
+     * A stay used in these tests.
+     */
     private StayPeriod stay;
 
+    /**
+     * Default constructor.
+     */
     public FriezeTest() {
     }
 
+    /**
+     * Sets up test fixtures before each test.
+     */
     @BeforeEach
     public void setUp() {
         FriezeObjectFactory.reset();
@@ -72,6 +93,9 @@ public final class FriezeTest {
         stay = StayFactory.createStayPeriodSimpleTime(person, 10.0, 20.0, place);
     }
 
+    /**
+     * Tears down test fixtures after each test.
+     */
     @AfterEach
     public void tearDown() {
         FriezeObjectFactory.reset();

--- a/src/test/java/com/github/noony/app/timelinefx/core/FriezeTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/FriezeTest.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core;
 
 import java.nio.file.Path;
@@ -23,10 +24,10 @@ import javafx.application.Platform;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Note: {@link Frieze#addPerson(Person)} calls {@code Platform.runLater(...)}, which requires the JavaFX

--- a/src/test/java/com/github/noony/app/timelinefx/core/FriezeTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/FriezeTest.java
@@ -35,7 +35,7 @@ import org.junit.jupiter.api.io.TempDir;
  *
  * @author solun
  */
-public class FriezeTest {
+public final class FriezeTest {
 
     static {
         try {

--- a/src/test/java/com/github/noony/app/timelinefx/core/FriezeTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/FriezeTest.java
@@ -1,0 +1,293 @@
+/*
+ * Copyright (C) 2026 NoOnY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.github.noony.app.timelinefx.core;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import javafx.application.Platform;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Note: {@link Frieze#addPerson(Person)} calls {@code Platform.runLater(...)}, which requires the JavaFX
+ * toolkit to be initialized. Bootstrapped once here since plain JUnit tests don't run inside a JavaFX
+ * Application.
+ *
+ * @author solun
+ */
+public class FriezeTest {
+
+    static {
+        try {
+            Platform.startup(() -> {
+            });
+        } catch (IllegalStateException alreadyStarted) {
+            // toolkit already initialized elsewhere in this JVM -- fine
+        }
+    }
+
+    @TempDir
+    private Path tempDir;
+
+    private TimeLineProject project;
+
+    private Person person;
+
+    private Place place;
+
+    private StayPeriod stay;
+
+    public FriezeTest() {
+    }
+
+    @BeforeEach
+    public void setUp() {
+        FriezeObjectFactory.reset();
+        FriezeFactory.reset();
+        final var configParams = Map.of(TimeLineProject.PROJECT_FOLDER_KEY, tempDir.toString());
+        project = TimeLineProjectFactory.createProject("FriezeTest", configParams);
+        person = PersonFactory.createPerson(project, "testPerson");
+        place = PlaceFactory.createPlace("testPlace", PlaceLevel.PLANET, null);
+        stay = StayFactory.createStayPeriodSimpleTime(person, 10.0, 20.0, place);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        FriezeObjectFactory.reset();
+        FriezeFactory.reset();
+    }
+
+    /**
+     * Test of getId method, of class Frieze.
+     */
+    @Test
+    public void testGetId() {
+        final var instance = FriezeFactory.createFrieze(42L, project, "testGetId", List.of());
+        assertEquals(42L, instance.getId());
+    }
+
+    /**
+     * Test of getName and setName methods, of class Frieze.
+     */
+    @Test
+    public void testName() {
+        final var instance = FriezeFactory.createFrieze(project, "testName");
+        assertEquals("testName", instance.getName());
+        instance.setName("newName");
+        assertEquals("newName", instance.getName());
+    }
+
+    /**
+     * Test of getProject method, of class Frieze.
+     */
+    @Test
+    public void testGetProject() {
+        final var instance = FriezeFactory.createFrieze(project, "testGetProject");
+        assertEquals(project, instance.getProject());
+    }
+
+    /**
+     * Test of addStay, getStayPeriods and getNbStays methods, of class Frieze.
+     */
+    @Test
+    public void testAddStay() {
+        final var instance = FriezeFactory.createFrieze(project, "testAddStay");
+        assertTrue(instance.getStayPeriods().isEmpty());
+        instance.addStay(stay);
+        assertEquals(1, instance.getNbStays());
+        assertTrue(instance.getStayPeriods().contains(stay));
+        assertTrue(instance.getPersons().contains(person));
+        assertTrue(instance.getPlaces().contains(place));
+    }
+
+    /**
+     * Test of removeStay method, of class Frieze.
+     */
+    @Test
+    public void testRemoveStay() {
+        final var instance = FriezeFactory.createFrieze(project, "testRemoveStay");
+        instance.addStay(stay);
+        instance.removeStay(stay);
+        assertTrue(instance.getStayPeriods().isEmpty());
+    }
+
+    /**
+     * Test of addAllStays(StayPeriod...) and removeAllStays(StayPeriod...) methods, of class Frieze.
+     */
+    @Test
+    public void testAddRemoveAllStaysVarargs() {
+        final var instance = FriezeFactory.createFrieze(project, "testAddRemoveAllStaysVarargs");
+        instance.addAllStays(stay);
+        assertEquals(1, instance.getNbStays());
+        instance.removeAllStays(stay);
+        assertTrue(instance.getStayPeriods().isEmpty());
+    }
+
+    /**
+     * Test of addAllStays(Collection) and removeAllStays(Collection) methods, of class Frieze.
+     */
+    @Test
+    public void testAddRemoveAllStaysCollection() {
+        final var instance = FriezeFactory.createFrieze(project, "testAddRemoveAllStaysCollection");
+        instance.addAllStays(List.of(stay));
+        assertEquals(1, instance.getNbStays());
+        instance.removeAllStays(List.of(stay));
+        assertTrue(instance.getStayPeriods().isEmpty());
+    }
+
+    /**
+     * Test of getStayPeriods(Person) and getStayPeriods(Place) methods, of class Frieze.
+     */
+    @Test
+    public void testGetStayPeriodsByPersonAndPlace() {
+        final var instance = FriezeFactory.createFrieze(project, "testGetStayPeriodsByPersonAndPlace");
+        instance.addStay(stay);
+        assertEquals(List.of(stay), instance.getStayPeriods(person));
+        assertEquals(List.of(stay), instance.getStayPeriods(place));
+    }
+
+    /**
+     * Test of getStayIndex method, of class Frieze.
+     */
+    @Test
+    public void testGetStayIndex() {
+        final var instance = FriezeFactory.createFrieze(project, "testGetStayIndex");
+        instance.addStay(stay);
+        assertEquals(instance.getPersons().indexOf(person), instance.getStayIndex(stay));
+    }
+
+    /**
+     * Test of updatePersonSelection method, of class Frieze.
+     */
+    @Test
+    public void testUpdatePersonSelection() {
+        final var instance = FriezeFactory.createFrieze(project, "testUpdatePersonSelection");
+        instance.updatePersonSelection(person, true);
+        assertTrue(instance.getPersons().contains(person));
+        instance.updatePersonSelection(person, false);
+        assertFalse(instance.getPersons().contains(person));
+    }
+
+    /**
+     * Test of updatePeopleSelection method, of class Frieze.
+     */
+    @Test
+    public void testUpdatePeopleSelection() {
+        final var instance = FriezeFactory.createFrieze(project, "testUpdatePeopleSelection");
+        instance.updatePeopleSelection(person, true);
+        assertTrue(instance.getPersons().contains(person));
+        instance.updatePeopleSelection(person, false);
+        assertFalse(instance.getPersons().contains(person));
+    }
+
+    /**
+     * Test of getPersonsAtPlace method, of class Frieze.
+     */
+    @Test
+    public void testGetPersonsAtPlace() {
+        final var instance = FriezeFactory.createFrieze(project, "testGetPersonsAtPlace");
+        assertTrue(instance.getPersonsAtPlace(place).isEmpty());
+        instance.addStay(stay);
+        assertTrue(instance.getPersonsAtPlace(place).contains(person));
+    }
+
+    /**
+     * Test of getMinDate, getMaxDate and getNbDates methods, of class Frieze.
+     */
+    @Test
+    public void testDatesRange() {
+        final var instance = FriezeFactory.createFrieze(project, "testDatesRange");
+        instance.addStay(stay);
+        assertEquals(10.0, instance.getMinDate());
+        assertEquals(20.0, instance.getMaxDate());
+        assertEquals(2, instance.getNbDates());
+        assertTrue(instance.getDates().containsAll(List.of(10.0, 20.0)));
+        assertTrue(instance.getStartDates().contains(10.0));
+        assertTrue(instance.getEndDates().contains(20.0));
+    }
+
+    /**
+     * Test of getMinDateWindow, setMinDateWindow, getMaxDateWindow and setMaxDateWindow methods, of class Frieze.
+     */
+    @Test
+    public void testDateWindow() {
+        final var instance = FriezeFactory.createFrieze(project, "testDateWindow");
+        instance.setMinDateWindow(5.0);
+        assertEquals(5.0, instance.getMinDateWindow());
+        instance.setMaxDateWindow(50.0);
+        assertEquals(50.0, instance.getMaxDateWindow());
+    }
+
+    /**
+     * Test of getTimeFormat method, of class Frieze.
+     */
+    @Test
+    public void testGetTimeFormat() {
+        final var instance = FriezeFactory.createFrieze(project, "testGetTimeFormat");
+        assertEquals(TimeFormat.TIME_MIN, instance.getTimeFormat());
+        instance.addStay(stay);
+        assertEquals(stay.getTimeFormat(), instance.getTimeFormat());
+    }
+
+    /**
+     * Test of toString method, of class Frieze.
+     */
+    @Test
+    public void testToString() {
+        final var instance = FriezeFactory.createFrieze(project, "testToString");
+        assertEquals("Frieze [testToString].", instance.toString());
+    }
+
+    /**
+     * Test of addListener/removeListener methods, of class Frieze.
+     */
+    @Test
+    public void testListener() {
+        final var instance = FriezeFactory.createFrieze(project, "testListener");
+        final var fired = new boolean[]{false};
+        final java.beans.PropertyChangeListener listener = e -> fired[0] = true;
+        instance.addListener(listener);
+        instance.addStay(stay);
+        assertTrue(fired[0]);
+        //
+        fired[0] = false;
+        instance.removeListener(listener);
+        instance.removeStay(stay);
+        assertFalse(fired[0]);
+    }
+
+    /**
+     * Test of createFriezeFreeMap, addFriezeFreeMap, removeFriezeFreeMap and getFriezeFreeMaps methods, of class
+     * Frieze.
+     */
+    @Test
+    public void testFriezeFreeMaps() {
+        final var instance = FriezeFactory.createFrieze(project, "testFriezeFreeMaps");
+        instance.addStay(stay);
+        final var freeMap = instance.createFriezeFreeMap();
+        assertTrue(instance.getFriezeFreeMaps().contains(freeMap));
+        instance.removeFriezeFreeMap(freeMap);
+        assertFalse(instance.getFriezeFreeMaps().contains(freeMap));
+    }
+
+}

--- a/src/test/java/com/github/noony/app/timelinefx/core/ItemSelectionPropagationTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/ItemSelectionPropagationTest.java
@@ -23,7 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 /**
  * @author solun
  */
-public class ItemSelectionPropagationTest {
+public final class ItemSelectionPropagationTest {
 
     public ItemSelectionPropagationTest() {
     }

--- a/src/test/java/com/github/noony/app/timelinefx/core/ItemSelectionPropagationTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/ItemSelectionPropagationTest.java
@@ -22,10 +22,15 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
+ * Unit tests for {@link ItemSelectionPropagation}.
+ *
  * @author solun
  */
 public final class ItemSelectionPropagationTest {
 
+    /**
+     * Default constructor.
+     */
     public ItemSelectionPropagationTest() {
     }
 

--- a/src/test/java/com/github/noony/app/timelinefx/core/ItemSelectionPropagationTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/ItemSelectionPropagationTest.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core;
 
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/github/noony/app/timelinefx/core/ItemSelectionPropagationTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/ItemSelectionPropagationTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2026 NoOnY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.github.noony.app.timelinefx.core;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * @author solun
+ */
+public class ItemSelectionPropagationTest {
+
+    public ItemSelectionPropagationTest() {
+    }
+
+    /**
+     * Test of values method, of class ItemSelectionPropagation.
+     */
+    @Test
+    public void testValues() {
+        assertArrayEquals(new ItemSelectionPropagation[]{ItemSelectionPropagation.NONE, ItemSelectionPropagation.RECURSIVE}, ItemSelectionPropagation.values());
+    }
+
+    /**
+     * Test of valueOf method, of class ItemSelectionPropagation.
+     */
+    @Test
+    public void testValueOf() {
+        assertSame(ItemSelectionPropagation.RECURSIVE, ItemSelectionPropagation.valueOf("RECURSIVE"));
+    }
+
+}

--- a/src/test/java/com/github/noony/app/timelinefx/core/MessagesTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/MessagesTest.java
@@ -22,10 +22,15 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
+ * Unit tests for {@link Messages}.
+ *
  * @author solun
  */
 public final class MessagesTest {
 
+    /**
+     * Default constructor.
+     */
     public MessagesTest() {
     }
 

--- a/src/test/java/com/github/noony/app/timelinefx/core/MessagesTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/MessagesTest.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core;
 
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/github/noony/app/timelinefx/core/MessagesTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/MessagesTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2026 NoOnY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.github.noony.app.timelinefx.core;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * @author solun
+ */
+public class MessagesTest {
+
+    public MessagesTest() {
+    }
+
+    /**
+     * Test that UNSUPPORTED_TIME_FORMAT is a non-empty, stable message prefix.
+     */
+    @Test
+    public void testUnsupportedTimeFormat() {
+        assertNotNull(Messages.UNSUPPORTED_TIME_FORMAT);
+        assertEquals("Unsupported time format: ", Messages.UNSUPPORTED_TIME_FORMAT);
+    }
+
+}

--- a/src/test/java/com/github/noony/app/timelinefx/core/PersonFactoryTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/PersonFactoryTest.java
@@ -33,7 +33,7 @@ import org.junit.jupiter.api.io.TempDir;
  *
  * @author solun
  */
-public class PersonFactoryTest {
+public final class PersonFactoryTest {
 
     @TempDir
     private Path tempDir;

--- a/src/test/java/com/github/noony/app/timelinefx/core/PersonFactoryTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/PersonFactoryTest.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core;
 
 import java.nio.file.Path;
@@ -22,10 +23,10 @@ import javafx.scene.paint.Color;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Note: uses a real {@link TimeLineProject}, created in a JUnit {@code @TempDir} via an explicit

--- a/src/test/java/com/github/noony/app/timelinefx/core/PersonFactoryTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/PersonFactoryTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) 2026 NoOnY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.github.noony.app.timelinefx.core;
+
+import java.nio.file.Path;
+import java.util.Map;
+import javafx.scene.paint.Color;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Note: uses a real {@link TimeLineProject}, created in a JUnit {@code @TempDir} via an explicit
+ * {@link TimeLineProject#PROJECT_FOLDER_KEY} override so it never touches the real user home directory.
+ *
+ * @author solun
+ */
+public class PersonFactoryTest {
+
+    @TempDir
+    private Path tempDir;
+
+    private TimeLineProject project;
+
+    public PersonFactoryTest() {
+    }
+
+    @BeforeEach
+    public void setUp() {
+        PersonFactory.reset();
+        final var configParams = Map.of(TimeLineProject.PROJECT_FOLDER_KEY, tempDir.toString());
+        project = TimeLineProjectFactory.createProject("PersonFactoryTest", configParams);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        PersonFactory.reset();
+    }
+
+    /**
+     * Test of createPerson and getPerson methods, of class PersonFactory.
+     */
+    @Test
+    public void testCreatePersonAndGetPerson() {
+        final var person = PersonFactory.createPerson(project, "testCreatePersonAndGetPerson");
+        assertEquals(person, PersonFactory.getPerson(person.getId()));
+        assertEquals(project, person.getProject());
+    }
+
+    /**
+     * Test of getPerson method, of class PersonFactory, with an unknown id.
+     */
+    @Test
+    public void testGetPersonUnknownId() {
+        assertNull(PersonFactory.getPerson(999L));
+    }
+
+    /**
+     * Test of createPerson method, of class PersonFactory, with a color.
+     */
+    @Test
+    public void testCreatePersonWithColor() {
+        final var person = PersonFactory.createPerson(project, "testCreatePersonWithColor", Color.CORAL);
+        assertEquals(Color.CORAL, person.getColor());
+    }
+
+    /**
+     * Test of createPerson method, of class PersonFactory, with a specific id.
+     */
+    @Test
+    public void testCreatePersonWithId() {
+        final var person = PersonFactory.createPerson(project, 42L, "testCreatePersonWithId", Color.CORAL);
+        assertEquals(42L, person.getId());
+    }
+
+    /**
+     * Test of createPerson method, of class PersonFactory, rejecting a duplicate id.
+     */
+    @Test
+    public void testCreatePersonDuplicateId() {
+        PersonFactory.createPerson(project, 42L, "testCreatePersonDuplicateIdA", Color.CORAL);
+        assertThrows(IllegalArgumentException.class,
+                () -> PersonFactory.createPerson(project, 42L, "testCreatePersonDuplicateIdB", Color.CORAL));
+    }
+
+    /**
+     * Test of getPERSONS method, of class PersonFactory: sorted by name.
+     */
+    @Test
+    public void testGetPersons() {
+        PersonFactory.createPerson(project, "Zebra");
+        PersonFactory.createPerson(project, "Apple");
+        final var persons = PersonFactory.getPERSONS();
+        assertEquals(2, persons.size());
+        assertEquals("Apple", persons.get(0).getName());
+        assertEquals("Zebra", persons.get(1).getName());
+    }
+
+    /**
+     * Test of reset method, of class PersonFactory.
+     */
+    @Test
+    public void testReset() {
+        PersonFactory.createPerson(project, "testReset");
+        PersonFactory.reset();
+        assertEquals(0, PersonFactory.getPERSONS().size());
+    }
+
+}

--- a/src/test/java/com/github/noony/app/timelinefx/core/PersonFactoryTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/PersonFactoryTest.java
@@ -36,14 +36,26 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  */
 public final class PersonFactoryTest {
 
+    /**
+     * Temporary directory used to create a test project without touching the real user directories.
+     */
     @TempDir
     private Path tempDir;
 
+    /**
+     * The project used in these tests.
+     */
     private TimeLineProject project;
 
+    /**
+     * Default constructor.
+     */
     public PersonFactoryTest() {
     }
 
+    /**
+     * Sets up test fixtures before each test.
+     */
     @BeforeEach
     public void setUp() {
         PersonFactory.reset();
@@ -51,6 +63,9 @@ public final class PersonFactoryTest {
         project = TimeLineProjectFactory.createProject("PersonFactoryTest", configParams);
     }
 
+    /**
+     * Tears down test fixtures after each test.
+     */
     @AfterEach
     public void tearDown() {
         PersonFactory.reset();

--- a/src/test/java/com/github/noony/app/timelinefx/core/PersonTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/PersonTest.java
@@ -32,18 +32,32 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
+ * Unit tests for {@link Person}.
+ *
  * @author solun
  */
 public final class PersonTest {
 
+    /**
+     * Temporary directory used to create a test project without touching the real user directories.
+     */
     @TempDir
     private Path tempDir;
 
+    /**
+     * The project used in these tests.
+     */
     private TimeLineProject project;
 
+    /**
+     * Default constructor.
+     */
     public PersonTest() {
     }
 
+    /**
+     * Sets up test fixtures before each test.
+     */
     @BeforeEach
     public void setUp() {
         PersonFactory.reset();
@@ -52,6 +66,9 @@ public final class PersonTest {
         project = TimeLineProjectFactory.createProject("PersonTest", configParams);
     }
 
+    /**
+     * Tears down test fixtures after each test.
+     */
     @AfterEach
     public void tearDown() {
         PersonFactory.reset();

--- a/src/test/java/com/github/noony/app/timelinefx/core/PersonTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/PersonTest.java
@@ -33,7 +33,7 @@ import org.junit.jupiter.api.io.TempDir;
 /**
  * @author solun
  */
-public class PersonTest {
+public final class PersonTest {
 
     @TempDir
     private Path tempDir;

--- a/src/test/java/com/github/noony/app/timelinefx/core/PersonTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/PersonTest.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core;
 
 import java.nio.file.Path;
@@ -23,12 +24,12 @@ import javafx.scene.paint.Color;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import org.junit.jupiter.api.io.TempDir;
 
 /**
  * @author solun

--- a/src/test/java/com/github/noony/app/timelinefx/core/PersonTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/PersonTest.java
@@ -1,0 +1,261 @@
+/*
+ * Copyright (C) 2026 NoOnY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.github.noony.app.timelinefx.core;
+
+import java.nio.file.Path;
+import java.time.LocalDate;
+import java.util.Map;
+import javafx.scene.paint.Color;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * @author solun
+ */
+public class PersonTest {
+
+    @TempDir
+    private Path tempDir;
+
+    private TimeLineProject project;
+
+    public PersonTest() {
+    }
+
+    @BeforeEach
+    public void setUp() {
+        PersonFactory.reset();
+        PortraitFactory.reset();
+        final var configParams = Map.of(TimeLineProject.PROJECT_FOLDER_KEY, tempDir.toString());
+        project = TimeLineProjectFactory.createProject("PersonTest", configParams);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        PersonFactory.reset();
+        PortraitFactory.reset();
+    }
+
+    /**
+     * Test of getId method, of class Person.
+     */
+    @Test
+    public void testGetId() {
+        final var instance = PersonFactory.createPerson(project, 23L, "testGetId", Color.CORAL);
+        assertEquals(23L, instance.getId());
+    }
+
+    /**
+     * Test of getProject method, of class Person.
+     */
+    @Test
+    public void testGetProject() {
+        final var instance = PersonFactory.createPerson(project, "testGetProject");
+        assertEquals(project, instance.getProject());
+    }
+
+    /**
+     * Test of getName and setName methods, of class Person.
+     */
+    @Test
+    public void testName() {
+        final var instance = PersonFactory.createPerson(project, "testName");
+        assertEquals("testName", instance.getName());
+        instance.setName("newName");
+        assertEquals("newName", instance.getName());
+    }
+
+    /**
+     * Test of getColor and setColor methods, of class Person.
+     */
+    @Test
+    public void testColor() {
+        final var instance = PersonFactory.createPerson(project, "testColor", Color.CORAL);
+        assertEquals(Color.CORAL, instance.getColor());
+        instance.setColor(Color.OLDLACE);
+        assertEquals(Color.OLDLACE, instance.getColor());
+    }
+
+    /**
+     * Test of getDefaultPortrait method, of class Person: lazily created on first access.
+     */
+    @Test
+    public void testGetDefaultPortrait() {
+        final var instance = PersonFactory.createPerson(project, "testGetDefaultPortrait");
+        final var portrait = instance.getDefaultPortrait();
+        assertNotNull(portrait);
+        assertEquals(portrait, instance.getDefaultPortrait());
+    }
+
+    /**
+     * Test of addPortrait, getPortraits, getPortrait and removePortrait methods, of class Person.
+     */
+    @Test
+    public void testPortraits() {
+        final var instance = PersonFactory.createPerson(project, "testPortraits");
+        assertTrue(instance.getPortraits().isEmpty());
+        final var portrait = PortraitFactory.createPortrait(instance);
+        instance.addPortrait(portrait);
+        assertEquals(1, instance.getPortraits().size());
+        assertEquals(portrait, instance.getPortrait(portrait.getId()));
+        //
+        instance.removePortrait(portrait);
+        assertTrue(instance.getPortraits().isEmpty());
+        assertNull(instance.getPortrait(portrait.getId()));
+    }
+
+    /**
+     * Test of setDefaultPortrait method, of class Person.
+     */
+    @Test
+    public void testSetDefaultPortrait() {
+        final var instance = PersonFactory.createPerson(project, "testSetDefaultPortrait");
+        final var portrait = PortraitFactory.createPortrait(instance);
+        instance.setDefaultPortrait(portrait);
+        assertEquals(portrait, instance.getDefaultPortrait());
+        assertTrue(instance.getPortraits().contains(portrait));
+    }
+
+    /**
+     * Test of getTimeFormat and setTimeFormat methods, of class Person.
+     */
+    @Test
+    public void testTimeFormat() {
+        final var instance = PersonFactory.createPerson(project, "testTimeFormat");
+        assertEquals(TimeFormat.TIME_MIN, instance.getTimeFormat());
+        instance.setTimeFormat(TimeFormat.LOCAL_TIME);
+        assertEquals(TimeFormat.LOCAL_TIME, instance.getTimeFormat());
+    }
+
+    /**
+     * Test of getDateOfBirth and setDateOfBirth methods, of class Person.
+     */
+    @Test
+    public void testDateOfBirth() {
+        final var instance = PersonFactory.createPerson(project, "testDateOfBirth");
+        final var dob = LocalDate.of(1990, 1, 2);
+        instance.setDateOfBirth(dob);
+        assertEquals(dob, instance.getDateOfBirth());
+        assertEquals(TimeFormat.LOCAL_TIME, instance.getTimeFormat());
+        assertEquals(dob.toEpochDay(), instance.getAbsolutTimeOfBirth());
+    }
+
+    /**
+     * Test of getDateOfDeath and setDateOfDeath methods, of class Person.
+     */
+    @Test
+    public void testDateOfDeath() {
+        final var instance = PersonFactory.createPerson(project, "testDateOfDeath");
+        final var dod = LocalDate.of(2020, 1, 2);
+        instance.setDateOfDeath(dod);
+        assertEquals(dod, instance.getDateOfDeath());
+        assertEquals(TimeFormat.LOCAL_TIME, instance.getTimeFormat());
+        assertEquals(dod.toEpochDay(), instance.getAbsolutTimeOfDeath());
+    }
+
+    /**
+     * Test of getTimeOfBirth and setTimeOfBirth methods, of class Person.
+     */
+    @Test
+    public void testTimeOfBirth() {
+        final var instance = PersonFactory.createPerson(project, "testTimeOfBirth");
+        instance.setTimeOfBirth(42L);
+        assertEquals(42L, instance.getTimeOfBirth());
+        assertEquals(TimeFormat.TIME_MIN, instance.getTimeFormat());
+        assertEquals(42L, instance.getAbsolutTimeOfBirth());
+    }
+
+    /**
+     * Test of getTimeOfDeath and setTimeOfDeath methods, of class Person.
+     */
+    @Test
+    public void testTimeOfDeath() {
+        final var instance = PersonFactory.createPerson(project, "testTimeOfDeath");
+        instance.setTimeOfDeath(99L);
+        assertEquals(99L, instance.getTimeOfDeath());
+        assertEquals(TimeFormat.TIME_MIN, instance.getTimeFormat());
+        assertEquals(99L, instance.getAbsolutTimeOfDeath());
+    }
+
+    /**
+     * Test of setSelected and isSelected methods, of class Person.
+     */
+    @Test
+    public void testSelected() {
+        final var instance = PersonFactory.createPerson(project, "testSelected");
+        assertFalse(instance.isSelected());
+        instance.setSelected(true);
+        assertTrue(instance.isSelected());
+    }
+
+    /**
+     * Test of setVisible and isVisible methods, of class Person.
+     */
+    @Test
+    public void testVisible() {
+        final var instance = PersonFactory.createPerson(project, "testVisible");
+        assertTrue(instance.isVisible());
+        instance.setVisible(false);
+        assertFalse(instance.isVisible());
+    }
+
+    /**
+     * Test of toString method, of class Person.
+     */
+    @Test
+    public void testToString() {
+        final var instance = PersonFactory.createPerson(project, "testToString");
+        assertEquals("testToString", instance.toString());
+    }
+
+    /**
+     * Test of addPropertyChangeListener/removePropertyChangeListener methods, of class Person.
+     */
+    @Test
+    public void testPropertyChangeListener() {
+        final var instance = PersonFactory.createPerson(project, "testPropertyChangeListener");
+        final var fired = new boolean[]{false};
+        final java.beans.PropertyChangeListener listener = e -> fired[0] = true;
+        instance.addPropertyChangeListener(listener);
+        instance.setName("newName");
+        assertTrue(fired[0]);
+        //
+        fired[0] = false;
+        instance.removePropertyChangeListener(listener);
+        instance.setName("anotherName");
+        assertFalse(fired[0]);
+    }
+
+    /**
+     * Test of COMPARATOR field, of class Person.
+     */
+    @Test
+    public void testComparator() {
+        final var zebra = PersonFactory.createPerson(project, "Zebra");
+        final var apple = PersonFactory.createPerson(project, "Apple");
+        assertTrue(Person.COMPARATOR.compare(apple, zebra) < 0);
+        assertTrue(Person.COMPARATOR.compare(zebra, apple) > 0);
+    }
+
+}

--- a/src/test/java/com/github/noony/app/timelinefx/core/PictureFactoryTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/PictureFactoryTest.java
@@ -35,7 +35,7 @@ import org.junit.jupiter.api.io.TempDir;
  *
  * @author solun
  */
-public class PictureFactoryTest {
+public final class PictureFactoryTest {
 
     @TempDir
     private Path tempDir;

--- a/src/test/java/com/github/noony/app/timelinefx/core/PictureFactoryTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/PictureFactoryTest.java
@@ -38,14 +38,26 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 public final class PictureFactoryTest {
 
+    /**
+     * Temporary directory used to create a test project without touching the real user directories.
+     */
     @TempDir
     private Path tempDir;
 
+    /**
+     * The project used in these tests.
+     */
     private TimeLineProject project;
 
+    /**
+     * Default constructor.
+     */
     public PictureFactoryTest() {
     }
 
+    /**
+     * Sets up test fixtures before each test.
+     */
     @BeforeEach
     public void setUp() {
         PictureFactory.reset();
@@ -53,6 +65,9 @@ public final class PictureFactoryTest {
         project = TimeLineProjectFactory.createProject("PictureFactoryTest", configParams);
     }
 
+    /**
+     * Tears down test fixtures after each test.
+     */
     @AfterEach
     public void tearDown() {
         PictureFactory.reset();

--- a/src/test/java/com/github/noony/app/timelinefx/core/PictureFactoryTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/PictureFactoryTest.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core;
 
 import java.nio.file.Path;
@@ -22,11 +23,11 @@ import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Note: uses a real {@link TimeLineProject}, created in a JUnit {@code @TempDir}. Only the id-based

--- a/src/test/java/com/github/noony/app/timelinefx/core/PictureFactoryTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/PictureFactoryTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (C) 2026 NoOnY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.github.noony.app.timelinefx.core;
+
+import java.nio.file.Path;
+import java.time.LocalDateTime;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Note: uses a real {@link TimeLineProject}, created in a JUnit {@code @TempDir}. Only the id-based
+ * {@code createPicture} overload is exercised; the file-copying overload needs a real, parseable image file
+ * and is left to integration testing.
+ *
+ * @author solun
+ */
+public class PictureFactoryTest {
+
+    @TempDir
+    private Path tempDir;
+
+    private TimeLineProject project;
+
+    public PictureFactoryTest() {
+    }
+
+    @BeforeEach
+    public void setUp() {
+        PictureFactory.reset();
+        final var configParams = Map.of(TimeLineProject.PROJECT_FOLDER_KEY, tempDir.toString());
+        project = TimeLineProjectFactory.createProject("PictureFactoryTest", configParams);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        PictureFactory.reset();
+    }
+
+    /**
+     * Test of createPicture and getPicture methods, of class PictureFactory.
+     */
+    @Test
+    public void testCreatePictureAndGetPicture() {
+        final var creationDate = LocalDateTime.of(2023, 1, 2, 3, 4, 5);
+        final var picture = PictureFactory.createPicture(project, 7L, "testCreatePictureAndGetPicture", creationDate, "pictures/foo.png", 640, 480);
+        assertEquals(picture, PictureFactory.getPicture(7L));
+        assertEquals(640, picture.getWidth());
+        assertEquals(480, picture.getHeight());
+    }
+
+    /**
+     * Test of getPicture method, of class PictureFactory, with an unknown id.
+     */
+    @Test
+    public void testGetPictureUnknownId() {
+        assertNull(PictureFactory.getPicture(999L));
+    }
+
+    /**
+     * Test of createPicture method, of class PictureFactory, rejecting a duplicate id.
+     */
+    @Test
+    public void testCreatePictureDuplicateId() {
+        final var creationDate = LocalDateTime.of(2023, 1, 2, 3, 4, 5);
+        PictureFactory.createPicture(project, 7L, "testCreatePictureDuplicateIdA", creationDate, "pictures/foo.png", 640, 480);
+        assertThrows(IllegalArgumentException.class,
+                () -> PictureFactory.createPicture(project, 7L, "testCreatePictureDuplicateIdB", creationDate, "pictures/bar.png", 640, 480));
+    }
+
+    /**
+     * Test of getPictures method, of class PictureFactory.
+     */
+    @Test
+    public void testGetPictures() {
+        final var creationDate = LocalDateTime.of(2023, 1, 2, 3, 4, 5);
+        final var picture = PictureFactory.createPicture(project, 7L, "testGetPictures", creationDate, "pictures/foo.png", 640, 480);
+        assertTrue(PictureFactory.getPictures().contains(picture));
+    }
+
+    /**
+     * Test of addPropertyChangeListener method, of class PictureFactory: fires PICTURE_ADDED.
+     */
+    @Test
+    public void testAddPropertyChangeListener() {
+        final var fired = new boolean[]{false};
+        final java.beans.PropertyChangeListener listener = e -> {
+            if (PictureFactory.PICTURE_ADDED.equals(e.getPropertyName())) {
+                fired[0] = true;
+            }
+        };
+        PictureFactory.addPropertyChangeListener(listener);
+        final var creationDate = LocalDateTime.of(2023, 1, 2, 3, 4, 5);
+        PictureFactory.createPicture(project, 7L, "testAddPropertyChangeListener", creationDate, "pictures/foo.png", 640, 480);
+        assertTrue(fired[0]);
+        //
+        fired[0] = false;
+        PictureFactory.removePropertyChangeListener(listener);
+        PictureFactory.createPicture(project, 8L, "testAddPropertyChangeListener2", creationDate, "pictures/bar.png", 640, 480);
+        assertTrue(!fired[0]);
+    }
+
+    /**
+     * Test of reset method, of class PictureFactory.
+     */
+    @Test
+    public void testReset() {
+        final var creationDate = LocalDateTime.of(2023, 1, 2, 3, 4, 5);
+        PictureFactory.createPicture(project, 7L, "testReset", creationDate, "pictures/foo.png", 640, 480);
+        PictureFactory.reset();
+        assertTrue(PictureFactory.getPictures().isEmpty());
+    }
+
+}

--- a/src/test/java/com/github/noony/app/timelinefx/core/PictureInfoTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/PictureInfoTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2026 NoOnY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.github.noony.app.timelinefx.core;
+
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * @author solun
+ */
+public class PictureInfoTest {
+
+    public PictureInfoTest() {
+    }
+
+    /**
+     * Test of the getters, of class PictureInfo.
+     */
+    @Test
+    public void testGetters() {
+        final var name = "Foo.png";
+        final var path = "pictures/Foo.png";
+        final var creationDate = LocalDateTime.of(2023, 1, 2, 3, 4, 5);
+        final var width = 640;
+        final var height = 480;
+        final var instance = new PictureInfo(name, path, creationDate, width, height);
+        assertEquals(name, instance.getName());
+        assertEquals(path, instance.getPath());
+        assertEquals(creationDate, instance.getCreationDate());
+        assertEquals(width, instance.getWidth());
+        assertEquals(height, instance.getHeight());
+    }
+
+}

--- a/src/test/java/com/github/noony/app/timelinefx/core/PictureInfoTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/PictureInfoTest.java
@@ -23,7 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 /**
  * @author solun
  */
-public class PictureInfoTest {
+public final class PictureInfoTest {
 
     public PictureInfoTest() {
     }

--- a/src/test/java/com/github/noony/app/timelinefx/core/PictureInfoTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/PictureInfoTest.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core;
 
 import java.time.LocalDateTime;

--- a/src/test/java/com/github/noony/app/timelinefx/core/PictureInfoTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/PictureInfoTest.java
@@ -22,10 +22,15 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
+ * Unit tests for {@link PictureInfo}.
+ *
  * @author solun
  */
 public final class PictureInfoTest {
 
+    /**
+     * Default constructor.
+     */
     public PictureInfoTest() {
     }
 

--- a/src/test/java/com/github/noony/app/timelinefx/core/PictureTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/PictureTest.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core;
 
 import java.io.File;
@@ -24,10 +25,10 @@ import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Note: also covers the {@link AbstractPicture} behavior shared with {@link Portrait}, since

--- a/src/test/java/com/github/noony/app/timelinefx/core/PictureTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/PictureTest.java
@@ -35,7 +35,7 @@ import org.junit.jupiter.api.io.TempDir;
  *
  * @author solun
  */
-public class PictureTest {
+public final class PictureTest {
 
     @TempDir
     private Path tempDir;

--- a/src/test/java/com/github/noony/app/timelinefx/core/PictureTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/PictureTest.java
@@ -38,20 +38,41 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 public final class PictureTest {
 
+    /**
+     * Temporary directory used to create a test project without touching the real user directories.
+     */
     @TempDir
     private Path tempDir;
 
+    /**
+     * The project used in these tests.
+     */
     private TimeLineProject project;
 
+    /**
+     * A person used in these tests.
+     */
     private Person personA;
 
+    /**
+     * Another person used in these tests.
+     */
     private Person personB;
 
+    /**
+     * A place used in these tests.
+     */
     private Place place;
 
+    /**
+     * Default constructor.
+     */
     public PictureTest() {
     }
 
+    /**
+     * Sets up test fixtures before each test.
+     */
     @BeforeEach
     public void setUp() {
         PictureFactory.reset();
@@ -64,6 +85,9 @@ public final class PictureTest {
         place = PlaceFactory.createPlace("testPlace", PlaceLevel.PLANET, null);
     }
 
+    /**
+     * Tears down test fixtures after each test.
+     */
     @AfterEach
     public void tearDown() {
         PictureFactory.reset();

--- a/src/test/java/com/github/noony/app/timelinefx/core/PictureTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/PictureTest.java
@@ -1,0 +1,243 @@
+/*
+ * Copyright (C) 2026 NoOnY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.github.noony.app.timelinefx.core;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Note: also covers the {@link AbstractPicture} behavior shared with {@link Portrait}, since
+ * {@code AbstractPicture} is abstract and {@link Picture} does not override most of it.
+ *
+ * @author solun
+ */
+public class PictureTest {
+
+    @TempDir
+    private Path tempDir;
+
+    private TimeLineProject project;
+
+    private Person personA;
+
+    private Person personB;
+
+    private Place place;
+
+    public PictureTest() {
+    }
+
+    @BeforeEach
+    public void setUp() {
+        PictureFactory.reset();
+        PersonFactory.reset();
+        PlaceFactory.reset();
+        final var configParams = Map.of(TimeLineProject.PROJECT_FOLDER_KEY, tempDir.toString());
+        project = TimeLineProjectFactory.createProject("PictureTest", configParams);
+        personA = PersonFactory.createPerson(project, "personA");
+        personB = PersonFactory.createPerson(project, "personB");
+        place = PlaceFactory.createPlace("testPlace", PlaceLevel.PLANET, null);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        PictureFactory.reset();
+        PersonFactory.reset();
+        PlaceFactory.reset();
+    }
+
+    private Picture createPicture() {
+        return PictureFactory.createPicture(project, 7L, "testPicture", LocalDateTime.of(2023, 1, 2, 3, 4, 5), "pictures/foo.png", 640, 480);
+    }
+
+    /**
+     * Test of getId method, of class Picture.
+     */
+    @Test
+    public void testGetId() {
+        assertEquals(7L, createPicture().getId());
+    }
+
+    /**
+     * Test of getProject method, of class Picture.
+     */
+    @Test
+    public void testGetProject() {
+        assertEquals(project, createPicture().getProject());
+    }
+
+    /**
+     * Test of getName and setName methods, of class Picture.
+     */
+    @Test
+    public void testName() {
+        final var instance = createPicture();
+        assertEquals("testPicture", instance.getName());
+        instance.setName("newName");
+        assertEquals("newName", instance.getName());
+    }
+
+    /**
+     * Test of getWidth and getHeight methods, of class Picture.
+     */
+    @Test
+    public void testDimensions() {
+        final var instance = createPicture();
+        assertEquals(640, instance.getWidth());
+        assertEquals(480, instance.getHeight());
+    }
+
+    /**
+     * Test of getProjectRelativePath and getAbsolutePath methods, of class Picture.
+     */
+    @Test
+    public void testPaths() {
+        final var instance = createPicture();
+        assertEquals("pictures/foo.png", instance.getProjectRelativePath());
+        assertEquals(project.getProjectFolder().getAbsolutePath() + File.separator + "pictures/foo.png", instance.getAbsolutePath());
+    }
+
+    /**
+     * Test of addPerson, getPersons and removePerson methods, of class Picture.
+     */
+    @Test
+    public void testPersons() {
+        final var instance = createPicture();
+        assertTrue(instance.getPersons().isEmpty());
+        assertTrue(instance.addPerson(personA));
+        assertFalse(instance.addPerson(personA));
+        assertEquals(1, instance.getPersons().size());
+        assertTrue(instance.removePerson(personA));
+        assertFalse(instance.removePerson(personA));
+        assertTrue(instance.getPersons().isEmpty());
+    }
+
+    /**
+     * Test of addPlace, getPlaces and removePlace methods, of class Picture.
+     */
+    @Test
+    public void testPlaces() {
+        final var instance = createPicture();
+        assertTrue(instance.getPlaces().isEmpty());
+        assertTrue(instance.addPlace(place));
+        assertFalse(instance.addPlace(place));
+        assertEquals(1, instance.getPlaces().size());
+        assertTrue(instance.removePlace(place));
+        assertFalse(instance.removePlace(place));
+        assertTrue(instance.getPlaces().isEmpty());
+    }
+
+    /**
+     * Test of movePersonUp and movePersonDown methods, of class Picture.
+     */
+    @Test
+    public void testMovePerson() {
+        final var instance = createPicture();
+        instance.addPerson(personA);
+        instance.addPerson(personB);
+        assertEquals(personA, instance.getPersons().get(0));
+        assertEquals(personB, instance.getPersons().get(1));
+        //
+        instance.movePersonUp(personB);
+        assertEquals(personB, instance.getPersons().get(0));
+        assertEquals(personA, instance.getPersons().get(1));
+        //
+        instance.movePersonDown(personB);
+        assertEquals(personA, instance.getPersons().get(0));
+        assertEquals(personB, instance.getPersons().get(1));
+    }
+
+    /**
+     * Test of getTimeFormat, getDate and setDate methods, of class Picture.
+     */
+    @Test
+    public void testDate() {
+        final var instance = createPicture();
+        assertEquals(TimeFormat.LOCAL_TIME, instance.getTimeFormat());
+        assertEquals(LocalDate.of(2023, 1, 2), instance.getDate());
+        final var newDate = LocalDate.of(2024, 5, 6);
+        instance.setDate(newDate);
+        assertEquals(newDate, instance.getDate());
+    }
+
+    /**
+     * Test of setTimestamp method, of class Picture: switches to TIME_MIN.
+     */
+    @Test
+    public void testSetTimestamp() {
+        final var instance = createPicture();
+        instance.setTimestamp(99.0);
+        assertEquals(TimeFormat.TIME_MIN, instance.getTimeFormat());
+        assertEquals(99.0, instance.getTimestamp());
+        assertEquals(99.0, instance.getAbsoluteTime());
+    }
+
+    /**
+     * Test of setValue method, of class Picture, with a LOCAL_TIME instance.
+     */
+    @Test
+    public void testSetValue() {
+        final var instance = createPicture();
+        instance.setValue("2024-05-06");
+        assertEquals(LocalDate.of(2024, 5, 6), instance.getDate());
+    }
+
+    /**
+     * Test of getAbsoluteTimeAsString method, of class Picture.
+     */
+    @Test
+    public void testGetAbsoluteTimeAsString() {
+        assertFalse(createPicture().getAbsoluteTimeAsString().isEmpty());
+    }
+
+    /**
+     * Test of addPropertyChangeListener/removePropertyChangeListener methods, of class Picture.
+     */
+    @Test
+    public void testPropertyChangeListener() {
+        final var instance = createPicture();
+        final var fired = new boolean[]{false};
+        final java.beans.PropertyChangeListener listener = e -> fired[0] = true;
+        instance.addPropertyChangeListener(listener);
+        instance.setName("newName");
+        assertTrue(fired[0]);
+        //
+        fired[0] = false;
+        instance.removePropertyChangeListener(listener);
+        instance.setName("anotherName");
+        assertFalse(fired[0]);
+    }
+
+    /**
+     * Test of toString method, of class Picture.
+     */
+    @Test
+    public void testToString() {
+        assertEquals("Pic[testPicture]", createPicture().toString());
+    }
+
+}

--- a/src/test/java/com/github/noony/app/timelinefx/core/PlaceFactoryTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/PlaceFactoryTest.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * @author solun
  */
-public class PlaceFactoryTest {
+public final class PlaceFactoryTest {
 
     public PlaceFactoryTest() {
     }

--- a/src/test/java/com/github/noony/app/timelinefx/core/PlaceFactoryTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/PlaceFactoryTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2026 NoOnY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.github.noony.app.timelinefx.core;
+
+import javafx.scene.paint.Color;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @author solun
+ */
+public class PlaceFactoryTest {
+
+    public PlaceFactoryTest() {
+    }
+
+    @BeforeEach
+    public void setUp() {
+        PlaceFactory.reset();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        PlaceFactory.reset();
+    }
+
+    /**
+     * Test of createPlace and getPlace methods, of class PlaceFactory.
+     */
+    @Test
+    public void testCreatePlaceAndGetPlace() {
+        final var place = PlaceFactory.createPlace("testCreatePlaceAndGetPlace", PlaceLevel.PLANET, null);
+        assertEquals(place, PlaceFactory.getPlace(place.getId()));
+    }
+
+    /**
+     * Test of getPlace method, of class PlaceFactory, with an unknown id.
+     */
+    @Test
+    public void testGetPlaceUnknownId() {
+        assertNull(PlaceFactory.getPlace(999L));
+    }
+
+    /**
+     * Test of createPlace method, of class PlaceFactory, with a specific id and color.
+     */
+    @Test
+    public void testCreatePlaceWithIdAndColor() {
+        final var place = PlaceFactory.createPlace(42L, "testCreatePlaceWithIdAndColor", PlaceLevel.PLANET, null, Color.CORAL);
+        assertEquals(42L, place.getId());
+        assertEquals(Color.CORAL, place.getColor());
+    }
+
+    /**
+     * Test of createPlace method, of class PlaceFactory, rejecting a duplicate id.
+     */
+    @Test
+    public void testCreatePlaceDuplicateId() {
+        PlaceFactory.createPlace(42L, "testCreatePlaceDuplicateIdA", PlaceLevel.PLANET, null, Color.CORAL);
+        assertThrows(IllegalArgumentException.class,
+                () -> PlaceFactory.createPlace(42L, "testCreatePlaceDuplicateIdB", PlaceLevel.PLANET, null, Color.CORAL));
+    }
+
+    /**
+     * Test of getPlaces method, of class PlaceFactory: sorted by name.
+     */
+    @Test
+    public void testGetPlaces() {
+        PlaceFactory.createPlace("Zebra", PlaceLevel.PLANET, null);
+        PlaceFactory.createPlace("Apple", PlaceLevel.PLANET, null);
+        final var places = PlaceFactory.getPlaces();
+        assertEquals(2, places.size());
+        assertEquals("Apple", places.get(0).getName());
+        assertEquals("Zebra", places.get(1).getName());
+    }
+
+    /**
+     * Test of getRootPlaces method, of class PlaceFactory.
+     */
+    @Test
+    public void testGetRootPlaces() {
+        final var rootPlace = PlaceFactory.createPlace("testGetRootPlacesRoot", PlaceLevel.PLANET, null);
+        PlaceFactory.createPlace("testGetRootPlacesChild", PlaceLevel.TOWN, rootPlace);
+        assertTrue(PlaceFactory.getRootPlaces().contains(rootPlace));
+    }
+
+    /**
+     * Test of reset method, of class PlaceFactory.
+     */
+    @Test
+    public void testReset() {
+        PlaceFactory.createPlace("testReset", PlaceLevel.PLANET, null);
+        PlaceFactory.reset();
+        assertTrue(PlaceFactory.getPlaces().isEmpty());
+        assertTrue(PlaceFactory.getRootPlaces().isEmpty());
+    }
+
+}

--- a/src/test/java/com/github/noony/app/timelinefx/core/PlaceFactoryTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/PlaceFactoryTest.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core;
 
 import javafx.scene.paint.Color;

--- a/src/test/java/com/github/noony/app/timelinefx/core/PlaceFactoryTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/PlaceFactoryTest.java
@@ -27,18 +27,29 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
+ * Unit tests for {@link PlaceFactory}.
+ *
  * @author solun
  */
 public final class PlaceFactoryTest {
 
+    /**
+     * Default constructor.
+     */
     public PlaceFactoryTest() {
     }
 
+    /**
+     * Sets up test fixtures before each test.
+     */
     @BeforeEach
     public void setUp() {
         PlaceFactory.reset();
     }
 
+    /**
+     * Tears down test fixtures after each test.
+     */
     @AfterEach
     public void tearDown() {
         PlaceFactory.reset();

--- a/src/test/java/com/github/noony/app/timelinefx/core/PlaceLevelTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/PlaceLevelTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2026 NoOnY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.github.noony.app.timelinefx.core;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @author solun
+ */
+public class PlaceLevelTest {
+
+    public PlaceLevelTest() {
+    }
+
+    /**
+     * Test of getLevelValue method, of class PlaceLevel.
+     */
+    @Test
+    public void testGetLevelValue() {
+        assertEquals(10, PlaceLevel.ADDRESS.getLevelValue());
+        assertEquals(1000, PlaceLevel.UNIVERSE.getLevelValue());
+        assertEquals(1_000_000, PlaceLevel.ROOT.getLevelValue());
+    }
+
+    /**
+     * Test that every level is ordered strictly below the next one, and that ROOT is the largest.
+     */
+    @Test
+    public void testLevelsAreOrdered() {
+        final var levels = PlaceLevel.values();
+        for (int i = 1; i < levels.length; i++) {
+            assertTrue(levels[i - 1].getLevelValue() < levels[i].getLevelValue(),
+                    levels[i - 1] + " should be lower than " + levels[i]);
+        }
+        assertEquals(PlaceLevel.ROOT, levels[levels.length - 1]);
+    }
+
+}

--- a/src/test/java/com/github/noony/app/timelinefx/core/PlaceLevelTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/PlaceLevelTest.java
@@ -23,7 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * @author solun
  */
-public class PlaceLevelTest {
+public final class PlaceLevelTest {
 
     public PlaceLevelTest() {
     }

--- a/src/test/java/com/github/noony/app/timelinefx/core/PlaceLevelTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/PlaceLevelTest.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core;
 
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/github/noony/app/timelinefx/core/PlaceLevelTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/PlaceLevelTest.java
@@ -22,10 +22,15 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
+ * Unit tests for {@link PlaceLevel}.
+ *
  * @author solun
  */
 public final class PlaceLevelTest {
 
+    /**
+     * Default constructor.
+     */
     public PlaceLevelTest() {
     }
 

--- a/src/test/java/com/github/noony/app/timelinefx/core/PlaceTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/PlaceTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -241,6 +242,86 @@ public class PlaceTest {
         assertFalse(europe.encompasses(egypt));
         assertFalse(europe.encompasses(cairo));
         assertFalse(europe.encompasses(atlantis));
+    }
+
+    /**
+     * Test of isLowerThanOrLeveled method, of class Place, with a null argument.
+     */
+    @Test
+    public void testIsLowerThanOrLeveledWithNull() {
+        var instance = PlaceFactory.createPlace("testIsLowerThanOrLeveledWithNull", PlaceLevel.PLANET, null);
+        assertTrue(instance.isLowerThanOrLeveled(null));
+    }
+
+    /**
+     * Test of encompasses method, of class Place, with a null argument.
+     */
+    @Test
+    public void testEncompassesWithNull() {
+        var instance = PlaceFactory.createPlace("testEncompassesWithNull", PlaceLevel.PLANET, null);
+        assertFalse(instance.encompasses(null));
+    }
+
+    /**
+     * Test of setParent method, of class Place.
+     */
+    @Test
+    public void testSetParent() {
+        var oldParent = PlaceFactory.createPlace("testSetParentOldParent", PlaceLevel.ORBIT, null);
+        var newParent = PlaceFactory.createPlace("testSetParentNewParent", PlaceLevel.ORBIT, null);
+        var child = PlaceFactory.createPlace("testSetParentChild", PlaceLevel.PLANET, oldParent);
+        assertTrue(oldParent.getPlaces().contains(child));
+        assertFalse(newParent.getPlaces().contains(child));
+        //
+        child.setParent(newParent);
+        assertEquals(newParent, child.getParent());
+        assertFalse(oldParent.getPlaces().contains(child));
+        assertTrue(newParent.getPlaces().contains(child));
+    }
+
+    /**
+     * Test of setParent method, of class Place, updating isRootPlace.
+     */
+    @Test
+    public void testSetParentUpdatesIsRootPlace() {
+        var parent = PlaceFactory.createPlace("testSetParentUpdatesIsRootPlaceParent", PlaceLevel.ORBIT, null);
+        var child = PlaceFactory.createPlace("testSetParentUpdatesIsRootPlaceChild", PlaceLevel.PLANET, parent);
+        assertFalse(child.isRootPlace());
+        child.setParent(null);
+        assertTrue(child.isRootPlace());
+    }
+
+    /**
+     * Test of setLevel method, of class Place, when a child place conflicts with the new level.
+     */
+    @Test
+    public void testSetLevelConflict() {
+        var parent = PlaceFactory.createPlace("testSetLevelConflictParent", PlaceLevel.CONTINENT, null);
+        var child = PlaceFactory.createPlace("testSetLevelConflictChild", PlaceLevel.COUNTRY, parent);
+        var result = parent.setLevel(PlaceLevel.TOWN);
+        assertFalse(result);
+        assertEquals(PlaceLevel.CONTINENT, parent.getLevel());
+        assertEquals(PlaceLevel.COUNTRY, child.getLevel());
+    }
+
+    /**
+     * Test of the Place constructor, of class Place, with a null level defaulting to PlaceLevel.ROOT.
+     */
+    @Test
+    public void testNullLevelDefaultsToRoot() {
+        var instance = PlaceFactory.createPlace("testNullLevelDefaultsToRoot", null, null);
+        assertEquals(PlaceLevel.ROOT, instance.getLevel());
+        assertTrue(instance.isRootPlace());
+    }
+
+    /**
+     * Test of the Place constructor, of class Place, rejecting a level greater than its parent's.
+     */
+    @Test
+    public void testConstructorThrowsWhenLevelConflictsWithParent() {
+        var townParent = PlaceFactory.createPlace("testConstructorThrowsWhenLevelConflictsWithParentParent", PlaceLevel.TOWN, null);
+        assertThrows(IllegalStateException.class,
+                () -> PlaceFactory.createPlace("testConstructorThrowsWhenLevelConflictsWithParentChild", PlaceLevel.GALAXY, townParent));
     }
 
 }

--- a/src/test/java/com/github/noony/app/timelinefx/core/PortraitFactoryTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/PortraitFactoryTest.java
@@ -36,16 +36,31 @@ import static org.junit.jupiter.api.Assertions.assertNull;
  */
 public final class PortraitFactoryTest {
 
+    /**
+     * Temporary directory used to create a test project without touching the real user directories.
+     */
     @TempDir
     private Path tempDir;
 
+    /**
+     * The project used in these tests.
+     */
     private TimeLineProject project;
 
+    /**
+     * A person used in these tests.
+     */
     private Person person;
 
+    /**
+     * Default constructor.
+     */
     public PortraitFactoryTest() {
     }
 
+    /**
+     * Sets up test fixtures before each test.
+     */
     @BeforeEach
     public void setUp() {
         PersonFactory.reset();
@@ -55,6 +70,9 @@ public final class PortraitFactoryTest {
         person = PersonFactory.createPerson(project, "testPerson");
     }
 
+    /**
+     * Tears down test fixtures after each test.
+     */
     @AfterEach
     public void tearDown() {
         PersonFactory.reset();

--- a/src/test/java/com/github/noony/app/timelinefx/core/PortraitFactoryTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/PortraitFactoryTest.java
@@ -33,7 +33,7 @@ import org.junit.jupiter.api.io.TempDir;
  *
  * @author solun
  */
-public class PortraitFactoryTest {
+public final class PortraitFactoryTest {
 
     @TempDir
     private Path tempDir;

--- a/src/test/java/com/github/noony/app/timelinefx/core/PortraitFactoryTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/PortraitFactoryTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C) 2026 NoOnY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.github.noony.app.timelinefx.core;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Note: uses a real {@link TimeLineProject}, created in a JUnit {@code @TempDir}. Project creation copies the
+ * bundled default portrait resource ({@link Person#DEFAULT_PICTURE_NAME}) into the project's portraits folder,
+ * which is what makes these portrait creations resolve to a real, readable file.
+ *
+ * @author solun
+ */
+public class PortraitFactoryTest {
+
+    @TempDir
+    private Path tempDir;
+
+    private TimeLineProject project;
+
+    private Person person;
+
+    public PortraitFactoryTest() {
+    }
+
+    @BeforeEach
+    public void setUp() {
+        PersonFactory.reset();
+        PortraitFactory.reset();
+        final var configParams = Map.of(TimeLineProject.PROJECT_FOLDER_KEY, tempDir.toString());
+        project = TimeLineProjectFactory.createProject("PortraitFactoryTest", configParams);
+        person = PersonFactory.createPerson(project, "testPerson");
+    }
+
+    @AfterEach
+    public void tearDown() {
+        PersonFactory.reset();
+        PortraitFactory.reset();
+    }
+
+    /**
+     * Test of createPortrait(Person) method, of class PortraitFactory: uses the default picture.
+     */
+    @Test
+    public void testCreatePortraitDefault() {
+        final var portrait = PortraitFactory.createPortrait(person);
+        assertEquals(person, portrait.getPerson());
+        assertEquals(portrait, PortraitFactory.getPortrait(portrait.getId()));
+    }
+
+    /**
+     * Test of createPortrait(Person, String) method, of class PortraitFactory: uses an explicit file path.
+     */
+    @Test
+    public void testCreatePortraitWithFilePath() {
+        final var relativePath = person.getProject().getPortraitsRelativeFolder() + File.separator + Person.DEFAULT_PICTURE_NAME;
+        final var portrait = PortraitFactory.createPortrait(person, relativePath);
+        assertEquals(person, portrait.getPerson());
+    }
+
+    /**
+     * Test of createPortrait(long, Person, String) method, of class PortraitFactory: uses a specific id.
+     */
+    @Test
+    public void testCreatePortraitWithId() {
+        final var relativePath = person.getProject().getPortraitsRelativeFolder() + File.separator + Person.DEFAULT_PICTURE_NAME;
+        final var portrait = PortraitFactory.createPortrait(42L, person, relativePath);
+        assertEquals(42L, portrait.getId());
+    }
+
+    /**
+     * Test of getPortrait method, of class PortraitFactory, with an unknown id.
+     */
+    @Test
+    public void testGetPortraitUnknownId() {
+        assertNull(PortraitFactory.getPortrait(999L));
+    }
+
+    /**
+     * Test of getPortraits method, of class PortraitFactory.
+     */
+    @Test
+    public void testGetPortraits() {
+        final var portrait = PortraitFactory.createPortrait(person);
+        assertEquals(1, PortraitFactory.getPortraits().size());
+        assertEquals(portrait, PortraitFactory.getPortraits().get(0));
+    }
+
+    /**
+     * Test of reset method, of class PortraitFactory.
+     */
+    @Test
+    public void testReset() {
+        PortraitFactory.createPortrait(person);
+        PortraitFactory.reset();
+        assertEquals(0, PortraitFactory.getPortraits().size());
+    }
+
+}

--- a/src/test/java/com/github/noony/app/timelinefx/core/PortraitFactoryTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/PortraitFactoryTest.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core;
 
 import java.io.File;
@@ -22,9 +23,9 @@ import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Note: uses a real {@link TimeLineProject}, created in a JUnit {@code @TempDir}. Project creation copies the

--- a/src/test/java/com/github/noony/app/timelinefx/core/PortraitTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/PortraitTest.java
@@ -28,22 +28,42 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
+ * Unit tests for {@link Portrait}.
+ *
  * @author solun
  */
 public final class PortraitTest {
 
+    /**
+     * Temporary directory used to create a test project without touching the real user directories.
+     */
     @TempDir
     private Path tempDir;
 
+    /**
+     * A person used in these tests.
+     */
     private Person person;
 
+    /**
+     * Another person used in these tests.
+     */
     private Person otherPerson;
 
+    /**
+     * A place used in these tests.
+     */
     private Place place;
 
+    /**
+     * Default constructor.
+     */
     public PortraitTest() {
     }
 
+    /**
+     * Sets up test fixtures before each test.
+     */
     @BeforeEach
     public void setUp() {
         PortraitFactory.reset();
@@ -56,6 +76,9 @@ public final class PortraitTest {
         place = PlaceFactory.createPlace("testPlace", PlaceLevel.PLANET, null);
     }
 
+    /**
+     * Tears down test fixtures after each test.
+     */
     @AfterEach
     public void tearDown() {
         PortraitFactory.reset();

--- a/src/test/java/com/github/noony/app/timelinefx/core/PortraitTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/PortraitTest.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core;
 
 import java.nio.file.Path;
@@ -21,10 +22,10 @@ import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import org.junit.jupiter.api.io.TempDir;
 
 /**
  * @author solun

--- a/src/test/java/com/github/noony/app/timelinefx/core/PortraitTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/PortraitTest.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.io.TempDir;
 /**
  * @author solun
  */
-public class PortraitTest {
+public final class PortraitTest {
 
     @TempDir
     private Path tempDir;

--- a/src/test/java/com/github/noony/app/timelinefx/core/PortraitTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/PortraitTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (C) 2026 NoOnY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.github.noony.app.timelinefx.core;
+
+import java.nio.file.Path;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * @author solun
+ */
+public class PortraitTest {
+
+    @TempDir
+    private Path tempDir;
+
+    private Person person;
+
+    private Person otherPerson;
+
+    private Place place;
+
+    public PortraitTest() {
+    }
+
+    @BeforeEach
+    public void setUp() {
+        PortraitFactory.reset();
+        PersonFactory.reset();
+        PlaceFactory.reset();
+        final var configParams = Map.of(TimeLineProject.PROJECT_FOLDER_KEY, tempDir.toString());
+        final var project = TimeLineProjectFactory.createProject("PortraitTest", configParams);
+        person = PersonFactory.createPerson(project, "testPerson");
+        otherPerson = PersonFactory.createPerson(project, "otherPerson");
+        place = PlaceFactory.createPlace("testPlace", PlaceLevel.PLANET, null);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        PortraitFactory.reset();
+        PersonFactory.reset();
+        PlaceFactory.reset();
+    }
+
+    /**
+     * Test of getPerson method, of class Portrait.
+     */
+    @Test
+    public void testGetPerson() {
+        final var instance = PortraitFactory.createPortrait(person);
+        assertEquals(person, instance.getPerson());
+    }
+
+    /**
+     * Test of getProject method, of class Portrait: delegates to the owning person's project.
+     */
+    @Test
+    public void testGetProject() {
+        final var instance = PortraitFactory.createPortrait(person);
+        assertEquals(person.getProject(), instance.getProject());
+    }
+
+    /**
+     * Test of getPersons method, of class Portrait: always the single owning person.
+     */
+    @Test
+    public void testGetPersons() {
+        final var instance = PortraitFactory.createPortrait(person);
+        assertEquals(1, instance.getPersons().size());
+        assertEquals(person, instance.getPersons().get(0));
+    }
+
+    /**
+     * Test of addPerson and removePerson methods, of class Portrait: always rejected.
+     */
+    @Test
+    public void testAddRemovePersonAlwaysRejected() {
+        final var instance = PortraitFactory.createPortrait(person);
+        assertFalse(instance.addPerson(otherPerson));
+        assertEquals(1, instance.getPersons().size());
+        assertFalse(instance.removePerson(person));
+        assertEquals(1, instance.getPersons().size());
+    }
+
+    /**
+     * Test of addPlace and removePlace methods, of class Portrait: always rejected.
+     */
+    @Test
+    public void testAddRemovePlaceAlwaysRejected() {
+        final var instance = PortraitFactory.createPortrait(person);
+        assertFalse(instance.addPlace(place));
+        assertTrue(instance.getPlaces().isEmpty());
+        assertFalse(instance.removePlace(place));
+    }
+
+    /**
+     * Test of compareTo method, of class Portrait.
+     */
+    @Test
+    public void testCompareTo() {
+        final var instance = PortraitFactory.createPortrait(person);
+        assertEquals(1, instance.compareTo(null));
+        assertEquals(0, instance.compareTo(instance));
+    }
+
+    /**
+     * Test of toString method, of class Portrait.
+     */
+    @Test
+    public void testToString() {
+        final var instance = PortraitFactory.createPortrait(person);
+        assertEquals(instance.getName(), instance.toString());
+    }
+
+    /**
+     * Test of COMPARATOR field, of class Portrait.
+     */
+    @Test
+    public void testComparator() {
+        final var first = PortraitFactory.createPortrait(1L, person, "portraits/LegoHead.png");
+        final var second = PortraitFactory.createPortrait(2L, person, "portraits/LegoHead.png");
+        assertTrue(Portrait.COMPARATOR.compare(first, second) < 0);
+        assertTrue(Portrait.COMPARATOR.compare(second, first) > 0);
+    }
+
+}

--- a/src/test/java/com/github/noony/app/timelinefx/core/StayFactoryTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/StayFactoryTest.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.io.TempDir;
 /**
  * @author solun
  */
-public class StayFactoryTest {
+public final class StayFactoryTest {
 
     @TempDir
     private Path tempDir;

--- a/src/test/java/com/github/noony/app/timelinefx/core/StayFactoryTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/StayFactoryTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (C) 2026 NoOnY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.github.noony.app.timelinefx.core;
+
+import java.nio.file.Path;
+import java.time.LocalDate;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * @author solun
+ */
+public class StayFactoryTest {
+
+    @TempDir
+    private Path tempDir;
+
+    private Person person;
+
+    private Place place;
+
+    public StayFactoryTest() {
+    }
+
+    @BeforeEach
+    public void setUp() {
+        PersonFactory.reset();
+        PlaceFactory.reset();
+        StayFactory.reset();
+        final var configParams = Map.of(TimeLineProject.PROJECT_FOLDER_KEY, tempDir.toString());
+        final var project = TimeLineProjectFactory.createProject("StayFactoryTest", configParams);
+        person = PersonFactory.createPerson(project, "testPerson");
+        place = PlaceFactory.createPlace("testPlace", PlaceLevel.PLANET, null);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        PersonFactory.reset();
+        PlaceFactory.reset();
+        StayFactory.reset();
+    }
+
+    /**
+     * Test of createStayPeriodSimpleTime and getStay methods, of class StayFactory.
+     */
+    @Test
+    public void testCreateStayPeriodSimpleTimeAndGetStay() {
+        final var stay = StayFactory.createStayPeriodSimpleTime(person, 0.0, 10.0, place);
+        assertEquals(stay, StayFactory.getStay(stay.getId()));
+        assertEquals(person, stay.getPerson());
+        assertEquals(place, stay.getPlace());
+    }
+
+    /**
+     * Test of createStayPeriodSimpleTime method, of class StayFactory, with a specific id.
+     */
+    @Test
+    public void testCreateStayPeriodSimpleTimeWithId() {
+        final var stay = StayFactory.createStayPeriodSimpleTime(42L, person, 0.0, 10.0, place);
+        assertEquals(42L, stay.getId());
+    }
+
+    /**
+     * Test of createStayPeriodSimpleTime method, of class StayFactory, rejecting a duplicate id.
+     */
+    @Test
+    public void testCreateStayPeriodSimpleTimeDuplicateId() {
+        StayFactory.createStayPeriodSimpleTime(42L, person, 0.0, 10.0, place);
+        assertThrows(IllegalArgumentException.class,
+                () -> StayFactory.createStayPeriodSimpleTime(42L, person, 0.0, 10.0, place));
+    }
+
+    /**
+     * Test of createStayPeriodLocalDate method, of class StayFactory.
+     */
+    @Test
+    public void testCreateStayPeriodLocalDate() {
+        final var start = LocalDate.of(2023, 1, 1);
+        final var end = LocalDate.of(2023, 1, 10);
+        final var stay = StayFactory.createStayPeriodLocalDate(person, start, end, place);
+        assertEquals(stay, StayFactory.getStay(stay.getId()));
+        assertEquals(person, stay.getPerson());
+        assertEquals(place, stay.getPlace());
+    }
+
+    /**
+     * Test of createStayPeriodLocalDate method, of class StayFactory, with a specific id.
+     */
+    @Test
+    public void testCreateStayPeriodLocalDateWithId() {
+        final var start = LocalDate.of(2023, 1, 1);
+        final var end = LocalDate.of(2023, 1, 10);
+        final var stay = StayFactory.createStayPeriodLocalDate(42L, person, start, end, place);
+        assertEquals(42L, stay.getId());
+    }
+
+    /**
+     * Test of createStayPeriodLocalDate method, of class StayFactory, rejecting a duplicate id.
+     */
+    @Test
+    public void testCreateStayPeriodLocalDateDuplicateId() {
+        final var start = LocalDate.of(2023, 1, 1);
+        final var end = LocalDate.of(2023, 1, 10);
+        StayFactory.createStayPeriodLocalDate(42L, person, start, end, place);
+        assertThrows(IllegalArgumentException.class,
+                () -> StayFactory.createStayPeriodLocalDate(42L, person, start, end, place));
+    }
+
+    /**
+     * Test of getStay method, of class StayFactory, with an unknown id.
+     */
+    @Test
+    public void testGetStayUnknownId() {
+        assertNull(StayFactory.getStay(999L));
+    }
+
+    /**
+     * Test of reset method, of class StayFactory.
+     */
+    @Test
+    public void testReset() {
+        StayFactory.createStayPeriodSimpleTime(person, 0.0, 10.0, place);
+        StayFactory.reset();
+        assertNull(StayFactory.getStay(0L));
+    }
+
+}

--- a/src/test/java/com/github/noony/app/timelinefx/core/StayFactoryTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/StayFactoryTest.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core;
 
 import java.nio.file.Path;
@@ -22,10 +23,10 @@ import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import org.junit.jupiter.api.io.TempDir;
 
 /**
  * @author solun

--- a/src/test/java/com/github/noony/app/timelinefx/core/StayFactoryTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/StayFactoryTest.java
@@ -29,20 +29,37 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
+ * Unit tests for {@link StayFactory}.
+ *
  * @author solun
  */
 public final class StayFactoryTest {
 
+    /**
+     * Temporary directory used to create a test project without touching the real user directories.
+     */
     @TempDir
     private Path tempDir;
 
+    /**
+     * A person used in these tests.
+     */
     private Person person;
 
+    /**
+     * A place used in these tests.
+     */
     private Place place;
 
+    /**
+     * Default constructor.
+     */
     public StayFactoryTest() {
     }
 
+    /**
+     * Sets up test fixtures before each test.
+     */
     @BeforeEach
     public void setUp() {
         PersonFactory.reset();
@@ -54,6 +71,9 @@ public final class StayFactoryTest {
         place = PlaceFactory.createPlace("testPlace", PlaceLevel.PLANET, null);
     }
 
+    /**
+     * Tears down test fixtures after each test.
+     */
     @AfterEach
     public void tearDown() {
         PersonFactory.reset();

--- a/src/test/java/com/github/noony/app/timelinefx/core/StayPeriodLocalDateTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/StayPeriodLocalDateTest.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core;
 
 import java.nio.file.Path;
@@ -22,9 +23,9 @@ import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import org.junit.jupiter.api.io.TempDir;
 
 /**
  * @author solun

--- a/src/test/java/com/github/noony/app/timelinefx/core/StayPeriodLocalDateTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/StayPeriodLocalDateTest.java
@@ -28,24 +28,47 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
+ * Unit tests for {@link StayPeriodLocalDate}.
+ *
  * @author solun
  */
 public final class StayPeriodLocalDateTest {
 
+    /**
+     * Temporary directory used to create a test project without touching the real user directories.
+     */
     @TempDir
     private Path tempDir;
 
+    /**
+     * A person used in these tests.
+     */
     private Person person;
 
+    /**
+     * Another person used in these tests.
+     */
     private Person otherPerson;
 
+    /**
+     * A place used in these tests.
+     */
     private Place place;
 
+    /**
+     * Another place used in these tests.
+     */
     private Place otherPlace;
 
+    /**
+     * Default constructor.
+     */
     public StayPeriodLocalDateTest() {
     }
 
+    /**
+     * Sets up test fixtures before each test.
+     */
     @BeforeEach
     public void setUp() {
         StayFactory.reset();
@@ -59,6 +82,9 @@ public final class StayPeriodLocalDateTest {
         otherPlace = PlaceFactory.createPlace("otherPlace", PlaceLevel.PLANET, null);
     }
 
+    /**
+     * Tears down test fixtures after each test.
+     */
     @AfterEach
     public void tearDown() {
         StayFactory.reset();

--- a/src/test/java/com/github/noony/app/timelinefx/core/StayPeriodLocalDateTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/StayPeriodLocalDateTest.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright (C) 2026 NoOnY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.github.noony.app.timelinefx.core;
+
+import java.nio.file.Path;
+import java.time.LocalDate;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * @author solun
+ */
+public class StayPeriodLocalDateTest {
+
+    @TempDir
+    private Path tempDir;
+
+    private Person person;
+
+    private Person otherPerson;
+
+    private Place place;
+
+    private Place otherPlace;
+
+    public StayPeriodLocalDateTest() {
+    }
+
+    @BeforeEach
+    public void setUp() {
+        StayFactory.reset();
+        PersonFactory.reset();
+        PlaceFactory.reset();
+        final var configParams = Map.of(TimeLineProject.PROJECT_FOLDER_KEY, tempDir.toString());
+        final var project = TimeLineProjectFactory.createProject("StayPeriodLocalDateTest", configParams);
+        person = PersonFactory.createPerson(project, "person");
+        otherPerson = PersonFactory.createPerson(project, "otherPerson");
+        place = PlaceFactory.createPlace("place", PlaceLevel.PLANET, null);
+        otherPlace = PlaceFactory.createPlace("otherPlace", PlaceLevel.PLANET, null);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        StayFactory.reset();
+        PersonFactory.reset();
+        PlaceFactory.reset();
+    }
+
+    private StayPeriodLocalDate createStay() {
+        return StayFactory.createStayPeriodLocalDate(person, LocalDate.of(2023, 1, 1), LocalDate.of(2023, 1, 10), place);
+    }
+
+    /**
+     * Test of getPerson and setPerson methods, of class StayPeriodLocalDate.
+     */
+    @Test
+    public void testPerson() {
+        final var instance = createStay();
+        assertEquals(person, instance.getPerson());
+        instance.setPerson(otherPerson);
+        assertEquals(otherPerson, instance.getPerson());
+    }
+
+    /**
+     * Test of getPlace and setPlace methods, of class StayPeriodLocalDate.
+     */
+    @Test
+    public void testPlace() {
+        final var instance = createStay();
+        assertEquals(place, instance.getPlace());
+        instance.setPlace(otherPlace);
+        assertEquals(otherPlace, instance.getPlace());
+    }
+
+    /**
+     * Test of getStartDate and setStartDate methods, of class StayPeriodLocalDate.
+     */
+    @Test
+    public void testStartDate() {
+        final var instance = createStay();
+        assertEquals(LocalDate.of(2023, 1, 1).toEpochDay(), instance.getStartDate());
+        final var newStart = LocalDate.of(2023, 2, 1);
+        instance.setStartDate(newStart);
+        assertEquals(newStart.toEpochDay(), instance.getStartDate());
+        assertEquals(LocalDate.of(2023, 1, 1).toEpochDay(), instance.getPreviousStartDate());
+    }
+
+    /**
+     * Test of getEndDate and setEndDate methods, of class StayPeriodLocalDate.
+     */
+    @Test
+    public void testEndDate() {
+        final var instance = createStay();
+        assertEquals(LocalDate.of(2023, 1, 10).toEpochDay(), instance.getEndDate());
+        final var newEnd = LocalDate.of(2023, 2, 10);
+        instance.setEndDate(newEnd);
+        assertEquals(newEnd.toEpochDay(), instance.getEndDate());
+        assertEquals(LocalDate.of(2023, 1, 10).toEpochDay(), instance.getPreviousEndDate());
+    }
+
+    /**
+     * Test of getTimeFormat method, of class StayPeriodLocalDate.
+     */
+    @Test
+    public void testGetTimeFormat() {
+        assertEquals(TimeFormat.LOCAL_TIME, createStay().getTimeFormat());
+    }
+
+    /**
+     * Test of getDisplayString and toString methods, of class StayPeriodLocalDate.
+     */
+    @Test
+    public void testDisplayString() {
+        final var instance = createStay();
+        assertEquals(instance.getDisplayString(), instance.toString());
+        assertTrue(instance.getDisplayString().contains("person"));
+        assertTrue(instance.getDisplayString().contains("place"));
+    }
+
+    /**
+     * Test of addListener/removeListener methods, of class StayPeriodLocalDate.
+     */
+    @Test
+    public void testListener() {
+        final var instance = createStay();
+        final var fired = new boolean[]{false};
+        final java.beans.PropertyChangeListener listener = e -> fired[0] = true;
+        instance.addListener(listener);
+        instance.setStartDate(LocalDate.of(2023, 3, 1));
+        assertTrue(fired[0]);
+        //
+        fired[0] = false;
+        instance.removeListener(listener);
+        instance.setStartDate(LocalDate.of(2023, 4, 1));
+        assertEquals(false, fired[0]);
+    }
+
+    /**
+     * Test of STAY_COMPARATOR field, of class StayPeriod.
+     */
+    @Test
+    public void testStayComparator() {
+        final var early = StayFactory.createStayPeriodLocalDate(person, LocalDate.of(2020, 1, 1), LocalDate.of(2020, 1, 10), place);
+        final var late = StayFactory.createStayPeriodLocalDate(person, LocalDate.of(2023, 1, 1), LocalDate.of(2023, 1, 10), place);
+        assertTrue(StayPeriod.STAY_COMPARATOR.compare(early, late) < 0);
+        assertTrue(StayPeriod.STAY_COMPARATOR.compare(late, early) > 0);
+    }
+
+}

--- a/src/test/java/com/github/noony/app/timelinefx/core/StayPeriodLocalDateTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/StayPeriodLocalDateTest.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.io.TempDir;
 /**
  * @author solun
  */
-public class StayPeriodLocalDateTest {
+public final class StayPeriodLocalDateTest {
 
     @TempDir
     private Path tempDir;

--- a/src/test/java/com/github/noony/app/timelinefx/core/StayPeriodSimpleTimeTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/StayPeriodSimpleTimeTest.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core;
 
 import java.nio.file.Path;
@@ -21,9 +22,9 @@ import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import org.junit.jupiter.api.io.TempDir;
 
 /**
  * @author solun

--- a/src/test/java/com/github/noony/app/timelinefx/core/StayPeriodSimpleTimeTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/StayPeriodSimpleTimeTest.java
@@ -27,20 +27,37 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
+ * Unit tests for {@link StayPeriodSimpleTime}.
+ *
  * @author solun
  */
 public final class StayPeriodSimpleTimeTest {
 
+    /**
+     * Temporary directory used to create a test project without touching the real user directories.
+     */
     @TempDir
     private Path tempDir;
 
+    /**
+     * A person used in these tests.
+     */
     private Person person;
 
+    /**
+     * A place used in these tests.
+     */
     private Place place;
 
+    /**
+     * Default constructor.
+     */
     public StayPeriodSimpleTimeTest() {
     }
 
+    /**
+     * Sets up test fixtures before each test.
+     */
     @BeforeEach
     public void setUp() {
         StayFactory.reset();
@@ -52,6 +69,9 @@ public final class StayPeriodSimpleTimeTest {
         place = PlaceFactory.createPlace("place", PlaceLevel.PLANET, null);
     }
 
+    /**
+     * Tears down test fixtures after each test.
+     */
     @AfterEach
     public void tearDown() {
         StayFactory.reset();

--- a/src/test/java/com/github/noony/app/timelinefx/core/StayPeriodSimpleTimeTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/StayPeriodSimpleTimeTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2026 NoOnY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.github.noony.app.timelinefx.core;
+
+import java.nio.file.Path;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * @author solun
+ */
+public class StayPeriodSimpleTimeTest {
+
+    @TempDir
+    private Path tempDir;
+
+    private Person person;
+
+    private Place place;
+
+    public StayPeriodSimpleTimeTest() {
+    }
+
+    @BeforeEach
+    public void setUp() {
+        StayFactory.reset();
+        PersonFactory.reset();
+        PlaceFactory.reset();
+        final var configParams = Map.of(TimeLineProject.PROJECT_FOLDER_KEY, tempDir.toString());
+        final var project = TimeLineProjectFactory.createProject("StayPeriodSimpleTimeTest", configParams);
+        person = PersonFactory.createPerson(project, "person");
+        place = PlaceFactory.createPlace("place", PlaceLevel.PLANET, null);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        StayFactory.reset();
+        PersonFactory.reset();
+        PlaceFactory.reset();
+    }
+
+    private StayPeriodSimpleTime createStay() {
+        return StayFactory.createStayPeriodSimpleTime(person, 0.0, 10.0, place);
+    }
+
+    /**
+     * Test of getStartDate and setStartDate methods, of class StayPeriodSimpleTime.
+     */
+    @Test
+    public void testStartDate() {
+        final var instance = createStay();
+        assertEquals(0.0, instance.getStartDate());
+        instance.setStartDate(5.0);
+        assertEquals(5.0, instance.getStartDate());
+        assertEquals(0.0, instance.getPreviousStartDate());
+    }
+
+    /**
+     * Test of getEndDate and setEndDate methods, of class StayPeriodSimpleTime.
+     */
+    @Test
+    public void testEndDate() {
+        final var instance = createStay();
+        assertEquals(10.0, instance.getEndDate());
+        instance.setEndDate(20.0);
+        assertEquals(20.0, instance.getEndDate());
+        assertEquals(10.0, instance.getPreviousEndDate());
+    }
+
+    /**
+     * Test of getTimeFormat method, of class StayPeriodSimpleTime.
+     */
+    @Test
+    public void testGetTimeFormat() {
+        assertEquals(TimeFormat.TIME_MIN, createStay().getTimeFormat());
+    }
+
+    /**
+     * Test of getDisplayString and toString methods, of class StayPeriodSimpleTime.
+     */
+    @Test
+    public void testDisplayString() {
+        final var instance = createStay();
+        assertEquals(instance.getDisplayString(), instance.toString());
+        assertTrue(instance.getDisplayString().contains("person"));
+        assertTrue(instance.getDisplayString().contains("place"));
+    }
+
+    /**
+     * Test of addListener/removeListener methods, of class StayPeriodSimpleTime.
+     */
+    @Test
+    public void testListener() {
+        final var instance = createStay();
+        final var fired = new boolean[]{false};
+        final java.beans.PropertyChangeListener listener = e -> fired[0] = true;
+        instance.addListener(listener);
+        instance.setStartDate(3.0);
+        assertTrue(fired[0]);
+        //
+        fired[0] = false;
+        instance.removeListener(listener);
+        instance.setStartDate(4.0);
+        assertEquals(false, fired[0]);
+    }
+
+}

--- a/src/test/java/com/github/noony/app/timelinefx/core/StayPeriodSimpleTimeTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/StayPeriodSimpleTimeTest.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.io.TempDir;
 /**
  * @author solun
  */
-public class StayPeriodSimpleTimeTest {
+public final class StayPeriodSimpleTimeTest {
 
     @TempDir
     private Path tempDir;

--- a/src/test/java/com/github/noony/app/timelinefx/core/TimeFormatTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/TimeFormatTest.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core;
 
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/github/noony/app/timelinefx/core/TimeFormatTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/TimeFormatTest.java
@@ -23,7 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 /**
  * @author solun
  */
-public class TimeFormatTest {
+public final class TimeFormatTest {
 
     public TimeFormatTest() {
     }

--- a/src/test/java/com/github/noony/app/timelinefx/core/TimeFormatTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/TimeFormatTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2026 NoOnY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.github.noony.app.timelinefx.core;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * @author solun
+ */
+public class TimeFormatTest {
+
+    public TimeFormatTest() {
+    }
+
+    /**
+     * Test of values method, of class TimeFormat.
+     */
+    @Test
+    public void testValues() {
+        assertArrayEquals(new TimeFormat[]{TimeFormat.LOCAL_TIME, TimeFormat.TIME_MIN}, TimeFormat.values());
+    }
+
+    /**
+     * Test of valueOf method, of class TimeFormat.
+     */
+    @Test
+    public void testValueOf() {
+        assertSame(TimeFormat.LOCAL_TIME, TimeFormat.valueOf("LOCAL_TIME"));
+    }
+
+}

--- a/src/test/java/com/github/noony/app/timelinefx/core/TimeFormatTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/TimeFormatTest.java
@@ -22,10 +22,15 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
+ * Unit tests for {@link TimeFormat}.
+ *
  * @author solun
  */
 public final class TimeFormatTest {
 
+    /**
+     * Default constructor.
+     */
     public TimeFormatTest() {
     }
 

--- a/src/test/java/com/github/noony/app/timelinefx/core/TimeLineProjectFactoryTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/TimeLineProjectFactoryTest.java
@@ -36,17 +36,29 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 public final class TimeLineProjectFactoryTest {
 
+    /**
+     * Temporary directory used to create a test project without touching the real user directories.
+     */
     @TempDir
     private Path tempDir;
 
+    /**
+     * Default constructor.
+     */
     public TimeLineProjectFactoryTest() {
     }
 
+    /**
+     * Sets up test fixtures before each test.
+     */
     @BeforeEach
     public void setUp() {
         FriezeObjectFactory.reset();
     }
 
+    /**
+     * Tears down test fixtures after each test.
+     */
     @AfterEach
     public void tearDown() {
         FriezeObjectFactory.reset();

--- a/src/test/java/com/github/noony/app/timelinefx/core/TimeLineProjectFactoryTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/TimeLineProjectFactoryTest.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core;
 
 import java.nio.file.Path;
@@ -21,9 +22,9 @@ import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Note: {@link TimeLineProjectFactory#createProject(String, Map)} is exercised here with an explicit

--- a/src/test/java/com/github/noony/app/timelinefx/core/TimeLineProjectFactoryTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/TimeLineProjectFactoryTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2026 NoOnY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.github.noony.app.timelinefx.core;
+
+import java.nio.file.Path;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Note: {@link TimeLineProjectFactory#createProject(String, Map)} is exercised here with an explicit
+ * {@link TimeLineProject#PROJECT_FOLDER_KEY} pointing at a JUnit {@code @TempDir}, so it never falls back to
+ * {@code Configuration.getProjectsParentFolder()} (which reads/writes a preferences file under the user's home
+ * directory). It does still create real folders under the temp directory, which JUnit cleans up automatically.
+ *
+ * @author solun
+ */
+public class TimeLineProjectFactoryTest {
+
+    @TempDir
+    private Path tempDir;
+
+    public TimeLineProjectFactoryTest() {
+    }
+
+    @BeforeEach
+    public void setUp() {
+        FriezeObjectFactory.reset();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        FriezeObjectFactory.reset();
+    }
+
+    private TimeLineProject createTestProject(final String name) {
+        final var configParams = Map.of(TimeLineProject.PROJECT_FOLDER_KEY, tempDir.resolve(name).toString());
+        return TimeLineProjectFactory.createProject(name, configParams);
+    }
+
+    /**
+     * Test of createProject method, of class TimeLineProjectFactory.
+     */
+    @Test
+    public void testCreateProject() {
+        final var instance = createTestProject("testCreateProject");
+        assertEquals("testCreateProject", instance.getName());
+        assertTrue(instance.getProjectFolder().exists());
+        assertTrue(instance.getPortraitsAbsoluteFolder().exists());
+        assertTrue(instance.getPicturesFolder().exists());
+        assertTrue(instance.getMiniaturesFolder().exists());
+    }
+
+}

--- a/src/test/java/com/github/noony/app/timelinefx/core/TimeLineProjectFactoryTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/TimeLineProjectFactoryTest.java
@@ -33,7 +33,7 @@ import org.junit.jupiter.api.io.TempDir;
  *
  * @author solun
  */
-public class TimeLineProjectFactoryTest {
+public final class TimeLineProjectFactoryTest {
 
     @TempDir
     private Path tempDir;

--- a/src/test/java/com/github/noony/app/timelinefx/core/TimeLineProjectTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/TimeLineProjectTest.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright (C) 2026 NoOnY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.github.noony.app.timelinefx.core;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Note: uses a real {@link TimeLineProject}, created in a JUnit {@code @TempDir} via an explicit
+ * {@link TimeLineProject#PROJECT_FOLDER_KEY} override so it never touches the real user home directory.
+ *
+ * @author solun
+ */
+public class TimeLineProjectTest {
+
+    @TempDir
+    private Path tempDir;
+
+    private TimeLineProject project;
+
+    private Person person;
+
+    private Place place;
+
+    private StayPeriod stay;
+
+    public TimeLineProjectTest() {
+    }
+
+    @BeforeEach
+    public void setUp() {
+        FriezeObjectFactory.reset();
+        final var configParams = Map.of(TimeLineProject.PROJECT_FOLDER_KEY, tempDir.toString());
+        project = TimeLineProjectFactory.createProject("TimeLineProjectTest", configParams);
+        person = PersonFactory.createPerson(project, "testPerson");
+        place = PlaceFactory.createPlace("testPlace", PlaceLevel.PLANET, null);
+        stay = StayFactory.createStayPeriodSimpleTime(person, 10.0, 20.0, place);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        FriezeObjectFactory.reset();
+    }
+
+    /**
+     * Test of getName method, of class TimeLineProject.
+     */
+    @Test
+    public void testGetName() {
+        assertEquals("TimeLineProjectTest", project.getName());
+    }
+
+    /**
+     * Test of getProjectFolder, getPortraitsAbsoluteFolder, getPicturesFolder and getMiniaturesFolder methods,
+     * of class TimeLineProject.
+     */
+    @Test
+    public void testFolders() {
+        assertTrue(project.getProjectFolder().exists());
+        assertTrue(project.getPortraitsAbsoluteFolder().exists());
+        assertTrue(project.getPicturesFolder().exists());
+        assertTrue(project.getMiniaturesFolder().exists());
+    }
+
+    /**
+     * Test of getPortraitsRelativeFolder method, of class TimeLineProject.
+     */
+    @Test
+    public void testGetPortraitsRelativeFolder() {
+        assertEquals(TimeLineProject.DEFAULT_PORTRAIT_FOLDER, project.getPortraitsRelativeFolder());
+    }
+
+    /**
+     * Test of getTimelineFile and getProjectLocation methods, of class TimeLineProject.
+     */
+    @Test
+    public void testTimelineFile() {
+        assertEquals("TimeLineProjectTest.xml", project.getTimelineFile().getName());
+        assertEquals(project.getTimelineFile().getAbsolutePath(), project.getProjectLocation());
+    }
+
+    /**
+     * Test of addHighLevelPlace, getHighLevelPlaces and getPlaceByName methods, of class TimeLineProject.
+     */
+    @Test
+    public void testAddHighLevelPlace() {
+        assertTrue(project.getHighLevelPlaces().isEmpty());
+        assertTrue(project.addHighLevelPlace(place));
+        assertFalse(project.addHighLevelPlace(place));
+        assertTrue(project.getHighLevelPlaces().contains(place));
+        assertEquals(place, project.getPlaceByName("testPlace"));
+    }
+
+    /**
+     * Test of removeHighLevelPlace method, of class TimeLineProject.
+     */
+    @Test
+    public void testRemoveHighLevelPlace() {
+        project.addHighLevelPlace(place);
+        assertTrue(project.removeHighLevelPlace(place));
+        assertTrue(project.getHighLevelPlaces().isEmpty());
+    }
+
+    /**
+     * Test of addPlace method, of class TimeLineProject, with a nested place.
+     */
+    @Test
+    public void testAddPlaceWithParent() {
+        final var child = PlaceFactory.createPlace("testAddPlaceWithParentChild", PlaceLevel.TOWN, place);
+        assertTrue(project.addPlace(child));
+        assertTrue(project.getHighLevelPlaces().contains(place));
+        assertEquals(child, project.getPlaceByName("testAddPlaceWithParentChild"));
+    }
+
+    /**
+     * Test of addPlace method, of class TimeLineProject, with a null place.
+     */
+    @Test
+    public void testAddPlaceNull() {
+        assertFalse(project.addPlace(null));
+    }
+
+    /**
+     * Test of getAllPlaces method, of class TimeLineProject.
+     */
+    @Test
+    public void testGetAllPlaces() {
+        project.addHighLevelPlace(place);
+        assertTrue(project.getAllPlaces().contains(place));
+    }
+
+    /**
+     * Test of removePlace method, of class TimeLineProject.
+     */
+    @Test
+    public void testRemovePlace() {
+        project.addHighLevelPlace(place);
+        project.removePlace(place);
+        assertNull(project.getPlaceByName("testPlace"));
+        assertFalse(project.getHighLevelPlaces().contains(place));
+    }
+
+    /**
+     * Test of addStay, getStays and removeStay methods, of class TimeLineProject.
+     */
+    @Test
+    public void testStays() {
+        assertTrue(project.getStays().isEmpty());
+        project.addStay(stay);
+        assertTrue(project.getStays().contains(stay));
+        project.removeStay(stay);
+        assertTrue(project.getStays().isEmpty());
+    }
+
+    /**
+     * Test of addAllStays(StayPeriod...) method, of class TimeLineProject.
+     */
+    @Test
+    public void testAddAllStaysVarargs() {
+        project.addAllStays(stay);
+        assertTrue(project.getStays().contains(stay));
+    }
+
+    /**
+     * Test of addAllStays(Collection) method, of class TimeLineProject.
+     */
+    @Test
+    public void testAddAllStaysCollection() {
+        project.addAllStays(List.of(stay));
+        assertTrue(project.getStays().contains(stay));
+    }
+
+    /**
+     * Test of addPerson, getPersons and removePerson methods, of class TimeLineProject.
+     */
+    @Test
+    public void testPersons() {
+        assertFalse(project.getPersons().contains(person));
+        assertTrue(project.addPerson(person));
+        assertFalse(project.addPerson(person));
+        assertTrue(project.getPersons().contains(person));
+        project.removePerson(person);
+        assertFalse(project.getPersons().contains(person));
+    }
+
+    /**
+     * Test of removePerson method, of class TimeLineProject: also removes the person's stays.
+     */
+    @Test
+    public void testRemovePersonRemovesStays() {
+        project.addPerson(person);
+        project.addStay(stay);
+        project.removePerson(person);
+        assertFalse(project.getStays().contains(stay));
+    }
+
+    /**
+     * Test of getFriezes method, of class TimeLineProject: populated via FriezeFactory.
+     */
+    @Test
+    public void testGetFriezes() {
+        assertTrue(project.getFriezes().isEmpty());
+        final var frieze = FriezeFactory.createFrieze(project, "testGetFriezes");
+        assertTrue(project.getFriezes().contains(frieze));
+        FriezeFactory.reset();
+    }
+
+    /**
+     * Test of getPictureChronologies method, of class TimeLineProject: starts empty.
+     */
+    @Test
+    public void testGetPictureChronologies() {
+        assertTrue(project.getPictureChronologies().isEmpty());
+    }
+
+    /**
+     * Test of addListener/removeListener methods, of class TimeLineProject.
+     */
+    @Test
+    public void testListener() {
+        final var fired = new boolean[]{false};
+        final java.beans.PropertyChangeListener listener = e -> fired[0] = true;
+        project.addListener(listener);
+        project.addHighLevelPlace(place);
+        assertTrue(fired[0]);
+        //
+        fired[0] = false;
+        project.removeListener(listener);
+        project.removeHighLevelPlace(place);
+        assertFalse(fired[0]);
+    }
+
+}

--- a/src/test/java/com/github/noony/app/timelinefx/core/TimeLineProjectTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/TimeLineProjectTest.java
@@ -34,7 +34,7 @@ import org.junit.jupiter.api.io.TempDir;
  *
  * @author solun
  */
-public class TimeLineProjectTest {
+public final class TimeLineProjectTest {
 
     @TempDir
     private Path tempDir;

--- a/src/test/java/com/github/noony/app/timelinefx/core/TimeLineProjectTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/TimeLineProjectTest.java
@@ -37,20 +37,41 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 public final class TimeLineProjectTest {
 
+    /**
+     * Temporary directory used to create a test project without touching the real user directories.
+     */
     @TempDir
     private Path tempDir;
 
+    /**
+     * The project used in these tests.
+     */
     private TimeLineProject project;
 
+    /**
+     * A person used in these tests.
+     */
     private Person person;
 
+    /**
+     * A place used in these tests.
+     */
     private Place place;
 
+    /**
+     * A stay used in these tests.
+     */
     private StayPeriod stay;
 
+    /**
+     * Default constructor.
+     */
     public TimeLineProjectTest() {
     }
 
+    /**
+     * Sets up test fixtures before each test.
+     */
     @BeforeEach
     public void setUp() {
         FriezeObjectFactory.reset();
@@ -61,6 +82,9 @@ public final class TimeLineProjectTest {
         stay = StayFactory.createStayPeriodSimpleTime(person, 10.0, 20.0, place);
     }
 
+    /**
+     * Tears down test fixtures after each test.
+     */
     @AfterEach
     public void tearDown() {
         FriezeObjectFactory.reset();

--- a/src/test/java/com/github/noony/app/timelinefx/core/TimeLineProjectTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/TimeLineProjectTest.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core;
 
 import java.nio.file.Path;
@@ -22,11 +23,11 @@ import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Note: uses a real {@link TimeLineProject}, created in a JUnit {@code @TempDir} via an explicit

--- a/src/test/java/com/github/noony/app/timelinefx/core/package-info.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/package-info.java
@@ -14,27 +14,8 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package com.github.noony.app.timelinefx.core;
-
-import org.junit.jupiter.api.Test;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
- * @author solun
+ * Unit tests for the core domain model.
  */
-public final class MessagesTest {
-
-    public MessagesTest() {
-    }
-
-    /**
-     * Test that UNSUPPORTED_TIME_FORMAT is a non-empty, stable message prefix.
-     */
-    @Test
-    public void testUnsupportedTimeFormat() {
-        assertNotNull(Messages.UNSUPPORTED_TIME_FORMAT);
-        assertEquals("Unsupported time format: ", Messages.UNSUPPORTED_TIME_FORMAT);
-    }
-
-}
+package com.github.noony.app.timelinefx.core;


### PR DESCRIPTION
## Summary

Two threads of work on this PR:

### 1. Residual Codacy findings in the `core` package (143 of 285 originally left after PR #34)
4 commits by category, plus follow-up commits fixing what those commits' own diffs surfaced as new, plus a manual review pass:
1. **Style** — `FinalParameters`, `FinalLocalVariable`, `RedundantModifier`, `AvoidStaticImport`, `EmptyLineSeparator`, `SeparatorWrap`
2. **Javadoc** — `SummaryJavadoc`, `MissingJavadocMethod`, `JavadocVariable`, `JavadocContentLocation`
3. **Annotations** — `AnnotationOnSameLine`
4. **String literals** — `MultipleStringLiterals`
5. **Cascade fix-up rounds 1-2** — a self-introduced regression (`@SuppressWarnings` same-line merge violated `AnnotationLocation` — reverted), more `FinalParameters`, `HiddenField` (renamed shadowing parameters), `AvoidInlineConditionals`/`MultipleStringLiterals` in `Place`
6. **Manual review** — `Portrait` sealed `final` (verified: not subclassed), resolving its `DesignForExtension`; `PlaceLevel`'s constructor parameter renamed to stop shadowing its field
7. **`PlaceLevel.ROOT`** — added as the level above `UNIVERSE`, wired in as `PlaceFactory.PLACES_PLACE`'s level and as `Place`'s default when constructed with a null level
8. **`@NonNull` same-line fix**, **`StayFactory` cascade fix-up**

### 2. Unit tests for the `core` package (only `PlaceTest` existed before)
Added in 3 groups, each committed separately: enums/simple POJOs, factories, complex domain classes (`Frieze`, `TimeLineProject`, `Person`, `Picture`, `Portrait`, `StayPeriod*`). 24 new test files, ~190 test methods total.

Three real bugs found and fixed while writing these tests:
- **`TimeLineProject.initFolders`** — `Map.getOrDefault(key, sideEffectingDefault)` evaluates the default eagerly, so `Configuration.getProjectsParentFolder()` ran (and NPE'd) on every construction regardless of whether `PROJECT_FOLDER_KEY` was supplied. Fixed with an explicit `containsKey` check — this is also what unlocked hermetic testing of `TimeLineProject`/`Frieze`/`Person`/`Picture`/`Portrait` via `@TempDir`.
- **`MetadataParser.parseMetadata`** — never closed the `FileInputStream` used to read image resolution; fixed with try-with-resources.
- **`Frieze.removeListener`** — called `addPropertyChangeListener` instead of `removePropertyChangeListener` (copy-paste bug); listener removal was a silent no-op.

The new test files then went through the same Codacy cleanup treatment as the main code: `package-info.java` added, all 23 new test classes sealed `final` (safe — no subclassing, unlike the production `DesignForExtension` cases), `ImportOrder`/`EmptyLineSeparator` fixes, and full Javadoc pass.

## Consciously left unaddressed

**In `core` main code:**
- **`InterfaceMemberImpliedModifier`** (39) — contradicts `RedundantModifier` for interface members; already tried and reverted in PR #34.
- **`ImportControl`** (25) — needs a new `import-control.xml` Checkstyle config file, not a source-code fix.
- **`Regexp`** ("duplicate pattern", 24) — the underlying custom ruleset isn't inspectable outside the Codacy dashboard.
- **`DesignForExtension`** (12 + 3 residual: `AbstractPicture.getName`, `StayPeriodLocalDate`/`StayPeriodSimpleTime.getPreviousEndDate`) — `StayPeriodLocalDate`/`StayPeriodSimpleTime` genuinely override `StayPeriod`'s date getters, so finalizing risks breaking intentional polymorphism.
- **`ReturnCount`** (7 + 1 residual in `Place`) — needs control-flow restructuring, not a mechanical fix.
- 1 residual `FinalParameters` (`PictureFactory.createPicture`'s `pictureHeight`) — tail end of the cascade, left to stop the chase.
- 20 assorted single/low-count structural rules (`OverloadMethodsDeclarationOrder`, `IllegalCatch`, `ExecutableStatementCount`, `AbstractClassName`, `DeclarationOrder`, `NestedTryDepth`, `AbbreviationAsWordInName`).

**In the new test files (310 findings, all consciously left as-is):**
- **`AvoidStaticImport`** (69) — every new test statically imports `org.junit.jupiter.api.Assertions.assertX`, matching the pre-existing `PlaceTest` convention and near-universal JUnit idiom. Qualifying every call as `Assertions.assertEquals(...)` would make the new tests inconsistent with the existing one for no real benefit.
- **`AnnotationOnSameLine`** (70) — `@Test`/`@BeforeEach`/`@AfterEach`/`@TempDir` on their own line above the target, same as `PlaceTest`'s existing style. Same reasoning as above.
- **`MagicNumber`** (92) and **`MultipleStringLiterals`** (25) — numeric/string literals in test fixtures and assertions (e.g. picture dimensions, date ranges, test names). These values are the test's semantic content, not incidental "magic" values; extracting every one to a named constant would add a lot of indirection for little readability gain.
- **`ImportControl`** (25) and **`Regexp`** (24) — same known blockers as the main code.

## Test plan
- [x] `mvn compile` / `mvn test-compile` / `mvn test` after every commit (all green)
- [x] Codacy check on this PR (fails on the documented residual above, both main-code and test-code; not chasing further)

🤖 Generated with [Claude Code](https://claude.com/claude-code)