### PR TITLE
Fix Checkstyle EmptyLineSeparator repo-wide

### DIFF
--- a/src/main/java/com/appiomatic/SvgExporter/SvgExporter.java
+++ b/src/main/java/com/appiomatic/SvgExporter/SvgExporter.java
@@ -3,6 +3,7 @@
  * @author Zunayed Hassan
  * @email zunayedhassan@appiomatic.com
  */
+
 package com.appiomatic.SvgExporter;
 
 import java.awt.image.BufferedImage;

--- a/src/main/java/com/github/noony/app/timelinefx/Configuration.java
+++ b/src/main/java/com/github/noony/app/timelinefx/Configuration.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx;
 
 import com.github.noony.app.timelinefx.hmi.ConfigurationViewController;
@@ -39,33 +40,48 @@ import jfxtras.styles.jmetro.Style;
 public class Configuration {
 
     public static final String TIMELINES_FOLDER_LOCATION_CHANGED = "timelinesFolderLocationChanged";
+
     public static final String PORTRAITS_FOLDER_LOCATION_CHANGED = "portraitsFolderLocationChanged";
+
     public static final String PICTURES_FOLDER_LOCATION_CHANGED = "picturesFolderLocationChanged";
+
     public static final String MINIATURES_FOLDER_LOCATION_CHANGED = "miniaturesFolderLocationChanged";
+
     public static final String THEME_CHANGED = "miniaturesFolderLocationChanged";
-    //
+
     public static final double DEFAULT_FXML_GAP = 8.0;
-    //
+
     private static final String DEFAULT_PORTRAITS_FOLDER_NAME = "portraits";
+
     private static final String DEFAULT_PICTURES_FOLDER_NAME = "pictures";
+
     private static final String DEFAULT_MINIATURES_FOLDER_NAME = "miniatures";
 
     private static final String DEFAULT_PROJECTS_FOLDER_NAME = "Timelines";
+
     private static final String PREFERENCE_FILE_NAME = ".timelines";
+
     private static final String TIMELINES_FOLDER_PROPERTY_NAME = "TimelinesFolder";
+
     private static final String PORTRAITS_FOLDER_PROPERTY_NAME = "PortraitsFolder";
+
     private static final String PICTURES_FOLDER_PROPERTY_NAME = "PicturesFolder";
+
     private static final String MINIATURES_FOLDER_PROPERTY_NAME = "MiniaturesFolder";
+
     private static final String THEME_PROPERTY_NAME = "Theme";
-    //
+
     private static final String DEFAULT_TIMELINES_FOLDER_PATH = System.getProperty("user.home") + File.separator + DEFAULT_PROJECTS_FOLDER_NAME;
+
     private static final Style DEFAULT_THEME = Style.DARK;
 
     //
     private static final Logger LOG = Logger.getGlobal();
+
     private static final PropertyChangeSupport PROPERTY_CHANGE_SUPPORT = new PropertyChangeSupport(ConfigurationViewController.class);
-    //
+
     private static File preferenceFile = null;
+
     private static Properties properties = null;
 
     private Configuration() {

--- a/src/main/java/com/github/noony/app/timelinefx/CustomLogFormatter.java
+++ b/src/main/java/com/github/noony/app/timelinefx/CustomLogFormatter.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx;
 
 import java.text.MessageFormat;

--- a/src/main/java/com/github/noony/app/timelinefx/Main.java
+++ b/src/main/java/com/github/noony/app/timelinefx/Main.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx;
 
 import com.github.noony.app.timelinefx.utils.ExecutorUtils;

--- a/src/main/java/com/github/noony/app/timelinefx/MainApp.java
+++ b/src/main/java/com/github/noony/app/timelinefx/MainApp.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx;
 
 import com.github.noony.app.timelinefx.hmi.AppInstanceConfiguration;
@@ -35,6 +36,7 @@ import javafx.stage.WindowEvent;
 public class MainApp extends Application {
 
     private static final String STAGE_TITLE = "Timeline";
+
     private static final Logger LOG = Logger.getGlobal();
 
     static {

--- a/src/main/java/com/github/noony/app/timelinefx/core/Place.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/Place.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core;
 
 import java.beans.PropertyChangeListener;
@@ -114,7 +115,6 @@ public final class Place implements FriezeObject {
      * Whether this place is currently selected.
      */
     private boolean selected;
-    //
 
     protected Place(final long placeId, final String placeName, final PlaceLevel placeLevel, final Place parentPlace, final Color aColor) {
         id = placeId;

--- a/src/main/java/com/github/noony/app/timelinefx/core/Portrait.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/Portrait.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core;
 
 import java.time.LocalDate;

--- a/src/main/java/com/github/noony/app/timelinefx/core/freemap/FreeMapDateHandle.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/freemap/FreeMapDateHandle.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core.freemap;
 
 import com.github.noony.app.timelinefx.core.freemap.connectors.FreeMapPlot;
@@ -38,6 +39,7 @@ public class FreeMapDateHandle {
     }
 
     public static final String PLOT_REMOVED = "plotRemoved";
+
     public static final String POSITION_CHANGED = "datePositionChanged";
 
     private static final Map<Long, List<FreeMapDateHandle>> FACTORY_CONTENT = new HashMap<>();
@@ -60,13 +62,17 @@ public class FreeMapDateHandle {
     }
 
     private final PropertyChangeSupport propertyChangeSupport;
+
     private final PropertyChangeListener propertyChangeListener;
+
     private final TimeType timeType;
+
     private final double date;
-    //
+
     private final List<FreeMapPlot> plots;
-    //
+
     private double xPos;
+
     private double yPos;
 
     private FreeMapDateHandle(double aDate, TimeType aTimeType, Point2D aPosition) {

--- a/src/main/java/com/github/noony/app/timelinefx/core/freemap/FreeMapLink.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/freemap/FreeMapLink.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core.freemap;
 
 import com.github.noony.app.timelinefx.core.FriezeObject;

--- a/src/main/java/com/github/noony/app/timelinefx/core/freemap/FreeMapMergedStay.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/freemap/FreeMapMergedStay.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core.freemap;
 
 import com.github.noony.app.timelinefx.core.StayPeriod;
@@ -39,22 +40,31 @@ import javafx.scene.paint.Color;
 public final class FreeMapMergedStay implements FreeMapStay {
 
     private final long id;
+
     private final List<FreeMapStay> stays;
+
     private final List<FreeMapConnector> intermediateConnectors;
-    //
+
     private final PropertyChangeSupport propertyChangeSupport;
-    //
+
     private final FreeMapPerson person;
+
     private FreeMapPlace forcedPlace = null;
+
     private FreeMapPlace place;
-    //
+
     private FreeMapStay earliestStay;
+
     private FreeMapStay latestStay;
+
     private final StartPlot beginPlot;
+
     private final EndPlot endPlot;
-    //
+
     private Color color;
+
     private LinkShape linkShape;
+
     private boolean isSelected = false;
 
     protected FreeMapMergedStay(long anID, long aStartID, long anEndID, long aLinkID, FreeMapPlace aForcedPlace, FreeMapStay... staysToMerge) {

--- a/src/main/java/com/github/noony/app/timelinefx/core/freemap/FreeMapPerson.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/freemap/FreeMapPerson.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core.freemap;
 
 import com.github.noony.app.timelinefx.core.FriezeObject;
@@ -40,16 +41,23 @@ import java.util.Map;
 public class FreeMapPerson implements FriezeObject {
 
     public static final String FREEMAP_STAY_ADDED = "stayAdded";
+
     public static final String FREEMAP_STAY_REMOVED = "stayRemoved";
+
     public static final String FIRST_PLOT_CHANGED = "firstPlotChanged";
+
     public static final String TRAVEL_LINK_ADDED = "travelLinkAdded";
+
     public static final String TRAVEL_LINK_REMOVED = "travelLinkRemoved";
+
     public static final String PORTRAIT_ADDED = "portraitAdded";
+
     public static final String PORTRAIT_REMOVED = "portraitRemoved";
+
     public static final String PORTRAIT_LINK_ADDED = "portraitLinkAdded";
+
     public static final String PORTRAIT_LINK_REMOVED = "portraitLinkRemoved";
 
-    //
     private static final Map<Long, List<FreeMapPerson>> FACTORY_CONTENT = new HashMap<>();
 
     public static final FreeMapPerson createFreeMapPerson(final long aFriezeFreeMapID, final Person aPerson) {
@@ -78,13 +86,16 @@ public class FreeMapPerson implements FriezeObject {
     // paramters to be saved
     //
     private final long id;
+
     private final long friezeFreeMapID;
-    //
+
     private final List<FreeMapStay> stays;
+
     private final List<FreeMapPortrait> freeMapPortraits;
     //
     // to be saved in next version
     //
+
     private final List<FreeMapTravelLink> travelLinks;
     private final Map<FreeMapPortrait, PortraitLink> portraitLinks;
     //
@@ -92,7 +103,7 @@ public class FreeMapPerson implements FriezeObject {
     //
     // no need to save since ids match by construction
     private final Person person;
-    //
+
     private final PropertyChangeSupport propertyChangeSupport;
 
     /**

--- a/src/main/java/com/github/noony/app/timelinefx/core/freemap/FreeMapPlace.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/freemap/FreeMapPlace.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core.freemap;
 
 import com.github.noony.app.timelinefx.core.FriezeObject;
@@ -39,11 +40,17 @@ import java.util.logging.Logger;
 public class FreeMapPlace implements FriezeObject {
 
     public static final String Y_POS_CHANGED = "yPosChanged";
+
     public static final String WIDTH_POS_CHANGED = "widthPosChanged";
+
     public static final String HEIGHT_POS_CHANGED = "heightPosChanged";
+
     public static final String MIN_MAX_X_CHANGED = "minMaxXChanged";
+
     public static final String NAME_WIDTH_CHANGED = "nameWidthChanged";
+
     public static final String FONT_SIZE_CHANGED = "fontSizeChanged";
+
     public static final String PLOT_SEPARATION_CHANGED = "plotSeparationChanged";
 
     public static final double PLACE_NAME_HEIGHT = 35;
@@ -53,6 +60,7 @@ public class FreeMapPlace implements FriezeObject {
     private static final Logger LOG = Logger.getGlobal();
 
     private static final double DEFAULT_MIN_X = 0;
+
     private static final double DEFAULT_MAX_X = 0;
 
     //
@@ -75,7 +83,6 @@ public class FreeMapPlace implements FriezeObject {
         FACTORY_CONTENT.clear();
     }
 
-    //
     private final PropertyChangeSupport propertyChangeSupport;
 
     //
@@ -84,21 +91,28 @@ public class FreeMapPlace implements FriezeObject {
     private final long id;
     // for the order of each person when drawn
     private final List<FreeMapPerson> persons;
+
     private double yPos;
+
     private double fontSize;
+
     private double placeNameWidth;
     //
     // other instance parameters, usually calculated
     //
+
     private final Place place;
     private final List<FreeMapPlot> registeredPlots;
     //
     private double placeStayWidth;
+
     private double height = DEFAULT_HEIGHT;
     private double requestedMinPlotSeparation;
     private double currentPlotSeparation;
     //
+
     private double minX = DEFAULT_MIN_X;
+
     private double maxX = DEFAULT_MAX_X;
 
     private FreeMapPlace(Place aPlace, double aPlotSeparation, double aNameWidth, double aFontSize) {

--- a/src/main/java/com/github/noony/app/timelinefx/core/freemap/FreeMapPortrait.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/freemap/FreeMapPortrait.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core.freemap;
 
 import com.github.noony.app.timelinefx.core.FriezeObject;
@@ -36,7 +37,9 @@ import javafx.scene.paint.Color;
 public final class FreeMapPortrait implements FriezeObject {
 
     public static final String POSITION_CHANGED = "positionChanged";
+
     public static final String RADIUS_CHANGED = "portraitRadiusChanged";
+
     public static final String PORTRAIT_UPDATED = "portraitUpdated";
 
     private static final Logger LOG = Logger.getGlobal();
@@ -44,14 +47,19 @@ public final class FreeMapPortrait implements FriezeObject {
     private static final double DEFAULT_POSITION = 0.0;
 
     private final PropertyChangeSupport propertyChangeSupport;
+
     private final FreeMapPerson person;
+
     private final long id;
+
     private final FreeMapBasicConnector connector;
+
     private Portrait portrait;
-    //
-    //
+
     private double xPos;
+
     private double yPos;
+
     private double radius;
 
     protected FreeMapPortrait(long anID, Portrait aPortrait, FreeMapPerson aFreeMapPerson, double aRadius) {

--- a/src/main/java/com/github/noony/app/timelinefx/core/freemap/FreeMapPortraitFactory.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/freemap/FreeMapPortraitFactory.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core.freemap;
 
 import com.github.noony.app.timelinefx.core.Factory;

--- a/src/main/java/com/github/noony/app/timelinefx/core/freemap/FreeMapSimpleStay.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/freemap/FreeMapSimpleStay.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core.freemap;
 
 import com.github.noony.app.timelinefx.core.StayPeriod;
@@ -38,21 +39,27 @@ import javafx.scene.paint.Color;
 public final class FreeMapSimpleStay implements FreeMapStay {
 
     private final long id;
-    //
+
     private final PropertyChangeSupport propertyChangeSupport;
-    //
+
     private final StayPeriod stay;
+
     private final StartPlot beginPlot;
+
     private final EndPlot endPlot;
-    //
+
     private final FreeMapPerson person;
+
     private final FreeMapPlace place;
-    //
+
     private final List<StayPeriod> stays;
+
     private final List<FreeMapConnector> intermediateConnectors;
-    //
+
     private Color color;
+
     private final LinkShape linkShape;
+
     private boolean isSelected = false;
 
     protected FreeMapSimpleStay(long anID, StayPeriod aStay, long aStartID, long anEndID, FreeMapPerson aFreeMapPerson, FreeMapPlace aFreeMapPlace, double aPlotSize) {

--- a/src/main/java/com/github/noony/app/timelinefx/core/freemap/FreeMapStayFactory.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/freemap/FreeMapStayFactory.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core.freemap;
 
 import com.github.noony.app.timelinefx.core.Factory;

--- a/src/main/java/com/github/noony/app/timelinefx/core/freemap/FriezeFreeMap.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/freemap/FriezeFreeMap.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core.freemap;
 
 import com.github.noony.app.timelinefx.core.Frieze;
@@ -57,16 +58,27 @@ public final class FriezeFreeMap implements FriezeObject {
 
     // PropertyChangeEvent names
     public static final String LAYOUT_CHANGED = "layoutChanged";
+
     public static final String NAME_CHANGED = "nameChanged";
+
     public static final String FREE_MAP_PLACE_ADDED = "freeMapPlaceAdded";
+
     public static final String FREE_MAP_PLACE_REMOVED = "freeMapPlaceRemoved";
+
     public static final String FREE_MAP_PERSON_ADDED = "freeMapPersonAdded";
+
     public static final String FREE_MAP_PERSON_REMOVED = "freeMapPersonRemoved";
+
     public static final String FREE_MAP_PORTRAIT_REMOVED = "freeMapPortraitRemoved";
+
     public static final String FREE_MAP_PLOT_SIZE_CHANGED = "freeMapPlotSizeChanged";
+
     public static final String START_DATE_HANDLE_ADDED = "freeMapStartDateAdded";
+
     public static final String START_DATE_HANDLE_REMOVED = "freeMapStartDateRemoved";
+
     public static final String END_DATE_HANDLE_ADDED = "freeMapEndDateAdded";
+
     public static final String END_DATE_HANDLE_REMOVED = "freeMapEndDateRemoved";
 
     // Default Values for layout
@@ -82,6 +94,7 @@ public final class FriezeFreeMap implements FriezeObject {
     public static final double DEFAULT_PLOT_SIZE = 8;
     //
     private static final double DEFAULT_PLOT_SEPARATION = 20;
+
     private static final boolean DEFAULT_PLOT_VISIBILITY = true;
     private static final boolean DEFAULT_PORTRAIT_CONNECTOR_VISIBILITY = true;
 
@@ -100,32 +113,46 @@ public final class FriezeFreeMap implements FriezeObject {
     private final Frieze frieze;
     // TODO remove ?
     private final List<FreeMapPerson> persons;
+
     private final Map<Place, FreeMapPlace> places;
+
     private final Map<Person, FreeMapPerson> freeMapPersons;
     private final Map<Double, FreeMapDateHandle> startDateHandles;
     private final Map<Double, FreeMapDateHandle> endDateHandles;
-    //
+
     private String name;
-    //
+
     private double width;
+
     private double height;
-    //
+
     private double portraitWidth;
+
     private double placeDrawingWidth;
+
     private double placeNamesWidth;
-    //
+
     private double portraitRadius;
+
     private double fontSize;
+
     private double plotSeparation;
+
     private boolean plotVisibiltiy;
+
     private boolean portraitConnectorsVisibiltiy;
+
     private double plotSize;
-    //
+
     private double minDate;
+
     private double maxDate;
+
     private double availableWidth;
+
     private double timeRatio;
-    //
+
+// to be created
 //    private TimeMode timeMode;
 
     protected FriezeFreeMap(long anID, Frieze aFrieze, FriezeFreeMapProperties properties, List<FreeMapDateHandle> dateHandles,

--- a/src/main/java/com/github/noony/app/timelinefx/core/freemap/FriezeFreeMapFactory.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/freemap/FriezeFreeMapFactory.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core.freemap;
 
 import com.github.noony.app.timelinefx.core.Factory;

--- a/src/main/java/com/github/noony/app/timelinefx/core/freemap/GridPositionable.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/freemap/GridPositionable.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core.freemap;
 
 /**
@@ -23,8 +24,11 @@ package com.github.noony.app.timelinefx.core.freemap;
 public interface GridPositionable {
 
     public static final String POS_CHANGED = "posChanged";
+
     public static final String PLOT_SIZE_CHANGED = "plotSizeChanged";
+
     public static final String PLOT_VISIBILITY_CHANGED = "plotVisibilityChanged";
+
     public static final String PLOT_COLOR_CHANGED = "plotColorChanged";
 
     public static final double EPSILON = 0.000000001;

--- a/src/main/java/com/github/noony/app/timelinefx/core/freemap/Selectable.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/freemap/Selectable.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core.freemap;
 
 import java.beans.PropertyChangeListener;

--- a/src/main/java/com/github/noony/app/timelinefx/core/freemap/TimeMode.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/freemap/TimeMode.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core.freemap;
 
 /**

--- a/src/main/java/com/github/noony/app/timelinefx/core/freemap/connectors/EndPlot.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/freemap/connectors/EndPlot.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core.freemap.connectors;
 
 import com.github.noony.app.timelinefx.core.freemap.FreeMapPerson;

--- a/src/main/java/com/github/noony/app/timelinefx/core/freemap/connectors/FreeMapBasicConnector.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/freemap/connectors/FreeMapBasicConnector.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core.freemap.connectors;
 
 import com.github.noony.app.timelinefx.core.FriezeObject;
@@ -32,17 +33,23 @@ public final class FreeMapBasicConnector implements FreeMapConnector {
     public static final String PLOT_DATE_CHANGED = "plotDateChanged";
 
     private final PropertyChangeSupport propertyChangeSupport;
+
     private final long id;
 
     private final FriezeObject parentObject;
 
     private double date;
+
     private final DoubleProperty xPos;
+
     private final DoubleProperty yPos;
 
     private boolean isVisible = true;
+
     private boolean isSelected = false;
+
     private Color color;
+
     private double plotSize;
 
     protected FreeMapBasicConnector(long anId, FriezeObject aParentObject, double aDate, double aPlotSize) {

--- a/src/main/java/com/github/noony/app/timelinefx/core/freemap/connectors/FreeMapConnector.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/freemap/connectors/FreeMapConnector.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core.freemap.connectors;
 
 import com.github.noony.app.timelinefx.core.FriezeObject;

--- a/src/main/java/com/github/noony/app/timelinefx/core/freemap/connectors/FreeMapConnectorFactory.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/freemap/connectors/FreeMapConnectorFactory.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core.freemap.connectors;
 
 import com.github.noony.app.timelinefx.core.Factory;
@@ -38,6 +39,7 @@ public class FreeMapConnectorFactory {
     private static final Logger LOG = Logger.getGlobal();
 
     private static final Factory<FreeMapConnector> FACTORY = new Factory<>();
+
     private static final PropertyChangeSupport PROPERTY_CHANGE_SUPPORT = new PropertyChangeSupport(FACTORY);
 
     private FreeMapConnectorFactory() {

--- a/src/main/java/com/github/noony/app/timelinefx/core/freemap/connectors/FreeMapLinkConnector.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/freemap/connectors/FreeMapLinkConnector.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core.freemap.connectors;
 
 import com.github.noony.app.timelinefx.core.freemap.FreeMapLink;
@@ -36,16 +37,23 @@ public final class FreeMapLinkConnector implements FreeMapConnector {
     private static final Logger LOG = Logger.getGlobal();
 
     private final PropertyChangeSupport propertyChangeSupport;
+
     private final long id;
+
     private final FreeMapLink sourceLink;
 
     private double date;
+
     private final DoubleProperty xPos;
+
     private final DoubleProperty yPos;
 
     private boolean isVisible = true;
+
     private boolean isSelected = false;
+
     private double plotSize;
+
     private Color color;
 
     protected FreeMapLinkConnector(long anID, FreeMapLink aSourceLink, double aDate, double aPlotSize) {

--- a/src/main/java/com/github/noony/app/timelinefx/core/freemap/connectors/FreeMapPlot.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/freemap/connectors/FreeMapPlot.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core.freemap.connectors;
 
 import com.github.noony.app.timelinefx.core.freemap.FreeMapPerson;
@@ -33,19 +34,29 @@ public class FreeMapPlot implements FreeMapConnector {
     public static final String PLOT_DATE_CHANGED = "plotDateChanged";
 
     private final PropertyChangeSupport propertyChangeSupport;
+
     private final long id;
+
     private final FreeMapPerson person;
+
     private final FreeMapPlace place;
+
     private final long parentPeriodID;
 
     private double date;
+
     private final PlotType type;
+
     private final DoubleProperty xPos;
+
     private final DoubleProperty yPos;
 
     private boolean isVisible = true;
+
     private boolean isSelected = false;
+
     private Color color;
+
     private double plotSize;
 
     @SuppressWarnings("this-escape")

--- a/src/main/java/com/github/noony/app/timelinefx/core/freemap/connectors/PlotType.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/freemap/connectors/PlotType.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core.freemap.connectors;
 
 /**

--- a/src/main/java/com/github/noony/app/timelinefx/core/freemap/connectors/StartPlot.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/freemap/connectors/StartPlot.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core.freemap.connectors;
 
 import com.github.noony.app.timelinefx.core.freemap.FreeMapPerson;

--- a/src/main/java/com/github/noony/app/timelinefx/core/freemap/links/FreeMapLinkFactory.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/freemap/links/FreeMapLinkFactory.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core.freemap.links;
 
 import com.github.noony.app.timelinefx.core.Factory;
@@ -39,6 +40,7 @@ public class FreeMapLinkFactory {
     private static final Logger LOG = Logger.getGlobal();
 
     private static final Factory<FreeMapSimpleLink> FACTORY = new Factory<>();
+
     private static final PropertyChangeSupport PROPERTY_CHANGE_SUPPORT = new PropertyChangeSupport(FACTORY);
 
     private FreeMapLinkFactory() {

--- a/src/main/java/com/github/noony/app/timelinefx/core/freemap/links/FreeMapSimpleLink.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/freemap/links/FreeMapSimpleLink.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core.freemap.links;
 
 import com.github.noony.app.timelinefx.core.freemap.FreeMapLink;
@@ -34,22 +35,31 @@ import javafx.scene.paint.Color;
 public class FreeMapSimpleLink implements FreeMapLink {
 
     public static final Color DEFAULT_COLOR = Color.BLUEVIOLET;
+
     public static final String COLOR_CHANGED = "colorChanged";
+
     public static final String LINK_SHAPE_CHANGED = "linkShapeChanged";
+
     public static final String CONNECTOR_ADDED = "connectorAdded";
 
     private final PropertyChangeSupport propertyChangeSupport;
 
     private final long id;
+
     private final FreeMapPerson person;
+
     private final FreeMapConnector beginConnector;
+
     private final FreeMapConnector endConnector;
+
     private final LinkType linkType;
-    //
+
     private final List<FreeMapConnector> intermediateConnectors;
-    //
+
     private LinkShape linkShape;
+
     private Color color;
+
     private boolean isSelected = false;
 
 

--- a/src/main/java/com/github/noony/app/timelinefx/core/freemap/links/FreeMapStayLink.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/freemap/links/FreeMapStayLink.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core.freemap.links;
 
 import com.github.noony.app.timelinefx.core.freemap.FreeMapStay;

--- a/src/main/java/com/github/noony/app/timelinefx/core/freemap/links/FreeMapTravelLink.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/freemap/links/FreeMapTravelLink.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core.freemap.links;
 
 import com.github.noony.app.timelinefx.core.freemap.FreeMapPerson;

--- a/src/main/java/com/github/noony/app/timelinefx/core/freemap/links/LinkType.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/freemap/links/LinkType.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core.freemap.links;
 
 /**

--- a/src/main/java/com/github/noony/app/timelinefx/core/freemap/links/PortraitLink.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/freemap/links/PortraitLink.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core.freemap.links;
 
 import com.github.noony.app.timelinefx.core.freemap.FreeMapPortrait;

--- a/src/main/java/com/github/noony/app/timelinefx/core/picturechronology/ChronologyLink.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/picturechronology/ChronologyLink.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core.picturechronology;
 
 import com.github.noony.app.timelinefx.core.AnchorSide;
@@ -44,25 +45,30 @@ public final class ChronologyLink implements FriezeObject {
     private static final AnchorSide DEFAULT_END_LINK_ANCHOR_SIDE = AnchorSide.LEFT;
 
     private static final Logger LOG = Logger.getGlobal();
+
     private static final double PLOT_SEPARATION = 15;
 
     private final PropertyChangeSupport propertyChangeSupport;
     private final long id;
 
     private final Person person;
+
     private final ChronologyPictureMiniature startMiniature;
+
     private final ChronologyPictureMiniature endMiniature;
-    //
+
     private ChronologyLinkType linkType;
     private AnchorSide startAnchorSide;
     private AnchorSide endAnchorSide;
-    //
+
     private int startIndex;
+
     private int endIndex;
-    //
+
     private Point2D startPosition;
+
     private Point2D endPosition;
-    //
+
     private double[] linkParameters;
 
     protected ChronologyLink(long anId, Person aPerson, ChronologyPictureMiniature aStartMiniature, ChronologyPictureMiniature anEndMiniature, ChronologyLinkType aLinkType, double[] allLinkParameters) {

--- a/src/main/java/com/github/noony/app/timelinefx/core/picturechronology/ChronologyLinkType.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/picturechronology/ChronologyLinkType.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core.picturechronology;
 
 import com.github.noony.app.timelinefx.core.Person;

--- a/src/main/java/com/github/noony/app/timelinefx/core/picturechronology/ChronologyPictureMiniature.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/picturechronology/ChronologyPictureMiniature.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core.picturechronology;
 
 import com.github.noony.app.timelinefx.core.DateObject;
@@ -35,8 +36,11 @@ import javafx.geometry.Point2D;
 public final class ChronologyPictureMiniature implements FriezeObject {
 
     public static final String POSITION_CHANGED = "ChronologyPictureMiniature__positionChanged";
+
     public static final String SCALE_CHANGED = "ChronologyPictureMiniature__scaleChanged";
+
     public static final String TIME_CHANGED = "ChronologyPictureMiniature__timeChanged";
+
     public static final String REQUEST_LINKS_UPDATE = "ChronologyPictureMiniature__requestLinksUpdate";
 
     public static final Comparator<ChronologyPictureMiniature> COMPARATOR = (c1, c2) -> Double.compare(c1.getCurrenltyUsedAbsoluteTime(), c2.getCurrenltyUsedAbsoluteTime());
@@ -45,9 +49,13 @@ public final class ChronologyPictureMiniature implements FriezeObject {
     private final long id;
 
     private final IPicture picture;
+
     private final DateObject dateObject;
+
     private Point2D position;
+
     private double scale;
+
     private boolean usesCustomTime;
 
     protected ChronologyPictureMiniature(long anId, IPicture aPicture, Point2D aPosition, double aScale) {

--- a/src/main/java/com/github/noony/app/timelinefx/core/picturechronology/PictureChronology.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/picturechronology/PictureChronology.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core.picturechronology;
 
 import com.github.noony.app.timelinefx.core.FriezeObject;
@@ -45,13 +46,19 @@ public final class PictureChronology implements FriezeObject, IDrawableObject {
     public static final String DEFAULT_NAME = "PictureChronologyNoName";
 
     public static final String LAYOUT_CHANGED = "layoutChanged";
+
     public static final String NAME_CHANGED = "nameChanged";
+
     public static final String PICTURE_ADDED = "pictureAdded";
+
     public static final String PICTURE_REMOVED = "pictureRemoved";
+
     public static final String LINK_ADDED = "linkedAdded";
+
     public static final String LINK_REMOVED = "linkedRemoved";
 
     private static final double DEFAULT_WIDTH = 1600;
+
     private static final double DEFAULT_HEIGHT = 1200;
 
     public static final double PERSON_CONTOUR_WIDTH = 6;
@@ -62,14 +69,19 @@ public final class PictureChronology implements FriezeObject, IDrawableObject {
     private final ChronologyLinkType chronologyLinkType = ChronologyLink.DEFAULT_LINK_TYPE;
 
     private final TimeLineProject project;
+
     private final List<ChronologyPictureMiniature> chronologyPictures;
+
     private final Map<String, ChronologyLink> chronologyLinks;
+
     private final List<Person> persons;
     //
     private final TimeFormat timeFormat;
-    //
+
     private String name;
+
     private double width;
+
     private double height;
 
     protected PictureChronology(long anID, TimeLineProject aProject, String aName, TimeFormat aTimeFormat, List<ChronologyPictureMiniature> exisitingMiniatures, List<ChronologyLink> existingLinks) {

--- a/src/main/java/com/github/noony/app/timelinefx/core/picturechronology/PictureChronologyFactory.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/picturechronology/PictureChronologyFactory.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core.picturechronology;
 
 import com.github.noony.app.timelinefx.core.Factory;
@@ -35,11 +36,14 @@ public class PictureChronologyFactory {
     private static final Logger LOG = Logger.getGlobal();
 
     private static final Factory<PictureChronology> CHROLOGY_FACTORY = new Factory<>();
+
     private static final Factory<ChronologyPictureMiniature> PICTURE_FACTORY = new Factory<>();
+
     private static final Factory<ChronologyLink> LINK_FACTORY = new Factory<>();
 
     //
     private static final String TRYING_CREATION_MSG = "Trying to create createPictureChronology ";
+
     private static final String EXISTING_ID_MSG = " with existing id=";
 
     private PictureChronologyFactory() {

--- a/src/main/java/com/github/noony/app/timelinefx/drawings/AbstractFxScalableNode.java
+++ b/src/main/java/com/github/noony/app/timelinefx/drawings/AbstractFxScalableNode.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.drawings;
 
 import javafx.scene.Group;
@@ -26,6 +27,7 @@ import javafx.scene.Node;
 public abstract class AbstractFxScalableNode implements IFxScalableNode {
 
     private final Group mainNode;
+
     private double scale;
 
     public AbstractFxScalableNode(double aScale) {

--- a/src/main/java/com/github/noony/app/timelinefx/drawings/FXDrawing.java
+++ b/src/main/java/com/github/noony/app/timelinefx/drawings/FXDrawing.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.drawings;
 
 import javafx.scene.Group;
@@ -28,11 +29,15 @@ import javafx.scene.shape.Rectangle;
 public class FXDrawing implements IFxNode {
 
     private final Group mainNode;
+
     private final Rectangle background;
-    //
+
     private double xPos;
+
     private double yPos;
+
     private double width;
+
     private double height;
 
     public FXDrawing() {

--- a/src/main/java/com/github/noony/app/timelinefx/drawings/FxScalableParent.java
+++ b/src/main/java/com/github/noony/app/timelinefx/drawings/FxScalableParent.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.drawings;
 
 import com.github.noony.app.timelinefx.core.IDrawableObject;
@@ -34,26 +35,31 @@ import javafx.scene.shape.Rectangle;
 public class FxScalableParent implements IFxScalableNode {
 
     public static final double MIN_SCALE = 0.2;
+
     public static final double MAX_SCALE = 20;
+
     public static final double SCALE_STEP = 0.1;
 
     public static final double BORDER = 0;//todo investigate why size does not take this into account
+
     public static final double PADDING = 8;
 
     private final PropertyChangeSupport propertyChangeSupport;
 
     private final Pane mainNode;
+
     private final Group mainGroup;
-    //
+
     private final Rectangle background;
-    //
+
     private final List<IFxScalableNode> scalableNodes;
-    //
+
     private final IDrawableObject drawableObject;
-    //
+
     private double drawingWidth;
+
     private double drawingHeight;
-    //
+
     private double viewingScale = 1.0;
 
     @SuppressWarnings("this-escape")

--- a/src/main/java/com/github/noony/app/timelinefx/drawings/GalleryTiles.java
+++ b/src/main/java/com/github/noony/app/timelinefx/drawings/GalleryTiles.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.drawings;
 
 import com.github.noony.app.timelinefx.MainApp;
@@ -55,24 +56,31 @@ import javafx.scene.text.TextAlignment;
 public final class GalleryTiles implements IFxNode {
 
     public static final double TILE_WIDTH = 250;
+
     public static final double TILE_HEIGHT = 200;
 
     public static final String TILE_CLICKED = "tileClicked";
+
     public static final String TILE_SELECTED = "tileSelected";
 
     private static final Logger LOG = Logger.getGlobal();
 
     private static final int DEFAULT_NUMBER_OF_TILES = 6;
+
     private static final double IMAGE_RATIO = 0.9;
+
     private static final double IMAGE_WIDTH = TILE_WIDTH * IMAGE_RATIO;
+
     private static final double IMAGE_HEIGHT = TILE_HEIGHT * IMAGE_RATIO;
+
     private static final Dimension IMAGE_DIMENSION = new Dimension((int) IMAGE_WIDTH, (int) IMAGE_HEIGHT);
 
     private FlowGridPane tilesPane;
 
     private final PropertyChangeSupport propertyChangeSupport;
-    //
+
     private final Map<IFileObject, Tile> content;
+
     private Tile activeTile = null;
 
     public GalleryTiles(List<IFileObject> objectList) {

--- a/src/main/java/com/github/noony/app/timelinefx/drawings/IFriezeView.java
+++ b/src/main/java/com/github/noony/app/timelinefx/drawings/IFriezeView.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.drawings;
 
 import com.github.noony.app.timelinefx.core.Frieze;

--- a/src/main/java/com/github/noony/app/timelinefx/drawings/IFxNode.java
+++ b/src/main/java/com/github/noony/app/timelinefx/drawings/IFxNode.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.drawings;
 
 import javafx.scene.Node;

--- a/src/main/java/com/github/noony/app/timelinefx/drawings/IFxScalableNode.java
+++ b/src/main/java/com/github/noony/app/timelinefx/drawings/IFxScalableNode.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.drawings;
 
 /**

--- a/src/main/java/com/github/noony/app/timelinefx/examples/StarWars.java
+++ b/src/main/java/com/github/noony/app/timelinefx/examples/StarWars.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.examples;
 
 import com.github.noony.app.timelinefx.Configuration;
@@ -47,20 +48,30 @@ import javafx.scene.paint.Color;
 public class StarWars {
 
     private static final Logger LOG = Logger.getGlobal();
+
     private static final String[] RESOURCES = {
         "c3po.png", "darth_sidius.png", "mace_windu.png", "quigon.png",
         "cpt_panaka.png", "darth_vader.png", "obi_wan.png", "r2d2.png",
         "darth_maul.png", "gunray.png", "padme.png", "yoda.png", "ahsoka.png"};
 
     private static Person obiWanKenobi;
+
     private static Person quiGon;
+
     private static Person yoda;
+
     private static Person padme;
+
     private static Person panaka;
+
     private static Person r2d2;
+
     private static Person c3po;
+
     private static Person anakin;
+
     private static Person maceWindu;
+
     private static Person gunray;
     private static Person darthMaul;
     private static Person darthSidious;

--- a/src/main/java/com/github/noony/app/timelinefx/examples/TestExample.java
+++ b/src/main/java/com/github/noony/app/timelinefx/examples/TestExample.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.examples;
 
 import com.github.noony.app.timelinefx.Configuration;

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/AppInstanceConfiguration.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/AppInstanceConfiguration.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.hmi;
 
 import com.github.noony.app.timelinefx.core.Frieze;
@@ -32,13 +33,15 @@ public class AppInstanceConfiguration {
     public static final double ANCHOR_CONSTRAINT_ZERO = 0.0;
 
     public static final String TIMELINE_SELECTED_CHANGED = "timelineSelectedChanged";
+
     public static final String FRIEZE_SELECTED_CHANGED = "friezeSelectedChanged";
-    //
+
     private static final Logger LOG = Logger.getGlobal();
+
     private static final PropertyChangeSupport PROPERTY_CHANGE_SUPPORT = new PropertyChangeSupport(ConfigurationViewController.class);
-    //
-    //
+
     private static TimeLineProject selectedProject = null;
+
     private static Frieze selectedFrieze = null;
 
     private AppInstanceConfiguration() {

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/ChronologyMiniatureConfiguratorController.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/ChronologyMiniatureConfiguratorController.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.hmi;
 
 import com.github.noony.app.timelinefx.core.AnchorSide;
@@ -56,6 +57,7 @@ public class ChronologyMiniatureConfiguratorController implements Initializable 
 
     @FXML
     private Label nameLabel;
+
     @FXML
     private Label idLabel;
     @FXML
@@ -81,6 +83,7 @@ public class ChronologyMiniatureConfiguratorController implements Initializable 
     private TableColumn<ChronologyLink, AnchorSide> linksSideColumn;
 
     private ChronologyPictureMiniature currentMiniature = null;
+
     private PictureChronology pictureChronology = null;
 
     @Override

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/ConfigurationViewController.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/ConfigurationViewController.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.hmi;
 
 import com.github.noony.app.timelinefx.Configuration;
@@ -48,12 +49,14 @@ public final class ConfigurationViewController implements Initializable {
 
     @FXML
     private TextField timelinesLocationField;
+
     @FXML
     private RadioButton darkThemeRB;
     @FXML
     private RadioButton lightThemeRB;
 
     private final PropertyChangeSupport propertyChangeSupport = new PropertyChangeSupport(ConfigurationViewController.this);
+
     private final DirectoryChooser directoryChooser = new DirectoryChooser();
 
     @Override

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/ContentEditionViewController.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/ContentEditionViewController.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.hmi;
 
 import com.github.noony.app.timelinefx.core.Person;
@@ -63,6 +64,7 @@ public final class ContentEditionViewController implements Initializable {
 
     @FXML
     private TreeView<Place> placesCheckTreeView;
+
     @FXML
     private ListView<Person> personCheckListView;
     @FXML
@@ -72,17 +74,23 @@ public final class ContentEditionViewController implements Initializable {
     private SplitPane splitPane;
 
     private final PropertyChangeListener timelineChangeListener = this::handleTimelineChanges;
-    //
+
     private TimeLineProject timeLineProject;
-    //
+
     private CustomModalWindow customModalWindow = null;
-    //
+
     private Parent placeCreationView = null;
+
     private Parent personCreationView = null;
+
     private Parent staysCreationView = null;
+
     private PlaceCreationViewController placeCreationController = null;
+
     private PersonCreationViewController personCreationController = null;
+
     private StaysCreationViewController staysCreationViewController = null;
+
     private EditType editType;
 
     @Override

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/CustomModalWindow.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/CustomModalWindow.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.hmi;
 
 import javafx.scene.Parent;
@@ -32,8 +33,11 @@ import jfxtras.styles.jmetro.Style;
 public class CustomModalWindow {
 
     private final Window parentWindow;
+
     private final Stage modalStage;
+
     private final Scene modalScene;
+
     private final JMetro jMetro;
 
     public CustomModalWindow(Window aParentWindow, Parent content) {

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/EditionMode.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/EditionMode.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.hmi;
 
 /**

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/FriezePeopleViewController.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/FriezePeopleViewController.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.hmi;
 
 import com.github.noony.app.timelinefx.core.Frieze;
@@ -47,6 +48,7 @@ public class FriezePeopleViewController implements Initializable {
 
     @FXML
     private AnchorPane peopleViewRootPane;
+
     @FXML
     private ScrollPane peopleViewScrollPane;
     @FXML
@@ -58,15 +60,19 @@ public class FriezePeopleViewController implements Initializable {
 
     /// DOUBLONS !!
     private final double barPadding = 15;
+
     private final double noBarPadding = 5;
 
     private final DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("dd LLLL yyyy");
 
     private double friezePaneWidth = 100;
+
     private double friezePaneHeight = 100;
+
     private boolean vBarVisible = true;
 
     private Frieze frieze = null;
+
     private FriezePeopleLinearDrawing friezePeopleLinearDrawing = null;
 
     @Override

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/GalleryViewController.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/GalleryViewController.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.hmi;
 
 import com.github.noony.app.timelinefx.core.Person;
@@ -70,10 +71,12 @@ public final class GalleryViewController implements Initializable, ViewControlle
     private TimeLineProject project = null;
 
     private Parent pictureLoaderView = null;
+
     private PictureLoaderViewController pictureLoaderController = null;
 
     @FXML
     private TableView<Picture> picturesTableView;
+
     @FXML
     private TableColumn<Picture, String> pictureNameColumn, pictureDateColumn, picturePeopleColumn, picturePlacesColumn;
     @FXML

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/PersonCreationViewController.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/PersonCreationViewController.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.hmi;
 
 import com.github.noony.app.timelinefx.Configuration;
@@ -68,7 +69,9 @@ import javafx.stage.FileChooser;
 public final class PersonCreationViewController implements Initializable {
 
     public static final String CANCEL_PERSON_CREATION = "cancelPersonCreation";
+
     public static final String PERSON_CREATED = "personCreated";
+
     public static final String PERSON_EDITIED = "personEdited";
 
     private static final Logger LOG = Logger.getGlobal();
@@ -77,6 +80,7 @@ public final class PersonCreationViewController implements Initializable {
 
     @FXML
     private GridPane propertiesGrid;
+
     @FXML
     private TextField nameField;
     @FXML
@@ -95,32 +99,44 @@ public final class PersonCreationViewController implements Initializable {
     private Button addPortraitButton, removePortraitButton;
     @FXML
     private HBox portraitTimeHB;
-    //
+
     private DatePicker birthDatePicker, deathDatePicker, portraitDatePicker;
+
     private TextField birthTimeField, deathTimeField, portraitTimeField;
-    //
+
     private Image image;
+
     private GalleryTiles galleryTiles;
+
     private FileChooser fileChooser;
-    //
+
     private EditionMode editionMode;
-    //
+
     private TimeLineProject currentProject = null;
+
     private Person currentEditedPerson = null;
+
     private List<Portrait> currentPortaitsList = null;
-    //
+
     private String personName = "";
+
     private Portrait defaultPortrait = null;
+
     private Color personColor = null;
+
     private LocalDate dateOfBirth = null;
+
     private LocalDate dateOfDeath = null;
-    //
+
     private Portrait portraitSelected = null;
+
     private Map<Portrait, LocalDate> updatedPortraitDates;
+
     private Map<Portrait, String> updatedPortraitTimes;
 
     //
     private boolean nameOK = false;
+
     private boolean colorOK = false;
 
     @Override

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/PictureLoaderViewController.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/PictureLoaderViewController.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.hmi;
 
 import com.github.noony.app.timelinefx.core.IDateObject;
@@ -60,7 +61,9 @@ import org.controlsfx.control.CheckListView;
 public final class PictureLoaderViewController implements Initializable, ViewController {
 
     public static final String CANCEL_EVENT = "cancel";
+
     public static final String OK_EVENT = "ok";
+
     public static final String FILE_REQUEST_EVENT = "fileChooserRequest";
 
     private static final Logger LOG = Logger.getGlobal();
@@ -69,6 +72,7 @@ public final class PictureLoaderViewController implements Initializable, ViewCon
 
     @FXML
     private TextField fileField;
+
     @FXML
     private TextField pictureNameField;
     @FXML
@@ -88,7 +92,9 @@ public final class PictureLoaderViewController implements Initializable, ViewCon
     private EditionMode editionMode;
 
     private TimeLineProject project = null;
+
     private File pictureFile = null;
+
     private String pictureName = null;
 
     private Picture picture = null;

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/PicturesChronologyConfiguratorController.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/PicturesChronologyConfiguratorController.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.hmi;
 
 import com.github.noony.app.timelinefx.Configuration;
@@ -50,6 +51,7 @@ public class PicturesChronologyConfiguratorController implements Initializable {
 
     @FXML
     private AnchorPane configuratorRoot;
+
     @FXML
     private TextField widthField;
     @FXML
@@ -58,10 +60,11 @@ public class PicturesChronologyConfiguratorController implements Initializable {
     private TextField zoomField;
     @FXML
     private CheckBox picturesVisibilityCB;
-    //
+
     private PictureChronology pictureChronology;
+
     private PictureChronologyDrawing pictureChronologyDrawing;
-    //
+
     private FileChooser fileChooser;
 
     @Override

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/PicturesChronologyViewController.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/PicturesChronologyViewController.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.hmi;
 
 import com.github.noony.app.timelinefx.core.IFileObject;
@@ -58,19 +59,26 @@ import javafx.scene.layout.AnchorPane;
 public final class PicturesChronologyViewController implements Initializable {
 
     private static final Logger LOG = Logger.getGlobal();
+
     private final PropertyChangeSupport propertyChangeSupport = new PropertyChangeSupport(this);
+
     private final PropertyChangeListener galleryTilesListener = PicturesChronologyViewController.this::handleGalleryTilesChanges;
+
     private final PropertyChangeListener portraitTilesListener = PicturesChronologyViewController.this::handlePortraitTilesChanges;
 
     private TimeLineProject project;
+
     private GalleryTiles picturesGalleryTiles = null;
+
     private GalleryTiles portraitGalleryTiles = null;
+
     private PictureChronology currentPictureChronology = null;
+
     private PictureChronologyDrawing pictureChronologyDrawing = null;
-    //
 
     @FXML
     private ScrollPane viewScrollPane;
+
     @FXML
     private TabPane propertiesTabPane;
     @FXML
@@ -85,14 +93,19 @@ public final class PicturesChronologyViewController implements Initializable {
     private Button insertPictureB, insertPortraitB;
 
     private AnchorPane configuratorView;
+
     private AnchorPane miniaturePropertyRootView;
+
     private AnchorPane linkPropertyRootView;
 
     private PicturesChronologyConfiguratorController configuratorController;
+
     private ChronologyMiniatureConfiguratorController miniaturePropertyController;
+
     private ChronologyLinkConfiguratorController linkPropertyController;
 
     private Tab configuratorTab = null;
+
     private Tab itemPropertyTab = null;
 
     @Override

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/PlaceCreationViewController.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/PlaceCreationViewController.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.hmi;
 
 import com.github.noony.app.timelinefx.core.Place;
@@ -41,11 +42,14 @@ import javafx.scene.paint.Color;
 public final class PlaceCreationViewController implements Initializable {
 
     public static final String PLACE_CREATED = "placeCreated";
+
     public static final String PLACE_EDITIED = "placeEdited";
+
     public static final String CANCEL_PLACE_CREATION = "cancelPlaceCreation";
 
     @FXML
     private TextField nameLabel;
+
     @FXML
     private ComboBox<PlaceLevel> placeLevelCB;
     @FXML
@@ -56,19 +60,25 @@ public final class PlaceCreationViewController implements Initializable {
     private Button createButton;
 
     private final PropertyChangeSupport propertyChangeSupport = new PropertyChangeSupport(PlaceCreationViewController.this);
-    //
+
     private Place currentEditedPlace = null;
-    //
+
     private String placeName = null;
+
     private PlaceLevel placeLevel = null;
+
     private Place parentPlace = null;
+
     private Color placeColor = null;
-    //
+
     private boolean nameOK = false;
+
     private boolean levelOK = false;
+
     private boolean parentOK = true;
+
     private boolean colorOK = true;
-    //
+
     private EditionMode editionMode;
 
     @Override

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/PlaceEditionViewController.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/PlaceEditionViewController.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.hmi;
 
 import com.github.noony.app.timelinefx.core.Place;
@@ -42,10 +43,12 @@ import javafx.scene.paint.Color;
 public final class PlaceEditionViewController implements Initializable {
 
     public static final String PLACE_EDITED = "placeEdited";
+
     public static final String CANCEL_PLACE_EDITION = "cancelPlaceEdition";
 
     @FXML
     private TextField nameLabel;
+
     @FXML
     private ComboBox<PlaceLevel> placeLevelCB;
     @FXML
@@ -61,14 +64,21 @@ public final class PlaceEditionViewController implements Initializable {
 
     //
     private Place currentPlace = null;
+
     private String placeName = null;
+
     private PlaceLevel placeLevel = null;
+
     private Place parentPlace = null;
+
     private Color placeColor = null;
-    //
+
     private boolean nameOK = false;
+
     private boolean levelOK = false;
+
     private boolean parentOK = true;
+
     private boolean colorOK = true;
 
     @Override

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/PortraitSelectionViewController.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/PortraitSelectionViewController.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.hmi;
 
 import com.github.noony.app.timelinefx.core.Portrait;
@@ -37,15 +38,18 @@ import javafx.scene.control.ScrollPane;
 public class PortraitSelectionViewController implements Initializable {
 
     public static final String PORTRAIT_SELECTION_UPDATED = "portraitSelectionUpdated";
+
     public static final String HIDE_REQUESTED = "hideRequested";
 
     @FXML
     private ScrollPane galleryScrollPane;
 
     private Portrait portraitSelected = null;
+
     private List<Portrait> portraits;
+
     private PropertyChangeSupport propertyChangeSupport;
-    //
+
     private GalleryTiles galleryTiles;
 
     @Override

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/ProjectCreationWizardController.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/ProjectCreationWizardController.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.hmi;
 
 import com.github.noony.app.timelinefx.Configuration;
@@ -39,6 +40,7 @@ import javafx.stage.DirectoryChooser;
 public final class ProjectCreationWizardController implements Initializable {
 
     public static final String CANCEL = "cancel";
+
     public static final String CREATE = "create";
 
     private DirectoryChooser directoryChooser = null;
@@ -47,6 +49,7 @@ public final class ProjectCreationWizardController implements Initializable {
 
     @FXML
     private Button createB;
+
     @FXML
     private TextField nameField;
     @FXML
@@ -59,12 +62,17 @@ public final class ProjectCreationWizardController implements Initializable {
     private TextField miniaturesField;
 
     private String name = "";
+
     private String projectFolderPath = "";
+
     private String portraitsFolderName = "";
+
     private String picturesFolderName = "";
+
     private String miniaturesFolderName = "";
-    //
+
     private File incompleteProjectFolder = null;
+
     private boolean isOK = false;
 
     @Override

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/ProjectViewController.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/ProjectViewController.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.hmi;
 
 import com.github.noony.app.timelinefx.Configuration;
@@ -75,6 +76,7 @@ public final class ProjectViewController implements Initializable {
 
     @FXML
     private AnchorPane mainAnchorPane;
+
     @FXML
     private MenuBar menuBar;
     @FXML
@@ -95,34 +97,51 @@ public final class ProjectViewController implements Initializable {
     private final Map<CheckMenuItem, Frieze> friezeMenuItems = new HashMap<>();
 
     private TimeLineProject timeLineProject;
+
     private FileChooser fileChooser;
-    //
+
     private Stage modalStage;
+
     private Scene modalScene;
-    //
+
     private Parent contentEditionView = null;
     private Parent friezeContentEditorView = null;
+
     private Parent galleryView = null;
+
     private Parent configurationView = null;
+
     private Parent projectCreationWizardView = null;
+
     private Parent pictureLoaderView = null;
+
     private Parent picturesChronologyView = null;
-    //
+
     private GalleryViewController galleryController = null;
+
     private ConfigurationViewController configurationController = null;
+
     private ProjectCreationWizardController projectCreationWizardController = null;
+
     private PictureLoaderViewController pictureLoaderViewController = null;
+
     private PicturesChronologyViewController pictureChronologyViewController = null;
-    //
+
     private SaveWindow saveWindow = null;
     // toolbarToggleGroup does not seem to work : TODO: fix
+
     private ToggleGroup toolbarToggleGroup;
+
     private ToggleGroup viewToggleGroup;
+
     private ACTION_ON_HOLD actionOnHold = ACTION_ON_HOLD.NONE;
-    //
+
     private ToggleButton contentEditionToggle;
+
     private ToggleButton timeLineToggle;
+
     private ToggleButton galleryToggle;
+
     private ToggleButton picturesChronologyToggle;
 
     @Override

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/SaveDialogController.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/SaveDialogController.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.hmi;
 
 import java.beans.PropertyChangeListener;
@@ -33,7 +34,7 @@ import javafx.fxml.Initializable;
 public final class SaveDialogController implements Initializable {
 
     private static final Logger LOG = Logger.getGlobal();
-    //
+
     private final PropertyChangeSupport propertyChangeSupport = new PropertyChangeSupport(this);
 
     @Override

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/SaveWindow.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/SaveWindow.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.hmi;
 
 import com.github.noony.app.timelinefx.core.TimeLineProject;
@@ -38,17 +39,23 @@ import javafx.stage.WindowEvent;
 public final class SaveWindow {
 
     public static final String SAVE = "save";
+
     public static final String CANCEL = "cancel";
+
     public static final String DISCARD = "discard";
 
     private static final Logger LOG = Logger.getGlobal();
 
     private final Window parentWindow;
+
     private final Stage stage;
+
     private final PropertyChangeSupport propertyChangeSupport;
-    //
+
     private Scene scene;
+
     private Parent saveDialogView = null;
+
     private SaveDialogController saveDialogController = null;
 
     public SaveWindow(Window aParentWindow) {

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/StageFactory.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/StageFactory.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.hmi;
 
 import com.github.noony.app.timelinefx.Configuration;
@@ -46,16 +47,19 @@ public class StageFactory {
     /**
      * Default scene height.
      */
+
     public static final double DEFAULT_SCENE_HEIGHT = 900;
-    //
+
     private static final Logger LOG = Logger.getGlobal();
-    //
+
     private static final boolean DEFAULT_LAF = false;
+
     private static final Map<Scene, JMetro> SCENE_STYLES = new HashMap<>();
     //
     /**
      * Font size in pt
      */
+
     private static final DoubleProperty FONT_SIZE = new SimpleDoubleProperty(12);
 
     private StageFactory() {

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/StaysCreationViewController.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/StaysCreationViewController.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.hmi;
 
 import com.github.noony.app.timelinefx.core.Person;
@@ -62,7 +63,7 @@ public final class StaysCreationViewController implements Initializable {
     private static final Logger LOG = Logger.getGlobal();
 
     private final PropertyChangeSupport propertyChangeSupport = new PropertyChangeSupport(StaysCreationViewController.this);
-    //
+
     @FXML
     private RadioButton timeRB, dateRB;
     //
@@ -84,22 +85,26 @@ public final class StaysCreationViewController implements Initializable {
     //
     @FXML
     private ListView<StayPeriod> chronologyListView;
-    //
+
     private TimeFormat timeFormat;
-    //
+
     private TimeLineProject timeline = null;
     //
     // is there a better way ?
     private final PropertyChangeListener timelineListener = StaysCreationViewController.this::handleTimelineChanges;
-    //
+
     private boolean personOK = false;
+
     private boolean placeOK = false;
+
     private boolean startOK = false;
+
     private boolean endOK = false;
-    //
+
     private long startTime = -1;
+
     private long endTime = -1;
-    //
+
     private StayPeriod selectedStayPeriod = null;
 
     /**

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/ViewController.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/ViewController.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.hmi;
 
 import java.beans.PropertyChangeListener;

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/byperson/FriezePeopleLinearDrawing.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/byperson/FriezePeopleLinearDrawing.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.hmi.byperson;
 
 import com.github.noony.app.timelinefx.core.Frieze;
@@ -40,20 +41,28 @@ public final class FriezePeopleLinearDrawing implements IFriezeView {
     private final Frieze frieze;
 
     private final Group mainNode;
+
     private final Group personsGroup;
+
     private final Group stayGroup;
+
     private final Rectangle stayGroupClip;
 
     private final Rectangle background;
 
     private final Map<Person, PersonDrawing> personsAndDrawings;
+
     private final List<Person> visiblePersons;
-    //
+
     private double width = 800;
+
     private double height = 600;
+
     private double placeWith;
     // temp since no zoom
+
     private double timeWindowWidth;
+
     private double timeWindowX;
 
     private double previewsPersonsHeight = 0;

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/byperson/PersonDrawing.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/byperson/PersonDrawing.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.hmi.byperson;
 
 import com.github.noony.app.timelinefx.core.Person;
@@ -39,24 +40,32 @@ import javafx.scene.text.TextAlignment;
 public final class PersonDrawing extends FXDrawing {
 
     public static final double DEFAULT_HEIGHT = 24;
+
     public static final double DEFAULT_WIDTH = 500;
 
     public static final double DEFAULT_SEPARATION = 12.0;
+
     public static final double DEFAULT_INNER_SEPARATION = 8.0;
 
     public static final double DEFAULT_NAME_WIDTH = 140;
 
     private final Person person;
+
     private final IFriezeView friezeView;
+
     private final Map<StayPeriod, PlaceStayDrawing> staysAndDrawings;
 
     //
     private final Label nameLabel;
+
     private final Line nameSeparationLine;
+
     private final Group placesGroup;
+
     private final Rectangle placesGroupClip;
-    //
+
     private double currentMinDate = 0L;
+
     private double currentRatio = 1;
 
     public PersonDrawing(IFriezeView aFriezeView, Person aPerson) {

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/byperson/PlaceStayDrawing.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/byperson/PlaceStayDrawing.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.hmi.byperson;
 
 import com.github.noony.app.timelinefx.core.Place;
@@ -30,6 +31,7 @@ import javafx.scene.shape.Rectangle;
 public class PlaceStayDrawing {
 
     public static final double STROKE_WIDTH = 6;
+
     public static final double SELECTED_STROKE_WIDTH = 12;
 
     public static final double PLACE_HEIGHT = PersonDrawing.DEFAULT_HEIGHT - 2.0 * PersonDrawing.DEFAULT_INNER_SEPARATION;
@@ -37,6 +39,7 @@ public class PlaceStayDrawing {
     private final StayPeriod stayPeriod;
 
     private final Rectangle rectangle;
+
     private final double yPos = PersonDrawing.DEFAULT_INNER_SEPARATION;
 
     public PlaceStayDrawing(StayPeriod stay) {

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/byplace/FriezePlaceViewController.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/byplace/FriezePlaceViewController.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.hmi.byplace;
 
 import com.github.noony.app.timelinefx.core.Frieze;
@@ -40,6 +41,7 @@ import org.controlsfx.control.RangeSlider;
 public class FriezePlaceViewController implements Initializable {
 
     private final double barPadding = 15;
+
     private final double noBarPadding = 5;
 
     @FXML
@@ -53,14 +55,18 @@ public class FriezePlaceViewController implements Initializable {
 
     @FXML
     private RangeSlider timeSlider;
+
     @FXML
     private Label minDateLabel, maxDateLabel;
 
     private double friezePaneWidth = 100;
+
     private double friezePaneHeight = 100;
+
     private boolean vBarVisible = true;
 
     private Frieze frieze = null;
+
     private FriezeSpaceLinearDrawing friezeSpaceLinearDrawing = null;
 
     @Override

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/byplace/FriezeSpaceLinearDrawing.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/byplace/FriezeSpaceLinearDrawing.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.hmi.byplace;
 
 import com.github.noony.app.timelinefx.core.Frieze;
@@ -42,19 +43,24 @@ public final class FriezeSpaceLinearDrawing {
     private final Frieze frieze;
 
     private final Group mainNode;
+
     private final VBox placesGroup;
+
     private final Group stayGroup;
 
     private final Rectangle background;
 
     private final Map<Place, PlaceDrawing> placesAndDrawings;
-    //
+
     private double width = 800;
+
     private double height = 600;
+
     private double placeWith;
     // temp since no zoom
+
     private double timeWindowWidth;
-    //
+
     private double timeRatio = 1;
 
     protected FriezeSpaceLinearDrawing(Frieze aFrieze) {

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/byplace/PlaceDrawing.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/byplace/PlaceDrawing.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.hmi.byplace;
 
 import com.github.noony.app.timelinefx.core.Frieze;
@@ -45,6 +46,7 @@ import javafx.scene.text.TextAlignment;
 public final class PlaceDrawing extends FXDrawing {
 
     public static final double DEFAULT_HEIGHT = 20;
+
     public static final double DEFAULT_WIDTH = 500;
 
     public static final double DEFAULT_SEPARATION = 12.0;
@@ -52,18 +54,25 @@ public final class PlaceDrawing extends FXDrawing {
     public static final double DEFAULT_NAME_WIDTH = 100;
 
     private final Place place;
+
     private final Frieze frieze;
-    //
+
     private final List<Person> visiblePersons;
+
     private final Map<StayPeriod, StayDrawing> staysAndDrawings;
+
     private final Map<Person, List<StayDrawing>> personsAndDrawings;
-    //
+
     private final Label nameLabel;
+
     private final Line nameSeparationLine;
+
     private final Group stayGroup;
+
     private final Rectangle stayGroupClip;
-    //
+
     private double currentMinDate = 0L;
+
     private double currentRatio = 1;
 
     public PlaceDrawing(Place aPlace, Frieze aFrieze) {

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/byplace/StayDrawing.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/byplace/StayDrawing.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.hmi.byplace;
 
 import com.github.noony.app.timelinefx.core.StayPeriod;
@@ -29,7 +30,9 @@ import javafx.scene.shape.StrokeType;
 public class StayDrawing {
 
     public static final double STROKE_WIDTH = 6;
+
     public static final double SELECTED_STROKE_WIDTH = 12;
+
     public static final double DEFAULT_SEPARATION = 6;
 
     private final StayPeriod stayPeriod;

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/freemap/DateHandleDrawing.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/freemap/DateHandleDrawing.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.hmi.freemap;
 
 import com.github.noony.app.timelinefx.core.freemap.FreeMapDateHandle;
@@ -39,9 +40,11 @@ public final class DateHandleDrawing extends AbstractFxScalableNode {
     private final FreeMapDateHandle dateHandle;
 
     private final ORIENTATION orientation;
+
     private final Polygon handle;
-    //
+
     private double lastMouseX;
+
     private double currentMouseX;
 
     public DateHandleDrawing(FreeMapDateHandle aDateHandle, double aScale) {

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/freemap/FreeMapListCellImpl.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/freemap/FreeMapListCellImpl.java
@@ -14,7 +14,9 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.hmi.freemap;
+
 //package javafx.scene.control.cell;
 
 import com.github.noony.app.timelinefx.core.freemap.FriezeFreeMap;

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/freemap/FreeMapPersonDrawing.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/freemap/FreeMapPersonDrawing.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.hmi.freemap;
 
 import com.github.noony.app.timelinefx.core.freemap.FreeMapLink;
@@ -42,18 +43,23 @@ import javafx.scene.Group;
 public final class FreeMapPersonDrawing extends AbstractFxScalableNode {
 
     private final FreeMapPerson freeMapPerson;
+
     private final FriezeFreeMap freeMap;
-    //
+
     private final PropertyChangeListener linkListener = FreeMapPersonDrawing.this::handleLinkChanges;
     // TODO: remove work around
+
     private final FriezeFreeFormDrawing freeFormDrawing;
-    //
+
     private final List<IFxScalableNode> scalableNodes;
+
     private final Map<FreeMapLink, LinkDrawing> linkDrawings;
     // TODO : use interface
+
     private final Map<FreeMapConnector, RectangleConnector> plotDrawings;
-    //
+
     private final Group linkGroup;
+
     private final Group plotGroup;
 
     // todo remove FriezeFreeMap

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/freemap/FreeMapPortraitDrawing.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/freemap/FreeMapPortraitDrawing.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.hmi.freemap;
 
 import com.github.noony.app.timelinefx.core.Person;
@@ -41,23 +42,33 @@ public final class FreeMapPortraitDrawing extends AbstractFxScalableNode {
     private static final Logger LOG = Logger.getGlobal();
 
     private final FriezeFreeFormDrawing friezeFreeFormDrawing;
+
     private final FreeMapPortrait freeMapPortrait;
+
     private final Circle circle;
+
     private final Circle smallerCircle;
+
     private final Circle imageClip;
+
     private final ImageView imageView;
-    //
+
     private Image image;
-    //
+
     private double xPos;
+
     private double yPos;
-    //
+
     private double oldScreenX;
+
     private double oldScreenY;
+
     private double oldTranslateX;
+
     private double oldTranslateY;
-    //
+
     private double tmpImgPos;
+
     private double tmpImgFit;
 
     public FreeMapPortraitDrawing(FreeMapPortrait aPortrait, FriezeFreeFormDrawing aFriezeFreeFormDrawing) {

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/freemap/FreeMapView.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/freemap/FreeMapView.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.hmi.freemap;
 
 import com.github.noony.app.timelinefx.core.freemap.FriezeFreeMap;
@@ -30,8 +31,9 @@ import javafx.scene.Node;
 public class FreeMapView {
 
     private final FriezeFreeMap freeMap;
-    //
+
     private Node mainNode;
+
     private FreeMapViewController freeMapViewController;
 
     public FreeMapView(FriezeFreeMap aFreeMap) {

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/freemap/FreeMapViewController.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/freemap/FreeMapViewController.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.hmi.freemap;
 
 import com.github.noony.app.timelinefx.Configuration;
@@ -57,6 +58,7 @@ public class FreeMapViewController implements Initializable {
 
     @FXML
     private ScrollPane viewScrollPane;
+
     @FXML
     private AnchorPane viewRootPane;
     @FXML
@@ -85,11 +87,15 @@ public class FreeMapViewController implements Initializable {
     private Button linearTimeButton, constantTimeButton;
 
     private FriezeFreeFormDrawing friezeFreeFormDrawing;
+
     private FriezeFreeMap friezeFreeMap;
-    //
+
     private FileChooser fileChooser;
+
     private CustomModalWindow modalWindow;
+
     private Parent portraitSelectionView = null;
+
     private PortraitSelectionViewController portraitSelectionViewController;
     //
     private FreeMapPortrait freeMapPortraitToUpdate = null;

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/freemap/FriezeFreeFormDrawing.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/freemap/FriezeFreeFormDrawing.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.hmi.freemap;
 
 import com.github.noony.app.timelinefx.core.freemap.FreeMapDateHandle;
@@ -53,38 +54,53 @@ public final class FriezeFreeFormDrawing {
 
     private final VBox mainNode;
     // Group which contains all the graphical elements necessary for the free map display
+
     private final Group freeMapGroup;
-    //
+
     private final Group startDateHandleGroup;
+
     private final Group endDateHandleGroup;
     // Group that contains only the printable elements (places, persons...). Date handles are not part of if for e.g.
+
     private final Group freeMapInnerGroup;
-    //
+
     private final Group personsGroup;
+
     private final Group personLinksGroup;
+
     private final Group placesGroup;
+
     private final Group portraitsGroup;
-    //
+
     private final Rectangle background;
+
     private final Rectangle innerBackground;
+
     private final Rectangle personsBackground;
+
     private final Rectangle placesBackground;
+
     private final Pane startDatesPane;
+
     private final Pane endDatesPane;
 
     private final FriezeFreeMap friezeFreeMap;
     //
     private final Map<FreeMapPortrait, FreeMapPortraitDrawing> portraitDrawings;
+
     private final Map<FreeMapPlace, PlaceDrawing> placeDrawings;
     private final Map<FreeMapPerson, FreeMapPersonDrawing> personDrawings;
+
     private final Map<Double, DateHandleDrawing> startDatesHandles;
+
     private final Map<Double, DateHandleDrawing> endDatesHandles;
-    //
+
     private final List<IFxScalableNode> scalableNodes;
-    //
+
     private double drawingWidth;
+
     private double drawingHeight;
-    //
+
     private double scale = 1.0;
 
     public FriezeFreeFormDrawing(FriezeFreeMap aFriezeFreeMap) {

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/freemap/LinkDrawing.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/freemap/LinkDrawing.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.hmi.freemap;
 
 import com.github.noony.app.timelinefx.core.freemap.FreeMapLink;
@@ -53,18 +54,23 @@ public final class LinkDrawing implements Selectable, IFxScalableNode {
     private final FreeMapLink link;
     private final FreeMapConnector beginConnector;
     private final FreeMapConnector endConnector;
-    //
+
     private double scale = 1.0;
-    //
+
     private Line line;
+
     private CubicCurve cubicCurve;
-    //
+
     private Color color;
+
     private boolean isSelected = false;
-    //
+
     private double startX = 1.0;
+
     private double startY = 1.0;
+
     private double endX = 1.0;
+
     private double endY = 1.0;
 
     protected LinkDrawing(FreeMapLink aLink) {

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/freemap/LinkShape.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/freemap/LinkShape.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.hmi.freemap;
 
 /**

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/freemap/PlaceDrawing.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/freemap/PlaceDrawing.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.hmi.freemap;
 
 import com.github.noony.app.timelinefx.core.freemap.FreeMapPlace;
@@ -35,22 +36,29 @@ import javafx.scene.text.TextAlignment;
 public final class PlaceDrawing extends AbstractFxScalableNode {
 
     private final FreeMapPlace place;
+
     private final FriezeFreeMap friezeFreeMap;
-    //
+
     private final Rectangle debugBackground;
+
     private final Rectangle background;
+
     private final Rectangle backgroundClip;
-    //
+
     private final Group placePlotsGroup;
+
     private final Group nameGroup;
+
     private final Label nameLabel;
-    //
+
     private PlaceDrawingMode drawingMode;
-    //
+
     private double minX;
+
     private double maxX;
-    //
+
     private double oldScreenY;
+
     private double oldTranslateY;
 
     protected PlaceDrawing(FreeMapPlace aPlace, FriezeFreeMap aFriezeFreeMap) {

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/freemap/PlaceDrawingMode.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/freemap/PlaceDrawingMode.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.hmi.freemap;
 
 /**

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/freemap/RectangleConnector.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/freemap/RectangleConnector.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.hmi.freemap;
 
 import com.github.noony.app.timelinefx.core.freemap.connectors.FreeMapConnector;
@@ -32,11 +33,15 @@ public final class RectangleConnector extends AbstractFxScalableNode {
     private static final Color DEFAULT_STROKE_COLOR = Color.BLACK;
 
     private final FreeMapConnector connector;
+
     private final Rectangle connectorRectangle;
-    //
+
     private Point2D oldScene;
+
     private Point2D currentScene;
+
     private double oldMainNodeTranslateX;
+
     private double oldMainNodeTranslateY;
 
     protected RectangleConnector(FreeMapConnector abstractConnector) {

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/frieze/FriezeContentEditorController.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/frieze/FriezeContentEditorController.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.hmi.frieze;
 
 import com.github.noony.app.timelinefx.core.Frieze;
@@ -72,6 +73,7 @@ public class FriezeContentEditorController implements Initializable {
 
     @FXML
     private TabPane tabPane;
+
     @FXML
     private TextField nameField;
     @FXML
@@ -91,24 +93,32 @@ public class FriezeContentEditorController implements Initializable {
     // properties
     @FXML
     private GridPane timeGrid;
-    //
+
     private List<CheckBoxTreeItem<Place>> allTreeItems = new LinkedList<>();
+
     private Map<FriezeFreeMap, Tab> freemapTabs;
-    //
+
     private TimeLineProject timeLineProject;
+
     private Frieze frieze;
-    //
+
     private FriezePlaceViewController spatialViewController;
+
     private FriezePeopleViewController peopleViewController;
     // properties
+
     private TextField friezeStartTimeField;
+
     private TextField friezeEndTimeField;
-    //
+
     private AnchorPane spatialViewRootPane;
+
     private AnchorPane peopleViewRootPane;
-    //
+
     private PropertyChangeListener projectListener;
+
     private PropertyChangeListener friezeListener;
+
     private PropertyChangeListener placeCheckTreeItemChangeListener;
 
     @Override

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/picturechronology/ChronologyLinkDrawing.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/picturechronology/ChronologyLinkDrawing.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.hmi.picturechronology;
 
 import com.github.noony.app.timelinefx.core.picturechronology.ChronologyLink;
@@ -48,27 +49,40 @@ public final class ChronologyLinkDrawing implements IFxScalableNode {
     private static final Logger LOG = Logger.getGlobal();
 
     private static final double DEFAULT_RADIUS = 12;
+
     private static final double DEFAULT_STROKE = 4;
+
     private static final Color DEFAULT_CONTROLS_COLOR = Color.MAGENTA;
 
     private final PropertyChangeSupport propertyChangeSupport;
+
     private final ChronologyLink chronologyLink;
-    //
+
     private final Group mainNode;
+
     private final Circle startNode;
+
     private final Circle endNode;
+
     private Line line = null;
+
     private QuadCurve quadCurve = null;
+
     private CubicCurve cubicCurve = null;
-    //
+
     private Shape linkShape = null;
     // in the future, do not create all the controls at once
+
     private Circle cubicControlPoint1 = null;
+
     private Line cubicControlLine1 = null;
+
     private Line cubicControlLine2 = null;
+
     private Circle cubicControlPoint2 = null;
-    //
+
     private double viewingScale = 1.0;
+
     private double[] linkParameters = null;
 
     public ChronologyLinkDrawing(ChronologyLink aChronologyLink) {

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/picturechronology/ChronologyPictureMiniatureDrawing.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/picturechronology/ChronologyPictureMiniatureDrawing.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.hmi.picturechronology;
 
 import com.github.noony.app.timelinefx.core.picturechronology.ChronologyPictureMiniature;
@@ -44,35 +45,53 @@ import javafx.scene.shape.Rectangle;
 public final class ChronologyPictureMiniatureDrawing implements IFxScalableNode {
 
     public static final String MINIATURE_REQUEST_REMOVAL = "miniatureRequestRemoval";
+
     public static final String MINIATURE_REQUEST_SELECTION = "miniatureRequestSelection";
 
     public static final double ARC_WIDTH = 32;
-    //
+
     private static final Logger LOG = Logger.getGlobal();
+
     private static final double MIN_SCALE = 0.05;
+
     private static final double SCALE_STEP = 0.05;
-    //
+
     private final PropertyChangeSupport propertyChangeSupport;
+
     private final ChronologyPictureMiniature chronologyPictureMiniature;
+
     private final List<ContourDrawing> contours;
-    //
+
     private final Group mainNode;
+
     private final Group contentNode;
+
     private final Group contoursNode;
+
     private final Rectangle clipRectangle;
+
     private final Rectangle frontGlass;
+
     private final Image image;
+
     private final ImageView imageView;
-    //
+
     private double scale;
+
     private double viewingScale = 1.0;
+
     private double renderingScale;
+
     private double width;
+
     private double height;
-    //
+
     private double oldScreenX;
+
     private double oldScreenY;
+
     private double oldTranslateX;
+
     private double oldTranslateY;
 
     public ChronologyPictureMiniatureDrawing(ChronologyPictureMiniature aChronologyPictureMiniature) {

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/picturechronology/ContourDrawing.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/picturechronology/ContourDrawing.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.hmi.picturechronology;
 
 import com.github.noony.app.timelinefx.core.Person;
@@ -34,9 +35,11 @@ public class ContourDrawing implements IFxScalableNode {
     private static final double DEFAULT_STROKE_WIDTH = 2.5;
 
     private final ChronologyPictureMiniature miniature;
+
     private final Person person;
+
     private Rectangle contourDrawing;
-    //
+
     private double viewingScale = 1.0;
 
     protected ContourDrawing(ChronologyPictureMiniature aMiniature, Person aPerson) {

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/picturechronology/PersonChronologyPicturesDrawing.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/picturechronology/PersonChronologyPicturesDrawing.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.hmi.picturechronology;
 
 import com.github.noony.app.timelinefx.core.Person;
@@ -35,14 +36,17 @@ import javafx.scene.Node;
 public final class PersonChronologyPicturesDrawing implements IFxScalableNode {
 
     private final PictureChronologyDrawing chronologyDrawing;
+
     private final PictureChronology chronology;
+
     private final Map<ChronologyLink, ChronologyLinkDrawing> linkDrawings;
-    //
+
     private final Group mainGroup;
-    //
+
     private final PropertyChangeSupport propertyChangeSupport;
+
     private final PropertyChangeListener linkListener;
-    //
+
     private double viewingScale = 1.0;
 
     public PersonChronologyPicturesDrawing(PictureChronologyDrawing aChronologyDrawing, Person aPerson) {

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/picturechronology/PictureChronologyDrawing.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/picturechronology/PictureChronologyDrawing.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.hmi.picturechronology;
 
 import com.github.noony.app.timelinefx.core.Person;
@@ -36,22 +37,31 @@ import javafx.scene.shape.Rectangle;
 public final class PictureChronologyDrawing extends FxScalableParent {
 
     public static final String LINK_SELECTED = "linkSelected";
+
     public static final String LINK_UNSELECTED = "linkUnselected";
+
     public static final String MINIATURE_SELECTED = "miniatureSelected";
+
     public static final String MINIATURE_UNSELECTED = "miniatureUnselected";
 
     private final PictureChronology pictureChronology;
+
     private final Map<ChronologyPictureMiniature, ChronologyPictureMiniatureDrawing> miniatureDrawings;
+
     private final Map<Person, PersonChronologyPicturesDrawing> personsDrawings;
-    //
+
     private final PropertyChangeListener personListener;
-    //
+
     private final Group drawingGroup;
+
     private final Rectangle drawingBackground;
+
     private final Group picturesGroup;
+
     private final Group personsGroup;
-    //
+
     private ChronologyLinkDrawing selectedLink = null;
+
     private ChronologyPictureMiniatureDrawing selectedMiniature = null;
 
     public PictureChronologyDrawing(PictureChronology aPictureChronology) {

--- a/src/main/java/com/github/noony/app/timelinefx/save/TimelineProjectProvider.java
+++ b/src/main/java/com/github/noony/app/timelinefx/save/TimelineProjectProvider.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.save;
 
 import com.github.noony.app.timelinefx.core.TimeLineProject;

--- a/src/main/java/com/github/noony/app/timelinefx/save/XMLHandler.java
+++ b/src/main/java/com/github/noony/app/timelinefx/save/XMLHandler.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.save;
 
 import com.github.noony.app.timelinefx.core.FriezeObjectFactory;
@@ -46,7 +47,9 @@ public final class XMLHandler {
     private static final XMLHandler INSTANCE = new XMLHandler();
 
     private final List<TimelineProjectProvider> providers;
+
     private TimelineProjectProvider saveProvider = null;
+
     private String saveVersion = "-1";
 
     private XMLHandler() {

--- a/src/main/java/com/github/noony/app/timelinefx/save/v3/FreeMapProviderV3.java
+++ b/src/main/java/com/github/noony/app/timelinefx/save/v3/FreeMapProviderV3.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.save.v3;
 
 import com.github.noony.app.timelinefx.core.Frieze;
@@ -54,25 +55,43 @@ import org.w3c.dom.Element;
 public class FreeMapProviderV3 {
 
     protected static final String FREEMAPS_GROUP = "freeMaps";
+
     private static final String FREEMAP_PLACES_GROUP = "freeMapPlaces";
+
     private static final String FREEMAP_PERSONS_GROUP = "freeMapPersons";
+
     private static final String FREEMAP_DATE_HANDLES_GROUP = "freeMapDateHandles";
+
     private static final String FREEMAP_PORTRAITS_GROUP = "freeMapPortraits";
+
     private static final String FREEMAP_STAYS_GROUP = "freeMapStays";
+
     private static final String FREEMAP_PARAMETERS_GROUP = "freeMapParameters";
+
     private static final String FREEMAP_ELEMENT = "freeMap";
+
     private static final String PARAMETER_ELEMENT = "parameter";
+
     private static final String PARAMETER_NAME_ATR = "name";
+
     private static final String PARAMETER_VALUE_ATR = "value";
+
     private static final String FREEMAP_PERSON_ELEMENT = "freeMapPerson";
+
     private static final String FREEMAP_PLACE_ELEMENT = "freeMapPlace";
+
     private static final String FREEMAP_STAY_ELEMENT = "freeMapStay";
+
     private static final String FREEMAP_DATE_HANDLE_ELEMENT = "freeMapDateHandle";
+
     private static final String FREEMAP_CONNECTOR_ELEMENT = "connector";
+
     private static final String FREEMAP_PORTRAIT_LINK_ELEMENT = "portraitLink";
-    //
+
     private static final String FREEMAP_PLACE_NAME_WIDTH_ATR = "placeNameWidth";
+
     private static final String FREEMAP_FONT_SIZE_ATR = "fontSize";
+
     private static final String FREEMAP_LINKED_ELEMENT_ID_ATR = "linkedElementID";
     private static final String FREEMAP_IS_MERGED_ATR = "isMerged";
 

--- a/src/main/java/com/github/noony/app/timelinefx/save/v3/TimeProjectProviderV3.java
+++ b/src/main/java/com/github/noony/app/timelinefx/save/v3/TimeProjectProviderV3.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.save.v3;
 
 import com.github.noony.app.timelinefx.core.Frieze;
@@ -86,25 +87,43 @@ import org.w3c.dom.NodeList;
 public class TimeProjectProviderV3 implements TimelineProjectProvider {
 
     public static final String PROJECT_GROUP = "PROJECT";
+
     public static final String PLACES_GROUP = "PLACES";
+
     public static final String PERSONS_GROUP = "PERSONS";
+
     public static final String PICTURES_GROUP = "PICTURES";
+
     public static final String FRIEZES_GROUP = "FRIEZES";
+
     public static final String STAYS_GROUP = "STAYS";
+
     public static final String STAYS_REF_GROUP = "stays";
+
     public static final String PORTRAITS_GROUP = "portraits";
+
     public static final String PICTURE_CHRONOLOGIES_GROUP = "PICTURE_CHRONOLOGIES";
-    //
+
     public static final String PLACE_ELEMENT = "place";
+
     public static final String PLACE_REF_ELEMENT = "placeRef";
+
     public static final String PERSON_ELEMENT = "person";
+
     public static final String PERSON_REF_ELEMENT = "personRef";
+
     public static final String PICTURE_ELEMENT = "picture";
+
     public static final String PICTURE_REF_ELEMENT = "pictureRef";
+
     public static final String FRIEZE_ELEMENT = "frieze";
+
     public static final String STAY_ELEMENT = "stay";
+
     public static final String STAY_ELEMENT_REF = "stayRef";
+
     public static final String PORTRAIT_ELEMENT = "portrait";
+
     public static final String PICTURE_CHRONOLOGY_ELEMENT = "pictureChronology";
     public static final String PICTURE_CHRONOLOGY_MINIATURE_ELEMENT = "pictureChronologyMiniature";
     public static final String PICTURE_CHRONOLOGY_LINK_ELEMENT = "pictureChronologyLink";

--- a/src/main/java/com/github/noony/app/timelinefx/utils/CustomFileUtils.java
+++ b/src/main/java/com/github/noony/app/timelinefx/utils/CustomFileUtils.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.utils;
 
 import com.github.noony.app.timelinefx.core.TimeLineProject;

--- a/src/main/java/com/github/noony/app/timelinefx/utils/CustomProfiler.java
+++ b/src/main/java/com/github/noony/app/timelinefx/utils/CustomProfiler.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.utils;
 
 import java.io.IOException;
@@ -35,6 +36,7 @@ public class CustomProfiler {
     private static final boolean WITH_PROFILE = true;
 
     private static final Map<String, Profile> profiles = new HashMap<>(); // Fast access to profiles by name
+
     private static final List<Profile> profilesStack = new LinkedList<>();// Profiles as created chronologically
 
     /**
@@ -123,10 +125,15 @@ public class CustomProfiler {
         private static final String CSV_FORMAT_STRING = "%s,%d,%d,%d,%d,%d,%d,%d\n";
 
         private final String name;
+
         private long startTime;
+
         private long callCount;
+
         private long totalTime;
+
         private long minTime;
+
         private long maxTime;
 
         public Profile(String aName) {

--- a/src/main/java/com/github/noony/app/timelinefx/utils/DateUtils.java
+++ b/src/main/java/com/github/noony/app/timelinefx/utils/DateUtils.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.utils;
 
 import java.time.LocalDate;

--- a/src/main/java/com/github/noony/app/timelinefx/utils/ExecutorUtils.java
+++ b/src/main/java/com/github/noony/app/timelinefx/utils/ExecutorUtils.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.utils;
 
 import com.github.noony.app.timelinefx.core.Picture;
@@ -32,6 +33,7 @@ public class ExecutorUtils {
     private static final int THREAD_POOL_SIZE = 3;
 
     private static ThreadPoolExecutor executor;
+
     private static List<Picture> picturesToBeLoaded;
 
     public static void init() {

--- a/src/main/java/com/github/noony/app/timelinefx/utils/MathUtils.java
+++ b/src/main/java/com/github/noony/app/timelinefx/utils/MathUtils.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.utils;
 
 import java.text.DecimalFormat;

--- a/src/main/java/com/github/noony/app/timelinefx/utils/MetadataParser.java
+++ b/src/main/java/com/github/noony/app/timelinefx/utils/MetadataParser.java
@@ -3,6 +3,7 @@
  * To change this template file, choose Tools | Templates
  * and open the template in the editor.
  */
+
 package com.github.noony.app.timelinefx.utils;
 
 import com.github.noony.app.timelinefx.core.PictureInfo;
@@ -35,6 +36,7 @@ public class MetadataParser {
     private static final DateTimeFormatter DT_PARSER = DateTimeFormatter.ofPattern("yyyy:MM:dd HH:mm:ss");
 
     private static final LocalDateTime DEFAULT_DATE = LocalDateTime.MIN;
+
     private static final int DEFAULT_RESOLUTION = -1;
 
     public static PictureInfo parseMetadata(TimeLineProject project, File file) {

--- a/src/main/java/com/github/noony/app/timelinefx/utils/PngExporter.java
+++ b/src/main/java/com/github/noony/app/timelinefx/utils/PngExporter.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.utils;
 
 import java.awt.AlphaComposite;

--- a/src/main/java/com/github/noony/app/timelinefx/utils/TimeFormatToString.java
+++ b/src/main/java/com/github/noony/app/timelinefx/utils/TimeFormatToString.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.utils;
 
 import com.github.noony.app.timelinefx.core.Messages;

--- a/src/test/java/com/github/noony/app/timelinefx/core/PlaceTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/PlaceTest.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core;
 
 import java.beans.PropertyChangeListener;


### PR DESCRIPTION
## Summary
Fixes all `Checkstyle_EmptyLineSeparator` findings across the repository (737 total, one commit per package):

- `core`, `core.picturechronology`, `core.freemap` (sample, validated first), `core.freemap.connectors`, `core.freemap.links`
- `save`, `save.v3`
- `utils`, `drawings`, `examples`, root package, `com.appiomatic.SvgExporter`
- `hmi`, `hmi.freemap`, `hmi.picturechronology`, `hmi.byplace`, `hmi.byperson`, `hmi.frieze`
- one test file (`PlaceTest`)

Every finding is one of exactly two kinds:
- `'package' should be separated from previous line` -- missing blank line between the license header and the `package` statement.
- `'VARIABLE_DEF' should be separated from previous line` -- consecutive field declarations with no blank line between them.

Fixed by inserting a blank line at each flagged line (only where the preceding line wasn't already blank), then removing now-redundant bare `//` separator comments that ended up sitting directly next to a newly-inserted blank line (pattern established by hand on the first package, then applied consistently across the rest).

Purely whitespace -- no logic changes anywhere.

## Test plan
- [x] `mvn test` passes after every single package commit: 246/246
- [x] Diffs spot-checked across several files/packages for correctness
- [ ] Codacy Static Code Analysis: EmptyLineSeparator findings should clear repo-wide

🤖 Generated with [Claude Code](https://claude.com/claude-code)