### PR TITLE
Wire up Edit menu with basic undo/redo infrastructure

### DIFF
--- a/src/main/java/com/github/noony/app/timelinefx/hmi/ProjectViewController.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/ProjectViewController.java
@@ -27,6 +27,7 @@ import com.github.noony.app.timelinefx.examples.TestExample;
 import static com.github.noony.app.timelinefx.hmi.AppInstanceConfiguration.ANCHOR_CONSTRAINT_ZERO;
 import com.github.noony.app.timelinefx.hmi.frieze.FriezeContentEditorController;
 import com.github.noony.app.timelinefx.save.XMLHandler;
+import com.github.noony.app.timelinefx.undo.UndoManager;
 import com.github.noony.app.timelinefx.utils.CustomProfiler;
 import java.beans.PropertyChangeEvent;
 import java.io.File;
@@ -93,6 +94,10 @@ public final class ProjectViewController implements Initializable {
     private RadioMenuItem galleryViewMI;
     @FXML
     private RadioMenuItem picturesChronologyViewMI;
+    @FXML
+    private MenuItem undoMenuItem;
+    @FXML
+    private MenuItem redoMenuItem;
 
     private final Map<CheckMenuItem, Frieze> friezeMenuItems = new HashMap<>();
 
@@ -192,6 +197,9 @@ public final class ProjectViewController implements Initializable {
         //
         AppInstanceConfiguration.addPropertyChangeListener(this::handleAppInstanceConfigChanges);
         //
+        UndoManager.addPropertyChangeListener(this::handleUndoStateChanged);
+        updateUndoRedoMenuState();
+        //
         displayContentEditionView();
         //
         StageFactory.reApplyTheme();
@@ -250,6 +258,27 @@ public final class ProjectViewController implements Initializable {
     }
 
     @FXML
+    protected void handleUndo(ActionEvent event) {
+        LOG.log(Level.INFO, "handleUndo {0}", event);
+        UndoManager.undo();
+    }
+
+    @FXML
+    protected void handleRedo(ActionEvent event) {
+        LOG.log(Level.INFO, "handleRedo {0}", event);
+        UndoManager.redo();
+    }
+
+    private void handleUndoStateChanged(PropertyChangeEvent event) {
+        updateUndoRedoMenuState();
+    }
+
+    private void updateUndoRedoMenuState() {
+        undoMenuItem.setDisable(!UndoManager.canUndo());
+        redoMenuItem.setDisable(!UndoManager.canRedo());
+    }
+
+    @FXML
     protected void handleFriezeCreation(ActionEvent event) {
         LOG.log(Level.INFO, "handleFriezeCreation {0}", event);
         var frieze = FriezeFactory.createFrieze(timeLineProject, "New Frieze", timeLineProject.getStays());
@@ -277,6 +306,7 @@ public final class ProjectViewController implements Initializable {
             System.err.println("TODO: manage listeners");
 //            timeLineProject.removeListener(listener);
         }
+        UndoManager.reset();
         timeLineProject = aTimeLineProject;
         friezeMenuItems.clear();
         friezesMenu.getItems().clear();

--- a/src/main/java/com/github/noony/app/timelinefx/undo/Command.java
+++ b/src/main/java/com/github/noony/app/timelinefx/undo/Command.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2026 NoOnY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.github.noony.app.timelinefx.undo;
+
+/**
+ * A single reversible action, to be executed and tracked through {@link UndoManager}.
+ *
+ * @author solun
+ */
+public interface Command {
+
+    /**
+     * Performs the action. Called once when the command is first run through
+     * {@link UndoManager#execute(Command)}, and again on every {@link UndoManager#redo()}.
+     */
+    void execute();
+
+    /**
+     * Reverts the action performed by {@link #execute()}. Called on {@link UndoManager#undo()}.
+     */
+    void undo();
+
+    /**
+     * @return a short, human-readable description of the action (e.g. "Move portrait"), for display next to
+     * "Undo"/"Redo" in the UI. Defaults to an empty string.
+     */
+    default String getDescription() {
+        return "";
+    }
+
+}

--- a/src/main/java/com/github/noony/app/timelinefx/undo/Command.java
+++ b/src/main/java/com/github/noony/app/timelinefx/undo/Command.java
@@ -20,7 +20,7 @@ package com.github.noony.app.timelinefx.undo;
 /**
  * A single reversible action, to be executed and tracked through {@link UndoManager}.
  *
- * @author solun
+ * @author hamon
  */
 public interface Command {
 

--- a/src/main/java/com/github/noony/app/timelinefx/undo/Command.java
+++ b/src/main/java/com/github/noony/app/timelinefx/undo/Command.java
@@ -36,8 +36,10 @@ public interface Command {
     void undo();
 
     /**
-     * @return a short, human-readable description of the action (e.g. "Move portrait"), for display next to
-     * "Undo"/"Redo" in the UI. Defaults to an empty string.
+     * A short, human-readable description of the action (e.g. "Move portrait"), for display next to
+     * "Undo"/"Redo" in the UI.
+     *
+     * @return the description, or an empty string by default
      */
     default String getDescription() {
         return "";

--- a/src/main/java/com/github/noony/app/timelinefx/undo/UndoManager.java
+++ b/src/main/java/com/github/noony/app/timelinefx/undo/UndoManager.java
@@ -40,12 +40,24 @@ public final class UndoManager {
      */
     public static final String UNDO_STATE_CHANGED = "undoStateChanged";
 
+    /**
+     * Logger for this class.
+     */
     private static final Logger LOG = Logger.getGlobal();
 
+    /**
+     * Support for {@link #UNDO_STATE_CHANGED} notifications.
+     */
     private static final PropertyChangeSupport PROPERTY_CHANGE_SUPPORT = new PropertyChangeSupport(UndoManager.class);
 
+    /**
+     * Executed (or redone) commands, most recent first.
+     */
     private static final Deque<Command> UNDO_STACK = new ArrayDeque<>();
 
+    /**
+     * Undone commands, most recent first.
+     */
     private static final Deque<Command> REDO_STACK = new ArrayDeque<>();
 
     private UndoManager() {
@@ -53,8 +65,10 @@ public final class UndoManager {
     }
 
     /**
-     * @param listener notified with {@link #UNDO_STATE_CHANGED} after every {@link #execute(Command)},
-     * {@link #undo()}, {@link #redo()} or {@link #reset()}
+     * Registers a listener to be notified after every {@link #execute(Command)}, {@link #undo()}, {@link #redo()}
+     * or {@link #reset()}.
+     *
+     * @param listener notified with {@link #UNDO_STATE_CHANGED}
      */
     public static void addPropertyChangeListener(final PropertyChangeListener listener) {
         PROPERTY_CHANGE_SUPPORT.addPropertyChangeListener(listener);

--- a/src/main/java/com/github/noony/app/timelinefx/undo/UndoManager.java
+++ b/src/main/java/com/github/noony/app/timelinefx/undo/UndoManager.java
@@ -75,6 +75,8 @@ public final class UndoManager {
     }
 
     /**
+     * Stops notifying a previously registered listener.
+     *
      * @param listener the listener to stop notifying
      */
     public static void removePropertyChangeListener(final PropertyChangeListener listener) {
@@ -126,6 +128,8 @@ public final class UndoManager {
     }
 
     /**
+     * Reports whether there is a command to undo.
+     *
      * @return {@code true} if {@link #undo()} would revert a command
      */
     public static boolean canUndo() {
@@ -133,6 +137,8 @@ public final class UndoManager {
     }
 
     /**
+     * Reports whether there is a command to redo.
+     *
      * @return {@code true} if {@link #redo()} would re-run a command
      */
     public static boolean canRedo() {

--- a/src/main/java/com/github/noony/app/timelinefx/undo/UndoManager.java
+++ b/src/main/java/com/github/noony/app/timelinefx/undo/UndoManager.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (C) 2026 NoOnY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.github.noony.app.timelinefx.undo;
+
+import java.beans.PropertyChangeListener;
+import java.beans.PropertyChangeSupport;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Application-wide undo/redo history, following the same static-singleton style as
+ * {@link com.github.noony.app.timelinefx.hmi.AppInstanceConfiguration}. No {@link Command} is currently pushed
+ * through this manager anywhere in the app; it is wired up (Edit menu, keyboard shortcuts, enablement) and ready
+ * for individual actions to be made undoable one at a time.
+ *
+ * @author solun
+ */
+public final class UndoManager {
+
+    /**
+     * Fired whenever {@link #canUndo()} or {@link #canRedo()} may have changed, so the UI can refresh its
+     * Undo/Redo controls. Carries no old/new value; listeners should re-read {@link #canUndo()}/{@link #canRedo()}.
+     */
+    public static final String UNDO_STATE_CHANGED = "undoStateChanged";
+
+    private static final Logger LOG = Logger.getGlobal();
+
+    private static final PropertyChangeSupport PROPERTY_CHANGE_SUPPORT = new PropertyChangeSupport(UndoManager.class);
+
+    private static final Deque<Command> UNDO_STACK = new ArrayDeque<>();
+
+    private static final Deque<Command> REDO_STACK = new ArrayDeque<>();
+
+    private UndoManager() {
+        // private utility constructor
+    }
+
+    /**
+     * @param listener notified with {@link #UNDO_STATE_CHANGED} after every {@link #execute(Command)},
+     * {@link #undo()}, {@link #redo()} or {@link #reset()}
+     */
+    public static void addPropertyChangeListener(final PropertyChangeListener listener) {
+        PROPERTY_CHANGE_SUPPORT.addPropertyChangeListener(listener);
+    }
+
+    /**
+     * @param listener the listener to stop notifying
+     */
+    public static void removePropertyChangeListener(final PropertyChangeListener listener) {
+        PROPERTY_CHANGE_SUPPORT.removePropertyChangeListener(listener);
+    }
+
+    /**
+     * Runs {@code command}, then pushes it onto the undo history. Clears the redo history, since redoing past
+     * actions no longer makes sense once a new command has been executed.
+     *
+     * @param command the command to run and track
+     */
+    public static void execute(final Command command) {
+        command.execute();
+        UNDO_STACK.push(command);
+        REDO_STACK.clear();
+        LOG.log(Level.INFO, "Executed command: {0}", new Object[]{command.getDescription()});
+        PROPERTY_CHANGE_SUPPORT.firePropertyChange(UNDO_STATE_CHANGED, null, null);
+    }
+
+    /**
+     * Reverts the most recently executed (or redone) command, moving it onto the redo history. Does nothing if
+     * {@link #canUndo()} is {@code false}.
+     */
+    public static void undo() {
+        if (UNDO_STACK.isEmpty()) {
+            return;
+        }
+        final var command = UNDO_STACK.pop();
+        command.undo();
+        REDO_STACK.push(command);
+        LOG.log(Level.INFO, "Undone command: {0}", new Object[]{command.getDescription()});
+        PROPERTY_CHANGE_SUPPORT.firePropertyChange(UNDO_STATE_CHANGED, null, null);
+    }
+
+    /**
+     * Re-runs the most recently undone command, moving it back onto the undo history. Does nothing if
+     * {@link #canRedo()} is {@code false}.
+     */
+    public static void redo() {
+        if (REDO_STACK.isEmpty()) {
+            return;
+        }
+        final var command = REDO_STACK.pop();
+        command.execute();
+        UNDO_STACK.push(command);
+        LOG.log(Level.INFO, "Redone command: {0}", new Object[]{command.getDescription()});
+        PROPERTY_CHANGE_SUPPORT.firePropertyChange(UNDO_STATE_CHANGED, null, null);
+    }
+
+    /**
+     * @return {@code true} if {@link #undo()} would revert a command
+     */
+    public static boolean canUndo() {
+        return !UNDO_STACK.isEmpty();
+    }
+
+    /**
+     * @return {@code true} if {@link #redo()} would re-run a command
+     */
+    public static boolean canRedo() {
+        return !REDO_STACK.isEmpty();
+    }
+
+    /**
+     * Clears both the undo and redo history, e.g. when switching to a different project.
+     */
+    public static void reset() {
+        UNDO_STACK.clear();
+        REDO_STACK.clear();
+        PROPERTY_CHANGE_SUPPORT.firePropertyChange(UNDO_STATE_CHANGED, null, null);
+    }
+
+}

--- a/src/main/java/com/github/noony/app/timelinefx/undo/UndoManager.java
+++ b/src/main/java/com/github/noony/app/timelinefx/undo/UndoManager.java
@@ -30,7 +30,7 @@ import java.util.logging.Logger;
  * through this manager anywhere in the app; it is wired up (Edit menu, keyboard shortcuts, enablement) and ready
  * for individual actions to be made undoable one at a time.
  *
- * @author solun
+ * @author hamon
  */
 public final class UndoManager {
 

--- a/src/main/java/com/github/noony/app/timelinefx/undo/package-info.java
+++ b/src/main/java/com/github/noony/app/timelinefx/undo/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2026 NoOnY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Application-wide undo/redo infrastructure (Command pattern).
+ */
+package com.github.noony.app.timelinefx.undo;

--- a/src/main/resources/com/github/noony/app/timelinefx/hmi/ProjectView.fxml
+++ b/src/main/resources/com/github/noony/app/timelinefx/hmi/ProjectView.fxml
@@ -4,6 +4,7 @@
 <?import javafx.scene.control.MenuBar?>
 <?import javafx.scene.control.MenuItem?>
 <?import javafx.scene.control.RadioMenuItem?>
+<?import javafx.scene.input.KeyCodeCombination?>
 <?import javafx.scene.layout.AnchorPane?>
 <?import javafx.scene.layout.BorderPane?>
 <?import javafx.scene.layout.HBox?>
@@ -24,7 +25,20 @@
                               <MenuItem mnemonicParsing="false" text="Close" />
                           </items>
                       </Menu>
-                      <Menu disable="true" mnemonicParsing="false" text="Edit" />
+                      <Menu mnemonicParsing="false" text="Edit">
+                          <items>
+                              <MenuItem fx:id="undoMenuItem" disable="true" mnemonicParsing="false" onAction="#handleUndo" text="Undo">
+                                  <accelerator>
+                                      <KeyCodeCombination alt="UP" code="Z" control="UP" meta="UP" shift="UP" shortcut="DOWN" />
+                                  </accelerator>
+                              </MenuItem>
+                              <MenuItem fx:id="redoMenuItem" disable="true" mnemonicParsing="false" onAction="#handleRedo" text="Redo">
+                                  <accelerator>
+                                      <KeyCodeCombination alt="UP" code="Y" control="UP" meta="UP" shift="UP" shortcut="DOWN" />
+                                  </accelerator>
+                              </MenuItem>
+                          </items>
+                      </Menu>
                   <Menu fx:id="friezesMenu" mnemonicParsing="false" text="Friezes">
                      <items>
                               <MenuItem fx:id="createFriezeMenuItem" mnemonicParsing="false" onAction="#handleFriezeCreation" text="Create New Frieze" />


### PR DESCRIPTION
## Summary
Wires the previously dead, permanently-disabled "Edit" menu with a basic Command-pattern undo/redo infrastructure. **No concrete action is made undoable yet** -- this is the plumbing (menu, shortcuts, enablement, history stacks), ready for individual actions to be made undoable one at a time going forward.

- New `undo` package: `Command` (`execute()`/`undo()`/`getDescription()`) and `UndoManager`, a static-singleton history stack following the same style already used by `AppInstanceConfiguration` (private constructor, static `PropertyChangeSupport`, a single `UNDO_STATE_CHANGED` notification).
- Edit menu now has Undo/Redo `MenuItem`s with Ctrl+Z/Ctrl+Y accelerators (`shortcut="DOWN"`, so Cmd on macOS).
- `ProjectViewController` listens for `UNDO_STATE_CHANGED` and enables/disables the two menu items based on `UndoManager.canUndo()`/`canRedo()`; both start disabled. `UndoManager.reset()` is called whenever a different project is loaded.

## Test plan
- [x] `mvn test` passes: 246/246
- [x] FXML verified as well-formed XML
- [x] **Manual check needed**: I can't drive the JavaFX desktop UI from this environment, so the Edit menu / Ctrl+Z / Ctrl+Y wiring hasn't been visually verified. Please confirm on first run that the Edit menu shows Undo/Redo (both greyed out, since nothing is wired to a real action yet) and the accelerators don't conflict with anything.
- [x] Codacy Static Code Analysis

🤖 Generated with [Claude Code](https://claude.com/claude-code)