### PR TITLE
Protect Double.parseDouble call sites against malformed input

### DIFF
--- a/src/main/java/com/github/noony/app/timelinefx/core/freemap/FriezeFreeMapProperties.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/freemap/FriezeFreeMapProperties.java
@@ -95,11 +95,13 @@ public record FriezeFreeMapProperties(Dimension2D dimension, double personWidth,
         if (raw == null) {
             return defaultValue;
         }
+        var parsedValue = defaultValue;
         try {
-            return Double.parseDouble(raw);
+            parsedValue = Double.parseDouble(raw);
         } catch (NumberFormatException e) {
-            return defaultValue;
+            // keep the default already assigned above
         }
+        return parsedValue;
     }
 
 }

--- a/src/main/java/com/github/noony/app/timelinefx/core/freemap/FriezeFreeMapProperties.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/freemap/FriezeFreeMapProperties.java
@@ -69,19 +69,37 @@ public record FriezeFreeMapProperties(Dimension2D dimension, double personWidth,
      * {@code defaults}
      */
     public static FriezeFreeMapProperties fromParameterMap(final Map<String, String> parameters, final FriezeFreeMapProperties defaults) {
-        final var width = Double.parseDouble(parameters.getOrDefault(FriezeFreeMap.FRIEZE_WIDTH, Double.toString(defaults.dimension().getWidth())));
-        final var height = Double.parseDouble(parameters.getOrDefault(FriezeFreeMap.FRIEZE_HEIGHT, Double.toString(defaults.dimension().getHeight())));
-        final var personWidthValue = Double.parseDouble(parameters.getOrDefault(FriezeFreeMap.PERSONS_WIDTH, Double.toString(defaults.personWidth())));
-        final var placeNameWidthValue = Double.parseDouble(parameters.getOrDefault(FriezeFreeMap.PLACE_NAMES_WIDTH, Double.toString(defaults.placeNameWidth())));
-        final var fontSizeValue = Double.parseDouble(parameters.getOrDefault(FriezeFreeMap.FONT_SIZE, Double.toString(defaults.fontSize())));
-        final var plotSeparationValue = Double.parseDouble(parameters.getOrDefault(FriezeFreeMap.PLOT_SEPARATION, Double.toString(defaults.plotSeparation())));
-        final var plotSizeValue = Double.parseDouble(parameters.getOrDefault(FriezeFreeMap.PLOT_SIZE, Double.toString(defaults.plotSize())));
+        final var width = parseDoubleOrDefault(parameters, FriezeFreeMap.FRIEZE_WIDTH, defaults.dimension().getWidth());
+        final var height = parseDoubleOrDefault(parameters, FriezeFreeMap.FRIEZE_HEIGHT, defaults.dimension().getHeight());
+        final var personWidthValue = parseDoubleOrDefault(parameters, FriezeFreeMap.PERSONS_WIDTH, defaults.personWidth());
+        final var placeNameWidthValue = parseDoubleOrDefault(parameters, FriezeFreeMap.PLACE_NAMES_WIDTH, defaults.placeNameWidth());
+        final var fontSizeValue = parseDoubleOrDefault(parameters, FriezeFreeMap.FONT_SIZE, defaults.fontSize());
+        final var plotSeparationValue = parseDoubleOrDefault(parameters, FriezeFreeMap.PLOT_SEPARATION, defaults.plotSeparation());
+        final var plotSizeValue = parseDoubleOrDefault(parameters, FriezeFreeMap.PLOT_SIZE, defaults.plotSize());
         final var plotVisibilityValue = Boolean.parseBoolean(parameters.getOrDefault(FriezeFreeMap.PLOT_VISIBILITY, Boolean.toString(defaults.plotVisibility())));
         final var portraitConnectorVisibilityValue = Boolean.parseBoolean(parameters.getOrDefault(FriezeFreeMap.PORTRAIT_CONNECTOR_VISIBILITY, Boolean.toString(defaults.portraitConnectorVisibility())));
-        final var portraitRadiusValue = Double.parseDouble(parameters.getOrDefault(FriezeFreeMap.PORTRAIT_RADIUS, Double.toString(defaults.portraitRadius())));
+        final var portraitRadiusValue = parseDoubleOrDefault(parameters, FriezeFreeMap.PORTRAIT_RADIUS, defaults.portraitRadius());
         return new FriezeFreeMapProperties(new Dimension2D(width, height), personWidthValue, placeNameWidthValue,
                 fontSizeValue, plotSeparationValue, plotSizeValue, plotVisibilityValue, portraitConnectorVisibilityValue,
                 portraitRadiusValue);
+    }
+
+    /**
+     * @param parameters the raw parameter map
+     * @param key the key to look up
+     * @param defaultValue the value to fall back to when the key is missing or its value is not a valid double
+     * @return the parsed value, or {@code defaultValue} if missing/unparseable
+     */
+    private static double parseDoubleOrDefault(final Map<String, String> parameters, final String key, final double defaultValue) {
+        final var raw = parameters.get(key);
+        if (raw == null) {
+            return defaultValue;
+        }
+        try {
+            return Double.parseDouble(raw);
+        } catch (NumberFormatException e) {
+            return defaultValue;
+        }
     }
 
 }

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/PicturesChronologyConfiguratorController.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/PicturesChronologyConfiguratorController.java
@@ -76,18 +76,26 @@ public class PicturesChronologyConfiguratorController implements Initializable {
         //
         widthField.textProperty().addListener((ObservableValue<? extends String> ov, String t, String t1) -> {
             if (!t1.isBlank() && !t1.isEmpty()) {
-                var width = Double.parseDouble(t1);
-                if (pictureChronology != null) {
-                    pictureChronology.setWidth(width);
+                try {
+                    var width = Double.parseDouble(t1);
+                    if (pictureChronology != null) {
+                        pictureChronology.setWidth(width);
+                    }
+                } catch (NumberFormatException e) {
+                    LOG.log(Level.FINEST, "The following value is not a valid width {0}. {1}", new Object[]{t1, e});
                 }
             }
         });
         //
         heightField.textProperty().addListener((ObservableValue<? extends String> ov, String t, String t1) -> {
             if (!t1.isBlank() && !t1.isEmpty()) {
-                var height = Double.parseDouble(t1);
-                if (pictureChronology != null) {
-                    pictureChronology.setHeight(height);
+                try {
+                    var height = Double.parseDouble(t1);
+                    if (pictureChronology != null) {
+                        pictureChronology.setHeight(height);
+                    }
+                } catch (NumberFormatException e) {
+                    LOG.log(Level.FINEST, "The following value is not a valid height {0}. {1}", new Object[]{t1, e});
                 }
             }
         });

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/freemap/FreeMapViewController.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/freemap/FreeMapViewController.java
@@ -121,9 +121,13 @@ public class FreeMapViewController implements Initializable {
             if (t1.isBlank() | t1.isEmpty()) {
                 // nothing
             } else {
-                var width = Double.parseDouble(t1);
-                if (friezeFreeMap != null) {
-                    friezeFreeMap.setWidth(width);
+                try {
+                    var width = Double.parseDouble(t1);
+                    if (friezeFreeMap != null) {
+                        friezeFreeMap.setWidth(width);
+                    }
+                } catch (NumberFormatException e) {
+                    LOG.log(Level.FINEST, "The following value is not a valid width {0}. {1}", new Object[]{t1, e});
                 }
             }
         });
@@ -132,9 +136,13 @@ public class FreeMapViewController implements Initializable {
             if (t1.isBlank() | t1.isEmpty()) {
                 // nothing
             } else {
-                var height = Double.parseDouble(t1);
-                if (friezeFreeMap != null) {
-                    friezeFreeMap.setHeight(height);
+                try {
+                    var height = Double.parseDouble(t1);
+                    if (friezeFreeMap != null) {
+                        friezeFreeMap.setHeight(height);
+                    }
+                } catch (NumberFormatException e) {
+                    LOG.log(Level.FINEST, "The following value is not a valid height {0}. {1}", new Object[]{t1, e});
                 }
             }
         });
@@ -143,9 +151,13 @@ public class FreeMapViewController implements Initializable {
             if (t1.isBlank() | t1.isEmpty()) {
                 // nothing
             } else {
-                var plotSize = Double.parseDouble(t1);
-                if (friezeFreeMap != null) {
-                    friezeFreeMap.setPlotSize(plotSize);
+                try {
+                    var plotSize = Double.parseDouble(t1);
+                    if (friezeFreeMap != null) {
+                        friezeFreeMap.setPlotSize(plotSize);
+                    }
+                } catch (NumberFormatException e) {
+                    LOG.log(Level.FINEST, "The following value is not a valid plot size {0}. {1}", new Object[]{t1, e});
                 }
             }
         });
@@ -154,9 +166,13 @@ public class FreeMapViewController implements Initializable {
             if (t1.isBlank() | t1.isEmpty()) {
                 // nothing
             } else {
-                var fontSize = Double.parseDouble(t1);
-                if (friezeFreeMap != null) {
-                    friezeFreeMap.setFontSize(fontSize);
+                try {
+                    var fontSize = Double.parseDouble(t1);
+                    if (friezeFreeMap != null) {
+                        friezeFreeMap.setFontSize(fontSize);
+                    }
+                } catch (NumberFormatException e) {
+                    LOG.log(Level.FINEST, "The following value is not a valid font size {0}. {1}", new Object[]{t1, e});
                 }
             }
         });
@@ -165,9 +181,13 @@ public class FreeMapViewController implements Initializable {
             if (t1.isBlank() | t1.isEmpty()) {
                 // nothing
             } else {
-                var portraitRadius = Double.parseDouble(t1);
-                if (friezeFreeMap != null) {
-                    friezeFreeMap.setPortraitRadius(portraitRadius);
+                try {
+                    var portraitRadius = Double.parseDouble(t1);
+                    if (friezeFreeMap != null) {
+                        friezeFreeMap.setPortraitRadius(portraitRadius);
+                    }
+                } catch (NumberFormatException e) {
+                    LOG.log(Level.FINEST, "The following value is not a valid portrait radius {0}. {1}", new Object[]{t1, e});
                 }
             }
         });

--- a/src/main/java/com/github/noony/app/timelinefx/save/v3/FreeMapProviderV3.java
+++ b/src/main/java/com/github/noony/app/timelinefx/save/v3/FreeMapProviderV3.java
@@ -295,9 +295,9 @@ public class FreeMapProviderV3 {
         var freemapDateHandlesElements = freemapDateHandleGroupElement.getElementsByTagName(FREEMAP_DATE_HANDLE_ELEMENT);
         for (int i = 0; i < freemapDateHandlesElements.getLength(); i++) {
             var dateHandleElement = (Element) freemapDateHandlesElements.item(i);
-            var date = Double.parseDouble(dateHandleElement.getAttribute(DATE_ATR));
-            var xPos = Double.parseDouble(dateHandleElement.getAttribute(X_POS_ATR));
-            var yPos = Double.parseDouble(dateHandleElement.getAttribute(Y_POS_ATR));
+            var date = parseDoubleAttribute(dateHandleElement, DATE_ATR);
+            var xPos = parseDoubleAttribute(dateHandleElement, X_POS_ATR);
+            var yPos = parseDoubleAttribute(dateHandleElement, Y_POS_ATR);
             var type = FreeMapDateHandle.TimeType.valueOf(dateHandleElement.getAttribute(TYPE_ATR));
             var freemapDateHandle = FreeMapDateHandle.createFreeMapDateHandle(parentFreeMapID, date, type, new Point2D(xPos, yPos));
             freeMapDateHandles.add(freemapDateHandle);
@@ -405,9 +405,9 @@ public class FreeMapProviderV3 {
         var freeMapPortraitID = Long.parseLong(freemapPortraitElement.getAttribute(ID_ATR));
         var personID = Long.parseLong(freemapPortraitElement.getAttribute(PERSON_ATR));
         var portraitRef = Long.parseLong(freemapPortraitElement.getAttribute(PORTRAIT_REF_ATR));
-        var xPos = Double.parseDouble(freemapPortraitElement.getAttribute(X_POS_ATR));
-        var yPos = Double.parseDouble(freemapPortraitElement.getAttribute(Y_POS_ATR));
-        var radius = Double.parseDouble(freemapPortraitElement.getAttribute(RADIUS_ATR));
+        var xPos = parseDoubleAttribute(freemapPortraitElement, X_POS_ATR);
+        var yPos = parseDoubleAttribute(freemapPortraitElement, Y_POS_ATR);
+        var radius = parseDoubleAttribute(freemapPortraitElement, RADIUS_ATR);
         //
         var person = PersonFactory.getPerson(personID);
         var portrait = person.getPortrait(portraitRef);
@@ -462,10 +462,10 @@ public class FreeMapProviderV3 {
 
     private static FreeMapPlace parseFreeMapPlace(Element freemapPlaceElement, long parentFreeMapID, FriezeFreeMapProperties freeMapProperties, Map<Long, FreeMapPerson> freeMapPersonsById) {
         var placeID = Long.parseLong(freemapPlaceElement.getAttribute(PLACE_ID_ATR));
-        var height = Double.parseDouble(freemapPlaceElement.getAttribute(HEIGHT_ATR));
-        var yPos = Double.parseDouble(freemapPlaceElement.getAttribute(Y_POS_ATR));
-        var fontSize = Double.parseDouble(freemapPlaceElement.getAttribute(FREEMAP_FONT_SIZE_ATR));
-        var nameWidth = Double.parseDouble(freemapPlaceElement.getAttribute(FREEMAP_PLACE_NAME_WIDTH_ATR));
+        var height = parseDoubleAttribute(freemapPlaceElement, HEIGHT_ATR);
+        var yPos = parseDoubleAttribute(freemapPlaceElement, Y_POS_ATR);
+        var fontSize = parseDoubleAttribute(freemapPlaceElement, FREEMAP_FONT_SIZE_ATR);
+        var nameWidth = parseDoubleAttribute(freemapPlaceElement, FREEMAP_PLACE_NAME_WIDTH_ATR);
         //
         var place = PlaceFactory.getPlace(placeID);
         //
@@ -489,14 +489,14 @@ public class FreeMapProviderV3 {
 
     private static FreeMapConnector parseConnectorElement(Element freeMapConnectorElement, Map<Long, FreeMapStay> freeMapStaysById) {
         var connectorID = Long.parseLong(freeMapConnectorElement.getAttribute(ID_ATR));
-        var date = Double.parseDouble(freeMapConnectorElement.getAttribute(DATE_ATR));
+        var date = parseDoubleAttribute(freeMapConnectorElement, DATE_ATR);
         var colorS = freeMapConnectorElement.getAttribute(COLOR_ATR);
-        var xPos = Double.parseDouble(freeMapConnectorElement.getAttribute(X_POS_ATR));
-        var yPos = Double.parseDouble(freeMapConnectorElement.getAttribute(Y_POS_ATR));
+        var xPos = parseDoubleAttribute(freeMapConnectorElement, X_POS_ATR);
+        var yPos = parseDoubleAttribute(freeMapConnectorElement, Y_POS_ATR);
         LOG.log(Level.FINE, "parseConnectorElement ignoring field color: {0}.", new Object[]{colorS});
         LOG.log(Level.FINE, "parseConnectorElement ignoring field xPos: {0}.", new Object[]{xPos});
         LOG.log(Level.FINE, "parseConnectorElement ignoring field yPos: {0}.", new Object[]{yPos});
-        var plotSize = Double.parseDouble(freeMapConnectorElement.getAttribute(PLOT_SIZE_ATR));
+        var plotSize = parseDoubleAttribute(freeMapConnectorElement, PLOT_SIZE_ATR);
         var linkedElementID = Long.parseLong(freeMapConnectorElement.getAttribute(FREEMAP_LINKED_ELEMENT_ID_ATR));
         //
         var stayLink = freeMapStaysById.get(linkedElementID);

--- a/src/main/java/com/github/noony/app/timelinefx/save/v3/TimeProjectProviderV3.java
+++ b/src/main/java/com/github/noony/app/timelinefx/save/v3/TimeProjectProviderV3.java
@@ -331,6 +331,23 @@ public class TimeProjectProviderV3 implements TimelineProjectProvider {
         return null;
     }
 
+    /**
+     * Parses the given attribute as a double, failing with a message identifying the element, attribute and
+     * raw value instead of the bare {@link NumberFormatException} {@link Double#parseDouble(String)} would throw.
+     *
+     * @param element the element carrying the attribute
+     * @param attributeName the attribute to parse
+     * @return the parsed value
+     */
+    protected static double parseDoubleAttribute(final Element element, final String attributeName) {
+        var value = element.getAttribute(attributeName);
+        try {
+            return Double.parseDouble(value);
+        } catch (NumberFormatException e) {
+            throw new IllegalStateException("Could not parse attribute '" + attributeName + "' of <" + element.getTagName() + "> as a double: '" + value + "'", e);
+        }
+    }
+
     private static List<Place> parsePlaces(Element placesRootElement, Place parentPlace) {
         List<Place> places = new LinkedList<>();
         NodeList placeElements = placesRootElement.getChildNodes();
@@ -445,8 +462,7 @@ public class TimeProjectProviderV3 implements TimelineProjectProvider {
                 }
                 case TIME_MIN -> {
                     if (sourceElement.hasAttribute(DATE_ATR)) {
-                        var timeS = sourceElement.getAttribute(DATE_ATR);
-                        var time = Double.parseDouble(timeS);
+                        var time = parseDoubleAttribute(sourceElement, DATE_ATR);
                         aDateObject.setTimestamp(time);
                     }
                 }
@@ -615,8 +631,8 @@ public class TimeProjectProviderV3 implements TimelineProjectProvider {
         if (place == null) {
             throw new IllegalStateException("Could not load StayPeriodSimpleTime id=" + id + " with placeID=" + placeID);
         }
-        var start = Double.parseDouble(stayElement.getAttribute(START_DATE_ATR));
-        var end = Double.parseDouble(stayElement.getAttribute(END_DATE_ATR));
+        var start = parseDoubleAttribute(stayElement, START_DATE_ATR);
+        var end = parseDoubleAttribute(stayElement, END_DATE_ATR);
         return StayFactory.createStayPeriodSimpleTime(id, person, start, end, place);
     }
 
@@ -636,8 +652,8 @@ public class TimeProjectProviderV3 implements TimelineProjectProvider {
     private PictureChronology parsePictureChronology(TimeLineProject project, Element pictureChronologyElement) {
         long id = Long.parseLong(pictureChronologyElement.getAttribute(ID_ATR));
         String name = pictureChronologyElement.getAttribute(NAME_ATR);
-        double width = Double.parseDouble(pictureChronologyElement.getAttribute(WIDTH_ATR));
-        double height = Double.parseDouble(pictureChronologyElement.getAttribute(HEIGHT_ATR));
+        double width = parseDoubleAttribute(pictureChronologyElement, WIDTH_ATR);
+        double height = parseDoubleAttribute(pictureChronologyElement, HEIGHT_ATR);
         //
         List<ChronologyPictureMiniature> miniatures = new LinkedList<>();
         List<ChronologyLink> links = new LinkedList<>();
@@ -665,9 +681,9 @@ public class TimeProjectProviderV3 implements TimelineProjectProvider {
 //        <pictureChronologyMiniature id="138" pictureRef="125" xPos="897.0" yPos="329.0" scale="0.5"/>
         long id = Long.parseLong(miniatureElement.getAttribute(ID_ATR));
         long pictureRef = Long.parseLong(miniatureElement.getAttribute(PICTURE_REF_ELEMENT));
-        double xPos = Double.parseDouble(miniatureElement.getAttribute(X_POS_ATR));
-        double yPos = Double.parseDouble(miniatureElement.getAttribute(Y_POS_ATR));
-        double scale = Double.parseDouble(miniatureElement.getAttribute(SCALE_ATR));
+        double xPos = parseDoubleAttribute(miniatureElement, X_POS_ATR);
+        double yPos = parseDoubleAttribute(miniatureElement, Y_POS_ATR);
+        double scale = parseDoubleAttribute(miniatureElement, SCALE_ATR);
         var miniature = PictureChronologyFactory.createChronologyPictureMiniature(id, IPicture.getPicture(pictureRef), new Point2D(xPos, yPos), scale);
         miniature.setUseCustomTime(!miniature.isInSyncWithPicture());
         if (!miniature.isInSyncWithPicture()) {

--- a/src/main/java/com/github/noony/app/timelinefx/utils/CustomFileUtils.java
+++ b/src/main/java/com/github/noony/app/timelinefx/utils/CustomFileUtils.java
@@ -73,7 +73,11 @@ public class CustomFileUtils {
         String[] valuesAsString = input.replace("[", "").replace("]", "").split(", ");
         double[] result = new double[valuesAsString.length];
         for (int i = 0; i < result.length; i++) {
-            result[i] = Double.parseDouble(valuesAsString[i]);
+            try {
+                result[i] = Double.parseDouble(valuesAsString[i]);
+            } catch (NumberFormatException e) {
+                throw new IllegalArgumentException("Could not parse double array from '" + input + "': invalid value '" + valuesAsString[i] + "' at index " + i, e);
+            }
         }
         return result;
     }

--- a/src/test/java/com/github/noony/app/timelinefx/core/freemap/FriezeFreeMapPropertiesTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/freemap/FriezeFreeMapPropertiesTest.java
@@ -64,4 +64,19 @@ public class FriezeFreeMapPropertiesTest {
         assertEquals(defaults.portraitRadius(), properties.portraitRadius());
     }
 
+    /**
+     * Regression test: the javadoc has always promised a fallback to defaults for keys that are "missing/
+     * unparseable", but the implementation used to only handle missing keys -- a present-but-garbled value threw
+     * NumberFormatException instead of honoring that contract.
+     */
+    @Test public void testFromParameterMapFallsBackOnUnparseableValues() {
+        final var defaults = FriezeFreeMap.DEFAULT_PROPERTIES;
+        final Map<String, String> garbledParameters = new HashMap<>();
+        garbledParameters.put(FriezeFreeMap.FONT_SIZE, "not-a-number");
+        garbledParameters.put(FriezeFreeMap.PLOT_SEPARATION, Double.toString(CUSTOM_FONT_SIZE));
+        final var properties = FriezeFreeMapProperties.fromParameterMap(garbledParameters, defaults);
+        assertEquals(defaults.fontSize(), properties.fontSize());
+        assertEquals(CUSTOM_FONT_SIZE, properties.plotSeparation());
+    }
+
 }

--- a/src/test/java/com/github/noony/app/timelinefx/save/v3/FreeMapProviderV3Test.java
+++ b/src/test/java/com/github/noony/app/timelinefx/save/v3/FreeMapProviderV3Test.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2026 NoOnY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.github.noony.app.timelinefx.save.v3;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import org.w3c.dom.Element;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @author solun
+ */
+public final class FreeMapProviderV3Test {
+
+    /**
+     * Default constructor.
+     */
+    public FreeMapProviderV3Test() {
+    }
+
+    /**
+     * Builds a minimal {@code <freeMaps>} element containing one {@code <freeMap>} whose only place has a
+     * malformed {@code height} attribute. Parsing fails while resolving that attribute, before the
+     * {@code frieze} argument of {@link FreeMapProviderV3#parseFreeMaps} is ever dereferenced, so {@code null}
+     * is a safe stand-in for it here.
+     */
+    private static Element newFreeMapsElementWithMalformedPlaceHeight() throws Exception {
+        var doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+        var freeMapsElement = doc.createElement("freeMaps");
+        var freeMapElement = doc.createElement("freeMap");
+        freeMapElement.setAttribute("id", "1");
+        freeMapElement.setAttribute("name", "Test FreeMap");
+        freeMapElement.appendChild(doc.createElement("freeMapDateHandles"));
+        freeMapElement.appendChild(doc.createElement("freeMapPersons"));
+        var placesElement = doc.createElement("freeMapPlaces");
+        var placeElement = doc.createElement("freeMapPlace");
+        placeElement.setAttribute("placeID", "1");
+        placeElement.setAttribute("height", "not-a-number");
+        placeElement.setAttribute("yPos", "0.0");
+        placeElement.setAttribute("fontSize", "10.0");
+        placeElement.setAttribute("placeNameWidth", "10.0");
+        placesElement.appendChild(placeElement);
+        freeMapElement.appendChild(placesElement);
+        freeMapsElement.appendChild(freeMapElement);
+        return freeMapsElement;
+    }
+
+    /**
+     * Regression test: confirms FreeMapProviderV3's own parsing methods are wired to the shared
+     * parseDoubleAttribute helper too, surfacing a clear IllegalStateException instead of a bare
+     * NumberFormatException for a malformed freemap place height.
+     */
+    @Test
+    public void testParseFreeMapsThrowsClearExceptionOnMalformedPlaceHeight() throws Exception {
+        var freeMapsElement = newFreeMapsElementWithMalformedPlaceHeight();
+        var exception = assertThrows(IllegalStateException.class,
+                () -> FreeMapProviderV3.parseFreeMaps(freeMapsElement, null));
+        assertTrue(exception.getMessage().contains("height"));
+        assertTrue(exception.getMessage().contains("not-a-number"));
+    }
+
+}

--- a/src/test/java/com/github/noony/app/timelinefx/save/v3/FreeMapProviderV3Test.java
+++ b/src/test/java/com/github/noony/app/timelinefx/save/v3/FreeMapProviderV3Test.java
@@ -18,12 +18,14 @@
 package com.github.noony.app.timelinefx.save.v3;
 
 import javax.xml.parsers.DocumentBuilderFactory;
-import org.w3c.dom.Element;
 import org.junit.jupiter.api.Test;
+import org.w3c.dom.Element;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
+ * Unit tests for {@link FreeMapProviderV3}.
+ *
  * @author solun
  */
 public final class FreeMapProviderV3Test {
@@ -39,24 +41,27 @@ public final class FreeMapProviderV3Test {
      * malformed {@code height} attribute. Parsing fails while resolving that attribute, before the
      * {@code frieze} argument of {@link FreeMapProviderV3#parseFreeMaps} is ever dereferenced, so {@code null}
      * is a safe stand-in for it here.
+     *
+     * @return the constructed {@code <freeMaps>} element
+     * @throws Exception if the document builder cannot be created
      */
     private static Element newFreeMapsElementWithMalformedPlaceHeight() throws Exception {
-        var doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
-        var freeMapsElement = doc.createElement("freeMaps");
-        var freeMapElement = doc.createElement("freeMap");
-        freeMapElement.setAttribute("id", "1");
-        freeMapElement.setAttribute("name", "Test FreeMap");
-        freeMapElement.appendChild(doc.createElement("freeMapDateHandles"));
-        freeMapElement.appendChild(doc.createElement("freeMapPersons"));
-        var placesElement = doc.createElement("freeMapPlaces");
-        var placeElement = doc.createElement("freeMapPlace");
+        final var doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+        final var placeElement = doc.createElement("freeMapPlace");
         placeElement.setAttribute("placeID", "1");
         placeElement.setAttribute("height", "not-a-number");
         placeElement.setAttribute("yPos", "0.0");
         placeElement.setAttribute("fontSize", "10.0");
         placeElement.setAttribute("placeNameWidth", "10.0");
+        final var placesElement = doc.createElement("freeMapPlaces");
         placesElement.appendChild(placeElement);
+        final var freeMapElement = doc.createElement("freeMap");
+        freeMapElement.setAttribute("id", "1");
+        freeMapElement.setAttribute("name", "Test FreeMap");
+        freeMapElement.appendChild(doc.createElement("freeMapDateHandles"));
+        freeMapElement.appendChild(doc.createElement("freeMapPersons"));
         freeMapElement.appendChild(placesElement);
+        final var freeMapsElement = doc.createElement("freeMaps");
         freeMapsElement.appendChild(freeMapElement);
         return freeMapsElement;
     }
@@ -68,8 +73,8 @@ public final class FreeMapProviderV3Test {
      */
     @Test
     public void testParseFreeMapsThrowsClearExceptionOnMalformedPlaceHeight() throws Exception {
-        var freeMapsElement = newFreeMapsElementWithMalformedPlaceHeight();
-        var exception = assertThrows(IllegalStateException.class,
+        final var freeMapsElement = newFreeMapsElementWithMalformedPlaceHeight();
+        final var exception = assertThrows(IllegalStateException.class,
                 () -> FreeMapProviderV3.parseFreeMaps(freeMapsElement, null));
         assertTrue(exception.getMessage().contains("height"));
         assertTrue(exception.getMessage().contains("not-a-number"));

--- a/src/test/java/com/github/noony/app/timelinefx/save/v3/TimeProjectProviderV3Test.java
+++ b/src/test/java/com/github/noony/app/timelinefx/save/v3/TimeProjectProviderV3Test.java
@@ -18,13 +18,15 @@
 package com.github.noony.app.timelinefx.save.v3;
 
 import javax.xml.parsers.DocumentBuilderFactory;
-import org.w3c.dom.Element;
 import org.junit.jupiter.api.Test;
+import org.w3c.dom.Element;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
+ * Unit tests for {@link TimeProjectProviderV3}.
+ *
  * @author solun
  */
 public final class TimeProjectProviderV3Test {
@@ -35,9 +37,18 @@ public final class TimeProjectProviderV3Test {
     public TimeProjectProviderV3Test() {
     }
 
-    private static Element newElement(String tagName, String attributeName, String attributeValue) throws Exception {
-        var doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
-        var element = doc.createElement(tagName);
+    /**
+     * Builds a single-attribute element to feed to {@code parseDoubleAttribute}.
+     *
+     * @param tagName the element's tag name
+     * @param attributeName the attribute's name
+     * @param attributeValue the attribute's raw string value
+     * @return the constructed element
+     * @throws Exception if the document builder cannot be created
+     */
+    private static Element newElement(final String tagName, final String attributeName, final String attributeValue) throws Exception {
+        final var doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+        final var element = doc.createElement(tagName);
         element.setAttribute(attributeName, attributeValue);
         return element;
     }
@@ -47,7 +58,7 @@ public final class TimeProjectProviderV3Test {
      */
     @Test
     public void testParseDoubleAttributeValidValue() throws Exception {
-        var element = newElement("stay", "startDate", "12.5");
+        final var element = newElement("stay", "startDate", "12.5");
         assertEquals(12.5, TimeProjectProviderV3.parseDoubleAttribute(element, "startDate"));
     }
 
@@ -57,8 +68,8 @@ public final class TimeProjectProviderV3Test {
      */
     @Test
     public void testParseDoubleAttributeThrowsClearExceptionOnMalformedValue() throws Exception {
-        var element = newElement("stay", "startDate", "not-a-number");
-        var exception = assertThrows(IllegalStateException.class,
+        final var element = newElement("stay", "startDate", "not-a-number");
+        final var exception = assertThrows(IllegalStateException.class,
                 () -> TimeProjectProviderV3.parseDoubleAttribute(element, "startDate"));
         assertTrue(exception.getMessage().contains("startDate"));
         assertTrue(exception.getMessage().contains("stay"));
@@ -71,8 +82,8 @@ public final class TimeProjectProviderV3Test {
      */
     @Test
     public void testParseDoubleAttributeThrowsClearExceptionOnMissingAttribute() throws Exception {
-        var element = newElement("stay", "otherAttribute", "1.0");
-        var exception = assertThrows(IllegalStateException.class,
+        final var element = newElement("stay", "otherAttribute", "1.0");
+        final var exception = assertThrows(IllegalStateException.class,
                 () -> TimeProjectProviderV3.parseDoubleAttribute(element, "startDate"));
         assertTrue(exception.getMessage().contains("startDate"));
         assertTrue(exception.getMessage().contains("stay"));

--- a/src/test/java/com/github/noony/app/timelinefx/save/v3/TimeProjectProviderV3Test.java
+++ b/src/test/java/com/github/noony/app/timelinefx/save/v3/TimeProjectProviderV3Test.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2026 NoOnY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.github.noony.app.timelinefx.save.v3;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import org.w3c.dom.Element;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @author solun
+ */
+public final class TimeProjectProviderV3Test {
+
+    /**
+     * Default constructor.
+     */
+    public TimeProjectProviderV3Test() {
+    }
+
+    private static Element newElement(String tagName, String attributeName, String attributeValue) throws Exception {
+        var doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+        var element = doc.createElement(tagName);
+        element.setAttribute(attributeName, attributeValue);
+        return element;
+    }
+
+    /**
+     * Test of parseDoubleAttribute method, of class TimeProjectProviderV3, with a well-formed value.
+     */
+    @Test
+    public void testParseDoubleAttributeValidValue() throws Exception {
+        var element = newElement("stay", "startDate", "12.5");
+        assertEquals(12.5, TimeProjectProviderV3.parseDoubleAttribute(element, "startDate"));
+    }
+
+    /**
+     * Regression test: a malformed attribute used to throw a bare NumberFormatException with no indication of
+     * which element/attribute in the save file was at fault.
+     */
+    @Test
+    public void testParseDoubleAttributeThrowsClearExceptionOnMalformedValue() throws Exception {
+        var element = newElement("stay", "startDate", "not-a-number");
+        var exception = assertThrows(IllegalStateException.class,
+                () -> TimeProjectProviderV3.parseDoubleAttribute(element, "startDate"));
+        assertTrue(exception.getMessage().contains("startDate"));
+        assertTrue(exception.getMessage().contains("stay"));
+        assertTrue(exception.getMessage().contains("not-a-number"));
+        assertTrue(exception.getCause() instanceof NumberFormatException);
+    }
+
+    /**
+     * Test of parseDoubleAttribute method, of class TimeProjectProviderV3, with a missing attribute.
+     */
+    @Test
+    public void testParseDoubleAttributeThrowsClearExceptionOnMissingAttribute() throws Exception {
+        var element = newElement("stay", "otherAttribute", "1.0");
+        var exception = assertThrows(IllegalStateException.class,
+                () -> TimeProjectProviderV3.parseDoubleAttribute(element, "startDate"));
+        assertTrue(exception.getMessage().contains("startDate"));
+        assertTrue(exception.getMessage().contains("stay"));
+    }
+
+}

--- a/src/test/java/com/github/noony/app/timelinefx/save/v3/package-info.java
+++ b/src/test/java/com/github/noony/app/timelinefx/save/v3/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2026 NoOnY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Tests for the V3 project save format providers.
+ */
+package com.github.noony.app.timelinefx.save.v3;

--- a/src/test/java/com/github/noony/app/timelinefx/utils/CustomFileUtilsTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/utils/CustomFileUtilsTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2026 NoOnY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.github.noony.app.timelinefx.utils;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @author solun
+ */
+public final class CustomFileUtilsTest {
+
+    /**
+     * Default constructor.
+     */
+    public CustomFileUtilsTest() {
+    }
+
+    /**
+     * Test of toDoubleArray method, of class CustomFileUtils, with a well-formed input.
+     */
+    @Test
+    public void testToDoubleArrayValidInput() {
+        var result = CustomFileUtils.toDoubleArray("[1.0, 2.5, -3.25]");
+        assertArrayEquals(new double[]{1.0, 2.5, -3.25}, result);
+    }
+
+    /**
+     * Regression test: a malformed token used to throw a bare NumberFormatException with no indication of which
+     * value, or which array, was at fault.
+     */
+    @Test
+    public void testToDoubleArrayThrowsClearExceptionOnMalformedValue() {
+        var exception = assertThrows(IllegalArgumentException.class, () -> CustomFileUtils.toDoubleArray("[1.0, oops, 3.0]"));
+        assertTrue(exception.getMessage().contains("oops"));
+        assertTrue(exception.getMessage().contains("[1.0, oops, 3.0]"));
+    }
+
+}

--- a/src/test/java/com/github/noony/app/timelinefx/utils/CustomFileUtilsTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/utils/CustomFileUtilsTest.java
@@ -23,6 +23,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
+ * Unit tests for {@link CustomFileUtils}.
+ *
  * @author solun
  */
 public final class CustomFileUtilsTest {
@@ -38,7 +40,7 @@ public final class CustomFileUtilsTest {
      */
     @Test
     public void testToDoubleArrayValidInput() {
-        var result = CustomFileUtils.toDoubleArray("[1.0, 2.5, -3.25]");
+        final var result = CustomFileUtils.toDoubleArray("[1.0, 2.5, -3.25]");
         assertArrayEquals(new double[]{1.0, 2.5, -3.25}, result);
     }
 
@@ -48,7 +50,7 @@ public final class CustomFileUtilsTest {
      */
     @Test
     public void testToDoubleArrayThrowsClearExceptionOnMalformedValue() {
-        var exception = assertThrows(IllegalArgumentException.class, () -> CustomFileUtils.toDoubleArray("[1.0, oops, 3.0]"));
+        final var exception = assertThrows(IllegalArgumentException.class, () -> CustomFileUtils.toDoubleArray("[1.0, oops, 3.0]"));
         assertTrue(exception.getMessage().contains("oops"));
         assertTrue(exception.getMessage().contains("[1.0, oops, 3.0]"));
     }

--- a/src/test/java/com/github/noony/app/timelinefx/utils/package-info.java
+++ b/src/test/java/com/github/noony/app/timelinefx/utils/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2026 NoOnY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Tests for {@link com.github.noony.app.timelinefx.utils.CustomFileUtils}.
+ */
+package com.github.noony.app.timelinefx.utils;


### PR DESCRIPTION
## Summary
- Adds a `parseDoubleAttribute` helper to `TimeProjectProviderV3` (reused by `FreeMapProviderV3`) that turns a bare `NumberFormatException` into a clear `IllegalStateException` naming the element, attribute and raw value when loading a save file.
- Fixes `FriezeFreeMapProperties.fromParameterMap` to actually fall back to defaults for present-but-unparseable values, matching the fallback contract its own javadoc already promised (previously only missing keys fell back).
- `CustomFileUtils.toDoubleArray` now rethrows with the offending token, its index and the raw input string instead of a bare `NumberFormatException`.
- `FreeMapViewController` and `PicturesChronologyConfiguratorController` had 7 text field listeners (width/height/plotSize/fontSize/portraitRadius, etc.) parsing user input with no try/catch, unlike the sibling `zoomField` listener in the same files. Wrapped them in the same try/catch + `LOG.FINEST` pattern.

## Tests
- New `TimeProjectProviderV3Test`: direct coverage of `parseDoubleAttribute` (valid/malformed/missing attribute).
- New `FreeMapProviderV3Test`: regression test proving the malformed-attribute path also throws cleanly through `parseFreeMaps`.
- New `CustomFileUtilsTest`: `toDoubleArray` valid input and contextual exception on a malformed token.
- `FriezeFreeMapPropertiesTest`: added a regression test for the fallback-on-unparseable-value bug fix.
- 193/193 tests pass locally (`mvn test`).

## Test plan
- [x] `mvn test` passes locally
- [x] Codacy Static Code Analysis
- [x] Codacy Diff Coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)