### PR TITLE
Extend Command pattern to picture chronology, gallery, and place editing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>org.controlsfx</groupId>
             <artifactId>controlsfx</artifactId>
-            <version>11.2.3</version>
+            <version>11.2.4</version>
         </dependency>
         <!--javafx-controls-->
         <dependency>

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/ChronologyMiniatureConfiguratorController.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/ChronologyMiniatureConfiguratorController.java
@@ -21,6 +21,8 @@ import com.github.noony.app.timelinefx.core.AnchorSide;
 import com.github.noony.app.timelinefx.core.picturechronology.ChronologyLink;
 import com.github.noony.app.timelinefx.core.picturechronology.ChronologyPictureMiniature;
 import com.github.noony.app.timelinefx.core.picturechronology.PictureChronology;
+import com.github.noony.app.timelinefx.undo.SimpleCommand;
+import com.github.noony.app.timelinefx.undo.UndoManager;
 import com.github.noony.app.timelinefx.utils.MathUtils;
 import java.beans.PropertyChangeEvent;
 import java.net.URL;
@@ -86,6 +88,8 @@ public class ChronologyMiniatureConfiguratorController implements Initializable 
 
     private PictureChronology pictureChronology = null;
 
+    private boolean applyingUndoRedo = false;
+
     @Override
     public void initialize(URL url, ResourceBundle rb) {
         LOG.log(Level.INFO, "Initializing ChronologyMiniatureConfiguratorController");
@@ -126,13 +130,18 @@ public class ChronologyMiniatureConfiguratorController implements Initializable 
             }
         });
         customDatePicker.valueProperty().addListener((ObservableValue<? extends LocalDate> ov, LocalDate t, LocalDate t1) -> {
-            if (currentMiniature != null) {
-                currentMiniature.setCurrenltyUsedTimeValue(t1);
+            if (currentMiniature != null && !applyingUndoRedo) {
+                final var oldDate = currentMiniature.getCurrenltyUsedTimeValue();
+                UndoManager.execute(new SimpleCommand("Change picture date",
+                        () -> setCustomDate(t1),
+                        () -> setCustomDate(oldDate)));
             }
         });
         customDateCB.selectedProperty().addListener((ov, t, t1) -> {
-            if (currentMiniature != null) {
-                currentMiniature.setUseCustomTime(t1);
+            if (currentMiniature != null && !applyingUndoRedo) {
+                UndoManager.execute(new SimpleCommand("Toggle custom date",
+                        () -> setUseCustomDate(t1),
+                        () -> setUseCustomDate(!t1)));
             }
         });
         //
@@ -158,6 +167,20 @@ public class ChronologyMiniatureConfiguratorController implements Initializable 
         linksSideColumn.setCellValueFactory(new PropertyValueFactory<>("startAnchorSide"));
         linksSideColumn.setCellFactory(ComboBoxTableCell.<ChronologyLink, AnchorSide>forTableColumn(FXCollections.observableList(Arrays.asList(AnchorSide.values()))));
         linksSideColumn.setEditable(true);
+    }
+
+    private void setUseCustomDate(final boolean useCustomDate) {
+        applyingUndoRedo = true;
+        customDateCB.setSelected(useCustomDate);
+        currentMiniature.setUseCustomTime(useCustomDate);
+        applyingUndoRedo = false;
+    }
+
+    private void setCustomDate(final LocalDate date) {
+        applyingUndoRedo = true;
+        customDatePicker.setValue(date);
+        currentMiniature.setCurrenltyUsedTimeValue(date);
+        applyingUndoRedo = false;
     }
 
     @FXML

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/ContentEditionViewController.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/ContentEditionViewController.java
@@ -21,6 +21,8 @@ import com.github.noony.app.timelinefx.core.Person;
 import com.github.noony.app.timelinefx.core.Place;
 import com.github.noony.app.timelinefx.core.PlaceFactory;
 import com.github.noony.app.timelinefx.core.TimeLineProject;
+import com.github.noony.app.timelinefx.undo.SimpleCommand;
+import com.github.noony.app.timelinefx.undo.UndoManager;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.io.IOException;
@@ -373,7 +375,10 @@ public final class ContentEditionViewController implements Initializable {
             case PlaceCreationViewController.PLACE_CREATED -> {
                 place = (Place) event.getNewValue();
                 customModalWindow.hide();
-                timeLineProject.addPlace(place);
+                final var createdPlace = place;
+                UndoManager.execute(new SimpleCommand("Create place",
+                        () -> timeLineProject.addPlace(createdPlace),
+                        () -> timeLineProject.removePlace(createdPlace)));
                 updatePlacesTab();
             }
 
@@ -415,7 +420,10 @@ public final class ContentEditionViewController implements Initializable {
             case PersonCreationViewController.PERSON_CREATED -> {
                 person = (Person) event.getNewValue();
                 customModalWindow.hide();
-                timeLineProject.addPerson(person);
+                final var createdPerson = person;
+                UndoManager.execute(new SimpleCommand("Create person",
+                        () -> timeLineProject.addPerson(createdPerson),
+                        () -> timeLineProject.removePerson(createdPerson)));
                 updatePersonTab();
             }
             case PersonCreationViewController.PERSON_EDITIED -> {

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/FriezePeopleViewController.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/FriezePeopleViewController.java
@@ -77,8 +77,14 @@ public class FriezePeopleViewController implements Initializable {
 
     private FriezePeopleLinearDrawing friezePeopleLinearDrawing = null;
 
+    /**
+     * The slider's low value when the current drag gesture started.
+     */
     private double lowValueAtDragStart;
 
+    /**
+     * The slider's high value when the current drag gesture started.
+     */
     private double highValueAtDragStart;
 
     @Override
@@ -121,34 +127,38 @@ public class FriezePeopleViewController implements Initializable {
                 updateUpperTimeValue();
             }
         });
-        peopleViewTimeSlider.lowValueChangingProperty().addListener((ov, wasChanging, isChanging) -> {
-            if (isChanging) {
-                lowValueAtDragStart = peopleViewTimeSlider.getLowValue();
-            } else {
-                final var oldLowValue = lowValueAtDragStart;
-                final var newLowValue = peopleViewTimeSlider.getLowValue();
-                if (oldLowValue != newLowValue) {
-                    UndoManager.execute(new SimpleCommand("Change lower time window",
-                            () -> peopleViewTimeSlider.setLowValue(newLowValue),
-                            () -> peopleViewTimeSlider.setLowValue(oldLowValue)));
-                }
-            }
-        });
-        peopleViewTimeSlider.highValueChangingProperty().addListener((ov, wasChanging, isChanging) -> {
-            if (isChanging) {
-                highValueAtDragStart = peopleViewTimeSlider.getHighValue();
-            } else {
-                final var oldHighValue = highValueAtDragStart;
-                final var newHighValue = peopleViewTimeSlider.getHighValue();
-                if (oldHighValue != newHighValue) {
-                    UndoManager.execute(new SimpleCommand("Change upper time window",
-                            () -> peopleViewTimeSlider.setHighValue(newHighValue),
-                            () -> peopleViewTimeSlider.setHighValue(oldHighValue)));
-                }
-            }
-        });
+        peopleViewTimeSlider.lowValueChangingProperty().addListener((ov, wasChanging, isChanging) -> handleLowValueChanging(isChanging));
+        peopleViewTimeSlider.highValueChangingProperty().addListener((ov, wasChanging, isChanging) -> handleHighValueChanging(isChanging));
         peopleViewMinDateLabel.setText("");
         peopleViewMaxDateLabel.setText("");
+    }
+
+    private void handleLowValueChanging(final boolean isChanging) {
+        if (isChanging) {
+            lowValueAtDragStart = peopleViewTimeSlider.getLowValue();
+        } else {
+            final var oldLowValue = lowValueAtDragStart;
+            final var newLowValue = peopleViewTimeSlider.getLowValue();
+            if (oldLowValue != newLowValue) {
+                UndoManager.execute(new SimpleCommand("Change lower time window",
+                        () -> peopleViewTimeSlider.setLowValue(newLowValue),
+                        () -> peopleViewTimeSlider.setLowValue(oldLowValue)));
+            }
+        }
+    }
+
+    private void handleHighValueChanging(final boolean isChanging) {
+        if (isChanging) {
+            highValueAtDragStart = peopleViewTimeSlider.getHighValue();
+        } else {
+            final var oldHighValue = highValueAtDragStart;
+            final var newHighValue = peopleViewTimeSlider.getHighValue();
+            if (oldHighValue != newHighValue) {
+                UndoManager.execute(new SimpleCommand("Change upper time window",
+                        () -> peopleViewTimeSlider.setHighValue(newHighValue),
+                        () -> peopleViewTimeSlider.setHighValue(oldHighValue)));
+            }
+        }
     }
 
     private void updateFriezeWidth() {

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/FriezePeopleViewController.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/FriezePeopleViewController.java
@@ -19,6 +19,8 @@ package com.github.noony.app.timelinefx.hmi;
 
 import com.github.noony.app.timelinefx.core.Frieze;
 import com.github.noony.app.timelinefx.hmi.byperson.FriezePeopleLinearDrawing;
+import com.github.noony.app.timelinefx.undo.SimpleCommand;
+import com.github.noony.app.timelinefx.undo.UndoManager;
 import com.github.noony.app.timelinefx.utils.TimeFormatToString;
 import java.net.URL;
 import java.time.format.DateTimeFormatter;
@@ -75,6 +77,10 @@ public class FriezePeopleViewController implements Initializable {
 
     private FriezePeopleLinearDrawing friezePeopleLinearDrawing = null;
 
+    private double lowValueAtDragStart;
+
+    private double highValueAtDragStart;
+
     @Override
     public void initialize(URL location, ResourceBundle resources) {
         peopleViewScrollPane.widthProperty().addListener((ObservableValue<? extends Number> observable, Number oldValue, Number newValue) -> {
@@ -113,6 +119,32 @@ public class FriezePeopleViewController implements Initializable {
         peopleViewTimeSlider.highValueProperty().addListener(o -> {
             if (!peopleViewTimeSlider.isLowValueChanging()) {
                 updateUpperTimeValue();
+            }
+        });
+        peopleViewTimeSlider.lowValueChangingProperty().addListener((ov, wasChanging, isChanging) -> {
+            if (isChanging) {
+                lowValueAtDragStart = peopleViewTimeSlider.getLowValue();
+            } else {
+                final var oldLowValue = lowValueAtDragStart;
+                final var newLowValue = peopleViewTimeSlider.getLowValue();
+                if (oldLowValue != newLowValue) {
+                    UndoManager.execute(new SimpleCommand("Change lower time window",
+                            () -> peopleViewTimeSlider.setLowValue(newLowValue),
+                            () -> peopleViewTimeSlider.setLowValue(oldLowValue)));
+                }
+            }
+        });
+        peopleViewTimeSlider.highValueChangingProperty().addListener((ov, wasChanging, isChanging) -> {
+            if (isChanging) {
+                highValueAtDragStart = peopleViewTimeSlider.getHighValue();
+            } else {
+                final var oldHighValue = highValueAtDragStart;
+                final var newHighValue = peopleViewTimeSlider.getHighValue();
+                if (oldHighValue != newHighValue) {
+                    UndoManager.execute(new SimpleCommand("Change upper time window",
+                            () -> peopleViewTimeSlider.setHighValue(newHighValue),
+                            () -> peopleViewTimeSlider.setHighValue(oldHighValue)));
+                }
             }
         });
         peopleViewMinDateLabel.setText("");

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/GalleryViewController.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/GalleryViewController.java
@@ -22,6 +22,8 @@ import com.github.noony.app.timelinefx.core.Picture;
 import com.github.noony.app.timelinefx.core.PictureFactory;
 import com.github.noony.app.timelinefx.core.Place;
 import com.github.noony.app.timelinefx.core.TimeLineProject;
+import com.github.noony.app.timelinefx.undo.SimpleCommand;
+import com.github.noony.app.timelinefx.undo.UndoManager;
 import com.github.noony.app.timelinefx.utils.CustomFileUtils;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
@@ -121,14 +123,27 @@ public final class GalleryViewController implements Initializable, ViewControlle
     @FXML
     protected void handleUpPerson(ActionEvent event) {
         LOG.log(Level.INFO, "handleUpPerson on event {0}", new Object[]{event});
-        currentPicture.movePersonUp(picturePersonsList.getSelectionModel().getSelectedItem());
-        picturePersonsList.setItems(FXCollections.observableArrayList(currentPicture.getPersons()));
+        final var person = picturePersonsList.getSelectionModel().getSelectedItem();
+        UndoManager.execute(new SimpleCommand("Move person up",
+                () -> movePerson(person, true),
+                () -> movePerson(person, false)));
     }
 
     @FXML
     protected void handleDownPerson(ActionEvent event) {
         LOG.log(Level.INFO, "handleDownPerson on event {0}", new Object[]{event});
-        currentPicture.movePersonDown(picturePersonsList.getSelectionModel().getSelectedItem());
+        final var person = picturePersonsList.getSelectionModel().getSelectedItem();
+        UndoManager.execute(new SimpleCommand("Move person down",
+                () -> movePerson(person, false),
+                () -> movePerson(person, true)));
+    }
+
+    private void movePerson(final Person person, final boolean up) {
+        if (up) {
+            currentPicture.movePersonUp(person);
+        } else {
+            currentPicture.movePersonDown(person);
+        }
         picturePersonsList.setItems(FXCollections.observableArrayList(currentPicture.getPersons()));
     }
 

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/PersonCreationViewController.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/PersonCreationViewController.java
@@ -26,6 +26,8 @@ import com.github.noony.app.timelinefx.core.PortraitFactory;
 import com.github.noony.app.timelinefx.core.TimeFormat;
 import com.github.noony.app.timelinefx.core.TimeLineProject;
 import com.github.noony.app.timelinefx.drawings.GalleryTiles;
+import com.github.noony.app.timelinefx.undo.SimpleCommand;
+import com.github.noony.app.timelinefx.undo.UndoManager;
 import com.github.noony.app.timelinefx.utils.CustomFileUtils;
 import com.github.noony.app.timelinefx.utils.MathUtils;
 import java.beans.PropertyChangeEvent;
@@ -37,6 +39,7 @@ import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -229,8 +232,14 @@ public final class PersonCreationViewController implements Initializable {
                 propertyChangeSupport.firePropertyChange(PERSON_CREATED, null, currentEditedPerson);
             }
             case EDITION -> {
-                updatePerson(currentEditedPerson);
-                propertyChangeSupport.firePropertyChange(PERSON_EDITIED, null, currentEditedPerson);
+                final var editedPerson = currentEditedPerson;
+                final var oldSnapshot = capturePersonSnapshot(editedPerson);
+                updatePerson(editedPerson);
+                final var newSnapshot = capturePersonSnapshot(editedPerson);
+                UndoManager.execute(new SimpleCommand("Edit person",
+                        () -> applyPersonSnapshot(editedPerson, newSnapshot),
+                        () -> applyPersonSnapshot(editedPerson, oldSnapshot)));
+                propertyChangeSupport.firePropertyChange(PERSON_EDITIED, null, editedPerson);
                 reset();
             }
             default ->
@@ -408,6 +417,46 @@ public final class PersonCreationViewController implements Initializable {
                 LOG.log(Level.SEVERE, "Exception while updating image foPicturer {0} : {1}", new Object[]{defaultPortrait, e});
                 LOG.log(Level.SEVERE, "> file name was: {0}", new Object[]{path});
             }
+        }
+    }
+
+    private record PersonSnapshot(String name, List<Portrait> portraits, Portrait defaultPortrait, Color color,
+            TimeFormat timeFormat, LocalDate dateOfBirth, LocalDate dateOfDeath, long timeOfBirth, long timeOfDeath,
+            Map<Portrait, LocalDate> portraitDates, Map<Portrait, Double> portraitTimestamps) {
+    }
+
+    private PersonSnapshot capturePersonSnapshot(Person person) {
+        var portraitDates = new HashMap<Portrait, LocalDate>();
+        updatedPortraitDates.keySet().forEach(portrait -> portraitDates.put(portrait, portrait.getDate()));
+        var portraitTimestamps = new HashMap<Portrait, Double>();
+        updatedPortraitTimes.keySet().forEach(portrait -> portraitTimestamps.put(portrait, portrait.getTimestamp()));
+        return new PersonSnapshot(person.getName(), new ArrayList<>(person.getPortraits()), person.getDefaultPortrait(),
+                person.getColor(), person.getTimeFormat(), person.getDateOfBirth(), person.getDateOfDeath(),
+                person.getTimeOfBirth(), person.getTimeOfDeath(), portraitDates, portraitTimestamps);
+    }
+
+    private void applyPersonSnapshot(Person person, PersonSnapshot snapshot) {
+        person.setName(snapshot.name());
+        new ArrayList<>(person.getPortraits()).stream()
+                .filter(p -> !snapshot.portraits().contains(p))
+                .forEach(person::removePortrait);
+        snapshot.portraits().forEach(person::addPortrait);
+        person.setDefaultPortrait(snapshot.defaultPortrait());
+        person.setColor(snapshot.color());
+        person.setTimeFormat(snapshot.timeFormat());
+        switch (snapshot.timeFormat()) {
+            case LOCAL_TIME -> {
+                person.setDateOfBirth(snapshot.dateOfBirth());
+                person.setDateOfDeath(snapshot.dateOfDeath());
+                snapshot.portraitDates().forEach((portrait, date) -> portrait.setDate(date));
+            }
+            case TIME_MIN -> {
+                person.setTimeOfBirth(snapshot.timeOfBirth());
+                person.setTimeOfDeath(snapshot.timeOfDeath());
+                snapshot.portraitTimestamps().forEach((portrait, timestamp) -> portrait.setTimestamp(timestamp));
+            }
+            default ->
+                throw new UnsupportedOperationException(Messages.UNSUPPORTED_TIME_FORMAT + snapshot.timeFormat());
         }
     }
 

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/PlaceCreationViewController.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/PlaceCreationViewController.java
@@ -20,6 +20,8 @@ package com.github.noony.app.timelinefx.hmi;
 import com.github.noony.app.timelinefx.core.Place;
 import com.github.noony.app.timelinefx.core.PlaceFactory;
 import com.github.noony.app.timelinefx.core.PlaceLevel;
+import com.github.noony.app.timelinefx.undo.SimpleCommand;
+import com.github.noony.app.timelinefx.undo.UndoManager;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
 import java.net.URL;
@@ -112,10 +114,26 @@ public final class PlaceCreationViewController implements Initializable {
             case CREATION ->
                 propertyChangeSupport.firePropertyChange(PLACE_CREATED, null, PlaceFactory.createPlace(placeName, placeLevel, parentPlace, placeColor));
             case EDITION -> {
-                currentEditedPlace.setName(placeName);
-                currentEditedPlace.setParent(parentPlace);
-                currentEditedPlace.setLevel(placeLevel);
-                currentEditedPlace.setColor(placeColor);
+                final var editedPlace = currentEditedPlace;
+                final var oldName = editedPlace.getName();
+                final var oldParent = editedPlace.getParent();
+                final var oldLevel = editedPlace.getLevel();
+                final var oldColor = editedPlace.getColor();
+                final var newName = placeName;
+                final var newParent = parentPlace;
+                final var newLevel = placeLevel;
+                final var newColor = placeColor;
+                UndoManager.execute(new SimpleCommand("Edit place", () -> {
+                    editedPlace.setName(newName);
+                    editedPlace.setParent(newParent);
+                    editedPlace.setLevel(newLevel);
+                    editedPlace.setColor(newColor);
+                }, () -> {
+                    editedPlace.setName(oldName);
+                    editedPlace.setParent(oldParent);
+                    editedPlace.setLevel(oldLevel);
+                    editedPlace.setColor(oldColor);
+                }));
                 propertyChangeSupport.firePropertyChange(PLACE_EDITIED, null, currentEditedPlace);
             }
             default ->

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/ProjectViewController.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/ProjectViewController.java
@@ -27,6 +27,7 @@ import com.github.noony.app.timelinefx.examples.TestExample;
 import static com.github.noony.app.timelinefx.hmi.AppInstanceConfiguration.ANCHOR_CONSTRAINT_ZERO;
 import com.github.noony.app.timelinefx.hmi.frieze.FriezeContentEditorController;
 import com.github.noony.app.timelinefx.save.XMLHandler;
+import com.github.noony.app.timelinefx.undo.UndoManager;
 import com.github.noony.app.timelinefx.utils.CustomProfiler;
 import java.beans.PropertyChangeEvent;
 import java.io.File;
@@ -93,6 +94,10 @@ public final class ProjectViewController implements Initializable {
     private RadioMenuItem galleryViewMI;
     @FXML
     private RadioMenuItem picturesChronologyViewMI;
+    @FXML
+    private MenuItem undoMenuItem;
+    @FXML
+    private MenuItem redoMenuItem;
 
     private final Map<CheckMenuItem, Frieze> friezeMenuItems = new HashMap<>();
 
@@ -192,6 +197,9 @@ public final class ProjectViewController implements Initializable {
         //
         AppInstanceConfiguration.addPropertyChangeListener(this::handleAppInstanceConfigChanges);
         //
+        UndoManager.addPropertyChangeListener(this::handleUndoStateChanged);
+        updateUndoRedoMenuState();
+        //
         displayContentEditionView();
         //
         StageFactory.reApplyTheme();
@@ -250,6 +258,27 @@ public final class ProjectViewController implements Initializable {
     }
 
     @FXML
+    protected void handleUndo(ActionEvent event) {
+        LOG.log(Level.INFO, "handleUndo {0}", event);
+        UndoManager.undo();
+    }
+
+    @FXML
+    protected void handleRedo(ActionEvent event) {
+        LOG.log(Level.INFO, "handleRedo {0}", event);
+        UndoManager.redo();
+    }
+
+    private void handleUndoStateChanged(PropertyChangeEvent event) {
+        updateUndoRedoMenuState();
+    }
+
+    private void updateUndoRedoMenuState() {
+        undoMenuItem.setDisable(!UndoManager.canUndo());
+        redoMenuItem.setDisable(!UndoManager.canRedo());
+    }
+
+    @FXML
     protected void handleFriezeCreation(ActionEvent event) {
         LOG.log(Level.INFO, "handleFriezeCreation {0}", event);
         var frieze = FriezeFactory.createFrieze(timeLineProject, "New Frieze", timeLineProject.getStays());
@@ -277,6 +306,7 @@ public final class ProjectViewController implements Initializable {
             System.err.println("TODO: manage listeners");
 //            timeLineProject.removeListener(listener);
         }
+        UndoManager.reset();
         timeLineProject = aTimeLineProject;
         friezeMenuItems.clear();
         friezesMenu.getItems().clear();

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/byplace/FriezePlaceViewController.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/byplace/FriezePlaceViewController.java
@@ -18,6 +18,8 @@
 package com.github.noony.app.timelinefx.hmi.byplace;
 
 import com.github.noony.app.timelinefx.core.Frieze;
+import com.github.noony.app.timelinefx.undo.SimpleCommand;
+import com.github.noony.app.timelinefx.undo.UndoManager;
 import com.github.noony.app.timelinefx.utils.TimeFormatToString;
 import java.net.URL;
 import java.util.Optional;
@@ -69,6 +71,10 @@ public class FriezePlaceViewController implements Initializable {
 
     private FriezeSpaceLinearDrawing friezeSpaceLinearDrawing = null;
 
+    private double lowValueAtDragStart;
+
+    private double highValueAtDragStart;
+
     @Override
     public void initialize(URL location, ResourceBundle resources) {
         scrollPane.widthProperty().addListener((ObservableValue<? extends Number> observable, Number oldValue, Number newValue) -> {
@@ -108,6 +114,32 @@ public class FriezePlaceViewController implements Initializable {
         timeSlider.highValueProperty().addListener(o -> {
             if (!timeSlider.isLowValueChanging()) {
                 updateUpperTimeValue();
+            }
+        });
+        timeSlider.lowValueChangingProperty().addListener((ov, wasChanging, isChanging) -> {
+            if (isChanging) {
+                lowValueAtDragStart = timeSlider.getLowValue();
+            } else {
+                final var oldLowValue = lowValueAtDragStart;
+                final var newLowValue = timeSlider.getLowValue();
+                if (oldLowValue != newLowValue) {
+                    UndoManager.execute(new SimpleCommand("Change lower time window",
+                            () -> timeSlider.setLowValue(newLowValue),
+                            () -> timeSlider.setLowValue(oldLowValue)));
+                }
+            }
+        });
+        timeSlider.highValueChangingProperty().addListener((ov, wasChanging, isChanging) -> {
+            if (isChanging) {
+                highValueAtDragStart = timeSlider.getHighValue();
+            } else {
+                final var oldHighValue = highValueAtDragStart;
+                final var newHighValue = timeSlider.getHighValue();
+                if (oldHighValue != newHighValue) {
+                    UndoManager.execute(new SimpleCommand("Change upper time window",
+                            () -> timeSlider.setHighValue(newHighValue),
+                            () -> timeSlider.setHighValue(oldHighValue)));
+                }
             }
         });
         minDateLabel.setText("");

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/byplace/FriezePlaceViewController.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/byplace/FriezePlaceViewController.java
@@ -71,8 +71,14 @@ public class FriezePlaceViewController implements Initializable {
 
     private FriezeSpaceLinearDrawing friezeSpaceLinearDrawing = null;
 
+    /**
+     * The slider's low value when the current drag gesture started.
+     */
     private double lowValueAtDragStart;
 
+    /**
+     * The slider's high value when the current drag gesture started.
+     */
     private double highValueAtDragStart;
 
     @Override
@@ -116,34 +122,38 @@ public class FriezePlaceViewController implements Initializable {
                 updateUpperTimeValue();
             }
         });
-        timeSlider.lowValueChangingProperty().addListener((ov, wasChanging, isChanging) -> {
-            if (isChanging) {
-                lowValueAtDragStart = timeSlider.getLowValue();
-            } else {
-                final var oldLowValue = lowValueAtDragStart;
-                final var newLowValue = timeSlider.getLowValue();
-                if (oldLowValue != newLowValue) {
-                    UndoManager.execute(new SimpleCommand("Change lower time window",
-                            () -> timeSlider.setLowValue(newLowValue),
-                            () -> timeSlider.setLowValue(oldLowValue)));
-                }
-            }
-        });
-        timeSlider.highValueChangingProperty().addListener((ov, wasChanging, isChanging) -> {
-            if (isChanging) {
-                highValueAtDragStart = timeSlider.getHighValue();
-            } else {
-                final var oldHighValue = highValueAtDragStart;
-                final var newHighValue = timeSlider.getHighValue();
-                if (oldHighValue != newHighValue) {
-                    UndoManager.execute(new SimpleCommand("Change upper time window",
-                            () -> timeSlider.setHighValue(newHighValue),
-                            () -> timeSlider.setHighValue(oldHighValue)));
-                }
-            }
-        });
+        timeSlider.lowValueChangingProperty().addListener((ov, wasChanging, isChanging) -> handleLowValueChanging(isChanging));
+        timeSlider.highValueChangingProperty().addListener((ov, wasChanging, isChanging) -> handleHighValueChanging(isChanging));
         minDateLabel.setText("");
         maxDateLabel.setText("");
+    }
+
+    private void handleLowValueChanging(final boolean isChanging) {
+        if (isChanging) {
+            lowValueAtDragStart = timeSlider.getLowValue();
+        } else {
+            final var oldLowValue = lowValueAtDragStart;
+            final var newLowValue = timeSlider.getLowValue();
+            if (oldLowValue != newLowValue) {
+                UndoManager.execute(new SimpleCommand("Change lower time window",
+                        () -> timeSlider.setLowValue(newLowValue),
+                        () -> timeSlider.setLowValue(oldLowValue)));
+            }
+        }
+    }
+
+    private void handleHighValueChanging(final boolean isChanging) {
+        if (isChanging) {
+            highValueAtDragStart = timeSlider.getHighValue();
+        } else {
+            final var oldHighValue = highValueAtDragStart;
+            final var newHighValue = timeSlider.getHighValue();
+            if (oldHighValue != newHighValue) {
+                UndoManager.execute(new SimpleCommand("Change upper time window",
+                        () -> timeSlider.setHighValue(newHighValue),
+                        () -> timeSlider.setHighValue(oldHighValue)));
+            }
+        }
     }
 
     private void updateFriezeWidth() {

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/freemap/FreeMapPortraitDrawing.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/freemap/FreeMapPortraitDrawing.java
@@ -69,8 +69,14 @@ public final class FreeMapPortraitDrawing extends AbstractFxScalableNode {
 
     private double oldTranslateY;
 
+    /**
+     * The portrait's X position when the current drag gesture started.
+     */
     private double oldX;
 
+    /**
+     * The portrait's Y position when the current drag gesture started.
+     */
     private double oldY;
 
     private double tmpImgPos;

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/freemap/FreeMapPortraitDrawing.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/freemap/FreeMapPortraitDrawing.java
@@ -20,6 +20,8 @@ package com.github.noony.app.timelinefx.hmi.freemap;
 import com.github.noony.app.timelinefx.core.Person;
 import com.github.noony.app.timelinefx.core.freemap.FreeMapPortrait;
 import com.github.noony.app.timelinefx.drawings.AbstractFxScalableNode;
+import com.github.noony.app.timelinefx.undo.SimpleCommand;
+import com.github.noony.app.timelinefx.undo.UndoManager;
 import java.beans.PropertyChangeEvent;
 import java.io.File;
 import java.io.FileInputStream;
@@ -66,6 +68,10 @@ public final class FreeMapPortraitDrawing extends AbstractFxScalableNode {
     private double oldTranslateX;
 
     private double oldTranslateY;
+
+    private double oldX;
+
+    private double oldY;
 
     private double tmpImgPos;
 
@@ -120,6 +126,8 @@ public final class FreeMapPortraitDrawing extends AbstractFxScalableNode {
             oldScreenY = event.getScreenY();
             oldTranslateX = getNode().getTranslateX();
             oldTranslateY = getNode().getTranslateY();
+            oldX = freeMapPortrait.getX();
+            oldY = freeMapPortrait.getY();
         });
         imageView.setOnMouseDragged(event -> {
             getNode().setTranslateX(oldTranslateX + event.getScreenX() - oldScreenX);
@@ -129,8 +137,17 @@ public final class FreeMapPortraitDrawing extends AbstractFxScalableNode {
             var translateXScaled = oldTranslateX + event.getScreenX() - oldScreenX;
             var translateYScaled = oldTranslateY + event.getScreenY() - oldScreenY;
             //
-            freeMapPortrait.setX(translateXScaled / getScale());
-            freeMapPortrait.setY(translateYScaled / getScale());
+            final var newX = translateXScaled / getScale();
+            final var newY = translateYScaled / getScale();
+            final var previousX = oldX;
+            final var previousY = oldY;
+            UndoManager.execute(new SimpleCommand("Move portrait", () -> {
+                freeMapPortrait.setX(newX);
+                freeMapPortrait.setY(newY);
+            }, () -> {
+                freeMapPortrait.setX(previousX);
+                freeMapPortrait.setY(previousY);
+            }));
         });
         imageView.setOnMouseClicked(event -> {
             if (event.getButton() == MouseButton.SECONDARY) {

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/freemap/FreeMapViewController.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/freemap/FreeMapViewController.java
@@ -23,6 +23,8 @@ import com.github.noony.app.timelinefx.core.freemap.FreeMapPortrait;
 import com.github.noony.app.timelinefx.core.freemap.FriezeFreeMap;
 import com.github.noony.app.timelinefx.hmi.CustomModalWindow;
 import com.github.noony.app.timelinefx.hmi.PortraitSelectionViewController;
+import com.github.noony.app.timelinefx.undo.SimpleCommand;
+import com.github.noony.app.timelinefx.undo.UndoManager;
 import com.github.noony.app.timelinefx.utils.PngExporter;
 import java.beans.PropertyChangeEvent;
 import java.io.File;
@@ -100,6 +102,8 @@ public class FreeMapViewController implements Initializable {
     //
     private FreeMapPortrait freeMapPortraitToUpdate = null;
 
+    private boolean applyingUndoRedo = false;
+
     @Override
     public void initialize(URL url, ResourceBundle rb) {
         timeHandleVisibilityCB.setSelected(true);
@@ -111,15 +115,19 @@ public class FreeMapViewController implements Initializable {
         //
         plotsVisibilityCB.setSelected(true);
         plotsVisibilityCB.selectedProperty().addListener((ObservableValue<? extends Boolean> ov, Boolean t, Boolean t1) -> {
-            if (friezeFreeMap != null) {
-                friezeFreeMap.setPlotVisibility(plotsVisibilityCB.isSelected());
+            if (friezeFreeMap != null && !applyingUndoRedo) {
+                UndoManager.execute(new SimpleCommand("Toggle plots visibility",
+                        () -> setPlotsVisibility(true),
+                        () -> setPlotsVisibility(false)));
             }
         });
         //
         portraitConnectorVisibilityCB.setSelected(true);
         portraitConnectorVisibilityCB.selectedProperty().addListener((ObservableValue<? extends Boolean> ov, Boolean t, Boolean t1) -> {
-            if (friezeFreeMap != null) {
-                friezeFreeMap.setPortraitConnectorVisibility(portraitConnectorVisibilityCB.isSelected());
+            if (friezeFreeMap != null && !applyingUndoRedo) {
+                UndoManager.execute(new SimpleCommand("Toggle portrait connectors visibility",
+                        () -> setPortraitConnectorsVisibility(true),
+                        () -> setPortraitConnectorsVisibility(false)));
             }
         });
         //
@@ -213,6 +221,20 @@ public class FreeMapViewController implements Initializable {
                 LOG.log(Level.FINEST, "The following value is not a valid zoom level {0}. {1}", new Object[]{t1, e});
             }
         });
+    }
+
+    private void setPlotsVisibility(final boolean visible) {
+        applyingUndoRedo = true;
+        plotsVisibilityCB.setSelected(visible);
+        friezeFreeMap.setPlotVisibility(visible);
+        applyingUndoRedo = false;
+    }
+
+    private void setPortraitConnectorsVisibility(final boolean visible) {
+        applyingUndoRedo = true;
+        portraitConnectorVisibilityCB.setSelected(visible);
+        friezeFreeMap.setPortraitConnectorVisibility(visible);
+        applyingUndoRedo = false;
     }
 
     @FXML
@@ -348,7 +370,11 @@ public class FreeMapViewController implements Initializable {
             case PortraitSelectionViewController.PORTRAIT_SELECTION_UPDATED -> {
                 if (freeMapPortraitToUpdate != null) {
                     var newPortrait = (Portrait) event.getNewValue();
-                    freeMapPortraitToUpdate.changePortrait(newPortrait);
+                    var portraitToUpdate = freeMapPortraitToUpdate;
+                    var oldPortrait = portraitToUpdate.getPortrait();
+                    UndoManager.execute(new SimpleCommand("Change portrait",
+                            () -> portraitToUpdate.changePortrait(newPortrait),
+                            () -> portraitToUpdate.changePortrait(oldPortrait)));
                 }
             }
             default ->

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/freemap/PlaceDrawing.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/freemap/PlaceDrawing.java
@@ -20,6 +20,8 @@ package com.github.noony.app.timelinefx.hmi.freemap;
 import com.github.noony.app.timelinefx.core.freemap.FreeMapPlace;
 import com.github.noony.app.timelinefx.core.freemap.FriezeFreeMap;
 import com.github.noony.app.timelinefx.drawings.AbstractFxScalableNode;
+import com.github.noony.app.timelinefx.undo.SimpleCommand;
+import com.github.noony.app.timelinefx.undo.UndoManager;
 import java.beans.PropertyChangeEvent;
 import javafx.geometry.Pos;
 import javafx.scene.Group;
@@ -60,6 +62,8 @@ public final class PlaceDrawing extends AbstractFxScalableNode {
     private double oldScreenY;
 
     private double oldTranslateY;
+
+    private double oldY;
 
     protected PlaceDrawing(FreeMapPlace aPlace, FriezeFreeMap aFriezeFreeMap) {
         super();
@@ -140,13 +144,18 @@ public final class PlaceDrawing extends AbstractFxScalableNode {
         background.setOnMousePressed(event -> {
             oldScreenY = event.getScreenY();
             oldTranslateY = getNode().getTranslateY();
+            oldY = place.getYPos();
         });
         background.setOnMouseDragged(event ->
             getNode().setTranslateY(oldTranslateY + event.getScreenY() - oldScreenY)
         );
         background.setOnMouseReleased(event -> {
             var translateYScaled = oldTranslateY + event.getScreenY() - oldScreenY;
-            place.setY(translateYScaled / getScale());
+            final var newY = translateYScaled / getScale();
+            final var previousY = oldY;
+            UndoManager.execute(new SimpleCommand("Move place",
+                    () -> place.setY(newY),
+                    () -> place.setY(previousY)));
         });
     }
 

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/freemap/PlaceDrawing.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/freemap/PlaceDrawing.java
@@ -63,6 +63,9 @@ public final class PlaceDrawing extends AbstractFxScalableNode {
 
     private double oldTranslateY;
 
+    /**
+     * The place's Y position when the current drag gesture started.
+     */
     private double oldY;
 
     protected PlaceDrawing(FreeMapPlace aPlace, FriezeFreeMap aFriezeFreeMap) {

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/freemap/RectangleConnector.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/freemap/RectangleConnector.java
@@ -35,6 +35,8 @@ public final class RectangleConnector extends AbstractFxScalableNode {
 
     private static final Color DEFAULT_STROKE_COLOR = Color.BLACK;
 
+    private static final String MOVE_CONNECTOR_DESCRIPTION = "Move connector";
+
     private final FreeMapConnector connector;
 
     /**
@@ -52,8 +54,14 @@ public final class RectangleConnector extends AbstractFxScalableNode {
 
     private double oldMainNodeTranslateY;
 
+    /**
+     * The connector's X position when the current drag gesture started.
+     */
     private double oldConnectorX;
 
+    /**
+     * The connector's Y position when the current drag gesture started.
+     */
     private double oldConnectorY;
 
     protected RectangleConnector(FreeMapConnector abstractConnector, InteractiveDragType anInteractiveDragType) {
@@ -102,18 +110,18 @@ public final class RectangleConnector extends AbstractFxScalableNode {
             final var previousY = oldConnectorY;
             switch (interactiveDragType) {
                 case FREE_TRANSLATION ->
-                    UndoManager.execute(new SimpleCommand("Move connector",
+                    UndoManager.execute(new SimpleCommand(MOVE_CONNECTOR_DESCRIPTION,
                             () -> connector.setPosition(newX, newY),
                             () -> connector.setPosition(previousX, previousY)));
                 case NOT_ALLOWED -> {
                     // nothing to be updated
                 }
                 case X_ONLY ->
-                    UndoManager.execute(new SimpleCommand("Move connector",
+                    UndoManager.execute(new SimpleCommand(MOVE_CONNECTOR_DESCRIPTION,
                             () -> connector.setPosition(newX, previousY),
                             () -> connector.setPosition(previousX, previousY)));
                 case Y_ONLY ->
-                    UndoManager.execute(new SimpleCommand("Move connector",
+                    UndoManager.execute(new SimpleCommand(MOVE_CONNECTOR_DESCRIPTION,
                             () -> connector.setPosition(previousX, newY),
                             () -> connector.setPosition(previousX, previousY)));
                 default ->

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/freemap/RectangleConnector.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/freemap/RectangleConnector.java
@@ -21,6 +21,8 @@ import com.github.noony.app.timelinefx.core.freemap.connectors.FreeMapConnector;
 import com.github.noony.app.timelinefx.core.freemap.connectors.FreeMapPlot;
 import com.github.noony.app.timelinefx.drawings.AbstractFxScalableNode;
 import com.github.noony.app.timelinefx.drawings.InteractiveDragType;
+import com.github.noony.app.timelinefx.undo.SimpleCommand;
+import com.github.noony.app.timelinefx.undo.UndoManager;
 import java.beans.PropertyChangeEvent;
 import javafx.geometry.Point2D;
 import javafx.scene.paint.Color;
@@ -50,6 +52,10 @@ public final class RectangleConnector extends AbstractFxScalableNode {
 
     private double oldMainNodeTranslateY;
 
+    private double oldConnectorX;
+
+    private double oldConnectorY;
+
     protected RectangleConnector(FreeMapConnector abstractConnector, InteractiveDragType anInteractiveDragType) {
         connector = abstractConnector;
         connector.addPropertyChangeListener(RectangleConnector.this::handlePropertyChange);
@@ -76,6 +82,8 @@ public final class RectangleConnector extends AbstractFxScalableNode {
             oldScene = new Point2D(event.getScreenX(), event.getScreenY());
             oldMainNodeTranslateX = getNode().getTranslateX();
             oldMainNodeTranslateY = getNode().getTranslateY();
+            oldConnectorX = connector.getX();
+            oldConnectorY = connector.getY();
         });
         connectorRectangle.setOnMouseDragged(event -> {
             currentScene = new Point2D(event.getScreenX(), event.getScreenY());
@@ -90,16 +98,24 @@ public final class RectangleConnector extends AbstractFxScalableNode {
             var deltaY = deltaYScaled / getScale();
             final var newX = connector.getX() + ((int) (deltaX / gridSpace)) * gridSpace;
             final var newY = connector.getY() + ((int) (deltaY / gridSpace)) * gridSpace;
+            final var previousX = oldConnectorX;
+            final var previousY = oldConnectorY;
             switch (interactiveDragType) {
                 case FREE_TRANSLATION ->
-                    connector.setPosition(newX, newY);
+                    UndoManager.execute(new SimpleCommand("Move connector",
+                            () -> connector.setPosition(newX, newY),
+                            () -> connector.setPosition(previousX, previousY)));
                 case NOT_ALLOWED -> {
                     // nothing to be updated
                 }
                 case X_ONLY ->
-                    connector.setPosition(newX, connector.getY());
+                    UndoManager.execute(new SimpleCommand("Move connector",
+                            () -> connector.setPosition(newX, previousY),
+                            () -> connector.setPosition(previousX, previousY)));
                 case Y_ONLY ->
-                    connector.setPosition(connector.getX(), newY);
+                    UndoManager.execute(new SimpleCommand("Move connector",
+                            () -> connector.setPosition(previousX, newY),
+                            () -> connector.setPosition(previousX, previousY)));
                 default ->
                     throw new AssertionError();
             }

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/freemap/RectangleConnector.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/freemap/RectangleConnector.java
@@ -35,6 +35,10 @@ public final class RectangleConnector extends AbstractFxScalableNode {
 
     private static final Color DEFAULT_STROKE_COLOR = Color.BLACK;
 
+    /**
+     * Description used for every {@link com.github.noony.app.timelinefx.undo.Command} pushed when this connector
+     * is dragged.
+     */
     private static final String MOVE_CONNECTOR_DESCRIPTION = "Move connector";
 
     private final FreeMapConnector connector;

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/picturechronology/ChronologyLinkDrawing.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/picturechronology/ChronologyLinkDrawing.java
@@ -20,6 +20,8 @@ package com.github.noony.app.timelinefx.hmi.picturechronology;
 import com.github.noony.app.timelinefx.core.picturechronology.ChronologyLink;
 import com.github.noony.app.timelinefx.core.picturechronology.ChronologyPictureMiniature;
 import com.github.noony.app.timelinefx.drawings.IFxScalableNode;
+import com.github.noony.app.timelinefx.undo.SimpleCommand;
+import com.github.noony.app.timelinefx.undo.UndoManager;
 import com.github.noony.app.timelinefx.utils.MathUtils;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
@@ -116,11 +118,19 @@ public final class ChronologyLinkDrawing implements IFxScalableNode {
             var controlPoint1 = new Point2D(e.getX(), e.getY());
             var startPoint = new Point2D(startNode.getCenterX(), startNode.getCenterY());
             //
-            var angle = MathUtils.getAngle(startPoint, controlPoint1);
-            var r = controlPoint1.distance(startPoint) / viewingScale;
-            linkParameters[2] = angle;
-            linkParameters[3] = r;
-            chronologyLink.updateLinkParameters(linkParameters);
+            final var angle = MathUtils.getAngle(startPoint, controlPoint1);
+            final var r = controlPoint1.distance(startPoint) / viewingScale;
+            final var oldAngle = linkParameters[2];
+            final var oldR = linkParameters[3];
+            UndoManager.execute(new SimpleCommand("Move link control point", () -> {
+                linkParameters[2] = angle;
+                linkParameters[3] = r;
+                chronologyLink.updateLinkParameters(linkParameters);
+            }, () -> {
+                linkParameters[2] = oldAngle;
+                linkParameters[3] = oldR;
+                chronologyLink.updateLinkParameters(linkParameters);
+            }));
         });
         cubicControlPoint2 = new Circle(DEFAULT_RADIUS, DEFAULT_CONTROLS_COLOR);
         cubicControlPoint2.setOnMouseDragged(e -> {
@@ -134,11 +144,19 @@ public final class ChronologyLinkDrawing implements IFxScalableNode {
         cubicControlPoint2.setOnMouseReleased(e -> {
             var controlPoint2 = new Point2D(e.getX(), e.getY());
             var endPoint = new Point2D(endNode.getCenterX(), endNode.getCenterY());
-            var angle = MathUtils.getAngle(endPoint, controlPoint2);
-            var r = controlPoint2.distance(endPoint) / viewingScale;
-            linkParameters[4] = angle;
-            linkParameters[5] = r;
-            chronologyLink.updateLinkParameters(linkParameters);
+            final var angle = MathUtils.getAngle(endPoint, controlPoint2);
+            final var r = controlPoint2.distance(endPoint) / viewingScale;
+            final var oldAngle = linkParameters[4];
+            final var oldR = linkParameters[5];
+            UndoManager.execute(new SimpleCommand("Move link control point", () -> {
+                linkParameters[4] = angle;
+                linkParameters[5] = r;
+                chronologyLink.updateLinkParameters(linkParameters);
+            }, () -> {
+                linkParameters[4] = oldAngle;
+                linkParameters[5] = oldR;
+                chronologyLink.updateLinkParameters(linkParameters);
+            }));
         });
         //
         createLinkShape();

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/picturechronology/ChronologyPictureMiniatureDrawing.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/picturechronology/ChronologyPictureMiniatureDrawing.java
@@ -19,6 +19,8 @@ package com.github.noony.app.timelinefx.hmi.picturechronology;
 
 import com.github.noony.app.timelinefx.core.picturechronology.ChronologyPictureMiniature;
 import com.github.noony.app.timelinefx.drawings.IFxScalableNode;
+import com.github.noony.app.timelinefx.undo.SimpleCommand;
+import com.github.noony.app.timelinefx.undo.UndoManager;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
@@ -94,6 +96,11 @@ public final class ChronologyPictureMiniatureDrawing implements IFxScalableNode 
 
     private double oldTranslateY;
 
+    /**
+     * The miniature's position when the current drag gesture started.
+     */
+    private Point2D oldPosition;
+
     public ChronologyPictureMiniatureDrawing(ChronologyPictureMiniature aChronologyPictureMiniature) {
         propertyChangeSupport = new PropertyChangeSupport(ChronologyPictureMiniatureDrawing.this);
         chronologyPictureMiniature = aChronologyPictureMiniature;
@@ -167,6 +174,7 @@ public final class ChronologyPictureMiniatureDrawing implements IFxScalableNode 
             oldScreenY = event.getScreenY();
             oldTranslateX = getNode().getTranslateX();
             oldTranslateY = getNode().getTranslateY();
+            oldPosition = chronologyPictureMiniature.getPosition();
         });
         frontGlass.setOnMouseDragged(event -> {
             getNode().setTranslateX(oldTranslateX + event.getScreenX() - oldScreenX);
@@ -178,7 +186,11 @@ public final class ChronologyPictureMiniatureDrawing implements IFxScalableNode 
             //
             mainNode.setTranslateX(translateXScaled);
             mainNode.setTranslateY(translateYScaled);
-            chronologyPictureMiniature.setPosition(new Point2D(translateXScaled / viewingScale, translateYScaled / viewingScale));
+            final var newPosition = new Point2D(translateXScaled / viewingScale, translateYScaled / viewingScale);
+            final var previousPosition = oldPosition;
+            UndoManager.execute(new SimpleCommand("Move picture",
+                    () -> chronologyPictureMiniature.setPosition(newPosition),
+                    () -> chronologyPictureMiniature.setPosition(previousPosition)));
         });
         frontGlass.setOnScroll(event -> {
             if (event.isControlDown()) {

--- a/src/main/java/com/github/noony/app/timelinefx/undo/Command.java
+++ b/src/main/java/com/github/noony/app/timelinefx/undo/Command.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2026 NoOnY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.github.noony.app.timelinefx.undo;
+
+/**
+ * A single reversible action, to be executed and tracked through {@link UndoManager}.
+ *
+ * @author solun
+ */
+public interface Command {
+
+    /**
+     * Performs the action. Called once when the command is first run through
+     * {@link UndoManager#execute(Command)}, and again on every {@link UndoManager#redo()}.
+     */
+    void execute();
+
+    /**
+     * Reverts the action performed by {@link #execute()}. Called on {@link UndoManager#undo()}.
+     */
+    void undo();
+
+    /**
+     * @return a short, human-readable description of the action (e.g. "Move portrait"), for display next to
+     * "Undo"/"Redo" in the UI. Defaults to an empty string.
+     */
+    default String getDescription() {
+        return "";
+    }
+
+}

--- a/src/main/java/com/github/noony/app/timelinefx/undo/Command.java
+++ b/src/main/java/com/github/noony/app/timelinefx/undo/Command.java
@@ -36,8 +36,10 @@ public interface Command {
     void undo();
 
     /**
-     * @return a short, human-readable description of the action (e.g. "Move portrait"), for display next to
-     * "Undo"/"Redo" in the UI. Defaults to an empty string.
+     * A short, human-readable description of the action (e.g. "Move portrait"), for display next to
+     * "Undo"/"Redo" in the UI.
+     *
+     * @return the description, or an empty string by default
      */
     default String getDescription() {
         return "";

--- a/src/main/java/com/github/noony/app/timelinefx/undo/SimpleCommand.java
+++ b/src/main/java/com/github/noony/app/timelinefx/undo/SimpleCommand.java
@@ -21,7 +21,7 @@ package com.github.noony.app.timelinefx.undo;
  * A {@link Command} built from two closures, for actions that boil down to "call a setter with the new value; to
  * undo, call it again with the old value" and don't warrant a dedicated class.
  *
- * @author solun
+ * @author hamon
  */
 public final class SimpleCommand implements Command {
 

--- a/src/main/java/com/github/noony/app/timelinefx/undo/SimpleCommand.java
+++ b/src/main/java/com/github/noony/app/timelinefx/undo/SimpleCommand.java
@@ -25,23 +25,32 @@ package com.github.noony.app.timelinefx.undo;
  */
 public final class SimpleCommand implements Command {
 
+    /**
+     * The description returned by {@link #getDescription()}.
+     */
     private final String description;
 
+    /**
+     * Applies the action.
+     */
     private final Runnable doAction;
 
+    /**
+     * Reverts the action.
+     */
     private final Runnable undoAction;
 
     /**
      * Creates a command from two closures.
      *
-     * @param description a short, human-readable description of the action
-     * @param doAction applies the action; called once now and again on every redo
-     * @param undoAction reverts the action
+     * @param aDescription a short, human-readable description of the action
+     * @param aDoAction applies the action; called once now and again on every redo
+     * @param anUndoAction reverts the action
      */
-    public SimpleCommand(final String description, final Runnable doAction, final Runnable undoAction) {
-        this.description = description;
-        this.doAction = doAction;
-        this.undoAction = undoAction;
+    public SimpleCommand(final String aDescription, final Runnable aDoAction, final Runnable anUndoAction) {
+        description = aDescription;
+        doAction = aDoAction;
+        undoAction = anUndoAction;
     }
 
     @Override

--- a/src/main/java/com/github/noony/app/timelinefx/undo/SimpleCommand.java
+++ b/src/main/java/com/github/noony/app/timelinefx/undo/SimpleCommand.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2026 NoOnY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.github.noony.app.timelinefx.undo;
+
+/**
+ * A {@link Command} built from two closures, for actions that boil down to "call a setter with the new value; to
+ * undo, call it again with the old value" and don't warrant a dedicated class.
+ *
+ * @author solun
+ */
+public final class SimpleCommand implements Command {
+
+    private final String description;
+
+    private final Runnable doAction;
+
+    private final Runnable undoAction;
+
+    /**
+     * Creates a command from two closures.
+     *
+     * @param description a short, human-readable description of the action
+     * @param doAction applies the action; called once now and again on every redo
+     * @param undoAction reverts the action
+     */
+    public SimpleCommand(final String description, final Runnable doAction, final Runnable undoAction) {
+        this.description = description;
+        this.doAction = doAction;
+        this.undoAction = undoAction;
+    }
+
+    @Override
+    public void execute() {
+        doAction.run();
+    }
+
+    @Override
+    public void undo() {
+        undoAction.run();
+    }
+
+    @Override
+    public String getDescription() {
+        return description;
+    }
+
+}

--- a/src/main/java/com/github/noony/app/timelinefx/undo/UndoManager.java
+++ b/src/main/java/com/github/noony/app/timelinefx/undo/UndoManager.java
@@ -40,12 +40,24 @@ public final class UndoManager {
      */
     public static final String UNDO_STATE_CHANGED = "undoStateChanged";
 
+    /**
+     * Logger for this class.
+     */
     private static final Logger LOG = Logger.getGlobal();
 
+    /**
+     * Support for {@link #UNDO_STATE_CHANGED} notifications.
+     */
     private static final PropertyChangeSupport PROPERTY_CHANGE_SUPPORT = new PropertyChangeSupport(UndoManager.class);
 
+    /**
+     * Executed (or redone) commands, most recent first.
+     */
     private static final Deque<Command> UNDO_STACK = new ArrayDeque<>();
 
+    /**
+     * Undone commands, most recent first.
+     */
     private static final Deque<Command> REDO_STACK = new ArrayDeque<>();
 
     private UndoManager() {
@@ -53,8 +65,10 @@ public final class UndoManager {
     }
 
     /**
-     * @param listener notified with {@link #UNDO_STATE_CHANGED} after every {@link #execute(Command)},
-     * {@link #undo()}, {@link #redo()} or {@link #reset()}
+     * Registers a listener to be notified after every {@link #execute(Command)}, {@link #undo()}, {@link #redo()}
+     * or {@link #reset()}.
+     *
+     * @param listener notified with {@link #UNDO_STATE_CHANGED}
      */
     public static void addPropertyChangeListener(final PropertyChangeListener listener) {
         PROPERTY_CHANGE_SUPPORT.addPropertyChangeListener(listener);

--- a/src/main/java/com/github/noony/app/timelinefx/undo/UndoManager.java
+++ b/src/main/java/com/github/noony/app/timelinefx/undo/UndoManager.java
@@ -75,6 +75,8 @@ public final class UndoManager {
     }
 
     /**
+     * Stops notifying a previously registered listener.
+     *
      * @param listener the listener to stop notifying
      */
     public static void removePropertyChangeListener(final PropertyChangeListener listener) {
@@ -126,6 +128,8 @@ public final class UndoManager {
     }
 
     /**
+     * Reports whether there is a command to undo.
+     *
      * @return {@code true} if {@link #undo()} would revert a command
      */
     public static boolean canUndo() {
@@ -133,6 +137,8 @@ public final class UndoManager {
     }
 
     /**
+     * Reports whether there is a command to redo.
+     *
      * @return {@code true} if {@link #redo()} would re-run a command
      */
     public static boolean canRedo() {

--- a/src/main/java/com/github/noony/app/timelinefx/undo/UndoManager.java
+++ b/src/main/java/com/github/noony/app/timelinefx/undo/UndoManager.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (C) 2026 NoOnY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.github.noony.app.timelinefx.undo;
+
+import java.beans.PropertyChangeListener;
+import java.beans.PropertyChangeSupport;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Application-wide undo/redo history, following the same static-singleton style as
+ * {@link com.github.noony.app.timelinefx.hmi.AppInstanceConfiguration}. No {@link Command} is currently pushed
+ * through this manager anywhere in the app; it is wired up (Edit menu, keyboard shortcuts, enablement) and ready
+ * for individual actions to be made undoable one at a time.
+ *
+ * @author solun
+ */
+public final class UndoManager {
+
+    /**
+     * Fired whenever {@link #canUndo()} or {@link #canRedo()} may have changed, so the UI can refresh its
+     * Undo/Redo controls. Carries no old/new value; listeners should re-read {@link #canUndo()}/{@link #canRedo()}.
+     */
+    public static final String UNDO_STATE_CHANGED = "undoStateChanged";
+
+    private static final Logger LOG = Logger.getGlobal();
+
+    private static final PropertyChangeSupport PROPERTY_CHANGE_SUPPORT = new PropertyChangeSupport(UndoManager.class);
+
+    private static final Deque<Command> UNDO_STACK = new ArrayDeque<>();
+
+    private static final Deque<Command> REDO_STACK = new ArrayDeque<>();
+
+    private UndoManager() {
+        // private utility constructor
+    }
+
+    /**
+     * @param listener notified with {@link #UNDO_STATE_CHANGED} after every {@link #execute(Command)},
+     * {@link #undo()}, {@link #redo()} or {@link #reset()}
+     */
+    public static void addPropertyChangeListener(final PropertyChangeListener listener) {
+        PROPERTY_CHANGE_SUPPORT.addPropertyChangeListener(listener);
+    }
+
+    /**
+     * @param listener the listener to stop notifying
+     */
+    public static void removePropertyChangeListener(final PropertyChangeListener listener) {
+        PROPERTY_CHANGE_SUPPORT.removePropertyChangeListener(listener);
+    }
+
+    /**
+     * Runs {@code command}, then pushes it onto the undo history. Clears the redo history, since redoing past
+     * actions no longer makes sense once a new command has been executed.
+     *
+     * @param command the command to run and track
+     */
+    public static void execute(final Command command) {
+        command.execute();
+        UNDO_STACK.push(command);
+        REDO_STACK.clear();
+        LOG.log(Level.INFO, "Executed command: {0}", new Object[]{command.getDescription()});
+        PROPERTY_CHANGE_SUPPORT.firePropertyChange(UNDO_STATE_CHANGED, null, null);
+    }
+
+    /**
+     * Reverts the most recently executed (or redone) command, moving it onto the redo history. Does nothing if
+     * {@link #canUndo()} is {@code false}.
+     */
+    public static void undo() {
+        if (UNDO_STACK.isEmpty()) {
+            return;
+        }
+        final var command = UNDO_STACK.pop();
+        command.undo();
+        REDO_STACK.push(command);
+        LOG.log(Level.INFO, "Undone command: {0}", new Object[]{command.getDescription()});
+        PROPERTY_CHANGE_SUPPORT.firePropertyChange(UNDO_STATE_CHANGED, null, null);
+    }
+
+    /**
+     * Re-runs the most recently undone command, moving it back onto the undo history. Does nothing if
+     * {@link #canRedo()} is {@code false}.
+     */
+    public static void redo() {
+        if (REDO_STACK.isEmpty()) {
+            return;
+        }
+        final var command = REDO_STACK.pop();
+        command.execute();
+        UNDO_STACK.push(command);
+        LOG.log(Level.INFO, "Redone command: {0}", new Object[]{command.getDescription()});
+        PROPERTY_CHANGE_SUPPORT.firePropertyChange(UNDO_STATE_CHANGED, null, null);
+    }
+
+    /**
+     * @return {@code true} if {@link #undo()} would revert a command
+     */
+    public static boolean canUndo() {
+        return !UNDO_STACK.isEmpty();
+    }
+
+    /**
+     * @return {@code true} if {@link #redo()} would re-run a command
+     */
+    public static boolean canRedo() {
+        return !REDO_STACK.isEmpty();
+    }
+
+    /**
+     * Clears both the undo and redo history, e.g. when switching to a different project.
+     */
+    public static void reset() {
+        UNDO_STACK.clear();
+        REDO_STACK.clear();
+        PROPERTY_CHANGE_SUPPORT.firePropertyChange(UNDO_STATE_CHANGED, null, null);
+    }
+
+}

--- a/src/main/java/com/github/noony/app/timelinefx/undo/package-info.java
+++ b/src/main/java/com/github/noony/app/timelinefx/undo/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2026 NoOnY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Application-wide undo/redo infrastructure (Command pattern).
+ */
+package com.github.noony.app.timelinefx.undo;

--- a/src/main/resources/com/github/noony/app/timelinefx/hmi/ProjectView.fxml
+++ b/src/main/resources/com/github/noony/app/timelinefx/hmi/ProjectView.fxml
@@ -4,6 +4,7 @@
 <?import javafx.scene.control.MenuBar?>
 <?import javafx.scene.control.MenuItem?>
 <?import javafx.scene.control.RadioMenuItem?>
+<?import javafx.scene.input.KeyCodeCombination?>
 <?import javafx.scene.layout.AnchorPane?>
 <?import javafx.scene.layout.BorderPane?>
 <?import javafx.scene.layout.HBox?>
@@ -24,7 +25,20 @@
                               <MenuItem mnemonicParsing="false" text="Close" />
                           </items>
                       </Menu>
-                      <Menu disable="true" mnemonicParsing="false" text="Edit" />
+                      <Menu mnemonicParsing="false" text="Edit">
+                          <items>
+                              <MenuItem fx:id="undoMenuItem" disable="true" mnemonicParsing="false" onAction="#handleUndo" text="Undo">
+                                  <accelerator>
+                                      <KeyCodeCombination alt="UP" code="Z" control="UP" meta="UP" shift="UP" shortcut="DOWN" />
+                                  </accelerator>
+                              </MenuItem>
+                              <MenuItem fx:id="redoMenuItem" disable="true" mnemonicParsing="false" onAction="#handleRedo" text="Redo">
+                                  <accelerator>
+                                      <KeyCodeCombination alt="UP" code="Y" control="UP" meta="UP" shift="UP" shortcut="DOWN" />
+                                  </accelerator>
+                              </MenuItem>
+                          </items>
+                      </Menu>
                   <Menu fx:id="friezesMenu" mnemonicParsing="false" text="Friezes">
                      <items>
                               <MenuItem fx:id="createFriezeMenuItem" mnemonicParsing="false" onAction="#handleFriezeCreation" text="Create New Frieze" />

--- a/src/test/java/com/github/noony/app/timelinefx/undo/SimpleCommandTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/undo/SimpleCommandTest.java
@@ -18,11 +18,11 @@
 package com.github.noony.app.timelinefx.undo;
 
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link SimpleCommand}.
@@ -31,8 +31,14 @@ import org.junit.jupiter.api.Test;
  */
 public final class SimpleCommandTest {
 
+    /**
+     * Description shared by the commands in this test that only ever apply a single fixed value.
+     */
     private static final String SET_TO_ONE_DESCRIPTION = "Set to 1";
 
+    /**
+     * Default constructor.
+     */
     public SimpleCommandTest() {
     }
 

--- a/src/test/java/com/github/noony/app/timelinefx/undo/SimpleCommandTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/undo/SimpleCommandTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2026 NoOnY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.github.noony.app.timelinefx.undo;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ *
+ * @author solun
+ */
+public class SimpleCommandTest {
+
+    @BeforeEach
+    public void setUp() {
+        UndoManager.reset();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        UndoManager.reset();
+    }
+
+    @Test
+    public void testExecuteRunsDoAction() {
+        var value = new int[]{0};
+        var command = new SimpleCommand("Set to 1", () -> value[0] = 1, () -> value[0] = 0);
+        command.execute();
+        assertEquals(1, value[0]);
+    }
+
+    @Test
+    public void testUndoRunsUndoAction() {
+        var value = new int[]{0};
+        var command = new SimpleCommand("Set to 1", () -> value[0] = 1, () -> value[0] = 0);
+        command.execute();
+        command.undo();
+        assertEquals(0, value[0]);
+    }
+
+    @Test
+    public void testGetDescription() {
+        var command = new SimpleCommand("Set to 1", () -> {
+        }, () -> {
+        });
+        assertEquals("Set to 1", command.getDescription());
+    }
+
+    @Test
+    public void testUndoManagerRoundTrip() {
+        var value = new int[]{0};
+        var command = new SimpleCommand("Set to 42", () -> value[0] = 42, () -> value[0] = 0);
+        //
+        UndoManager.execute(command);
+        assertEquals(42, value[0]);
+        assertTrue(UndoManager.canUndo());
+        assertFalse(UndoManager.canRedo());
+        //
+        UndoManager.undo();
+        assertEquals(0, value[0]);
+        assertFalse(UndoManager.canUndo());
+        assertTrue(UndoManager.canRedo());
+        //
+        UndoManager.redo();
+        assertEquals(42, value[0]);
+        assertTrue(UndoManager.canUndo());
+        assertFalse(UndoManager.canRedo());
+    }
+
+}

--- a/src/test/java/com/github/noony/app/timelinefx/undo/SimpleCommandTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/undo/SimpleCommandTest.java
@@ -27,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * Tests for {@link SimpleCommand}.
  *
- * @author solun
+ * @author hamon
  */
 public final class SimpleCommandTest {
 

--- a/src/test/java/com/github/noony/app/timelinefx/undo/SimpleCommandTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/undo/SimpleCommandTest.java
@@ -17,61 +17,87 @@
 
 package com.github.noony.app.timelinefx.undo;
 
+import org.junit.jupiter.api.AfterEach;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
+ * Tests for {@link SimpleCommand}.
  *
  * @author solun
  */
-public class SimpleCommandTest {
+public final class SimpleCommandTest {
 
+    private static final String SET_TO_ONE_DESCRIPTION = "Set to 1";
+
+    public SimpleCommandTest() {
+    }
+
+    /**
+     * Resets the shared {@link UndoManager} history before each test.
+     */
     @BeforeEach
     public void setUp() {
         UndoManager.reset();
     }
 
+    /**
+     * Resets the shared {@link UndoManager} history after each test.
+     */
     @AfterEach
     public void tearDown() {
         UndoManager.reset();
     }
 
+    /**
+     * Checks that {@link SimpleCommand#execute()} runs the {@code doAction} closure.
+     */
     @Test
     public void testExecuteRunsDoAction() {
-        var value = new int[]{0};
-        var command = new SimpleCommand("Set to 1", () -> value[0] = 1, () -> value[0] = 0);
+        final var value = new int[]{0};
+        final var command = new SimpleCommand(SET_TO_ONE_DESCRIPTION, () -> value[0] = 1, () -> value[0] = 0);
         command.execute();
         assertEquals(1, value[0]);
     }
 
+    /**
+     * Checks that {@link SimpleCommand#undo()} runs the {@code undoAction} closure.
+     */
     @Test
     public void testUndoRunsUndoAction() {
-        var value = new int[]{0};
-        var command = new SimpleCommand("Set to 1", () -> value[0] = 1, () -> value[0] = 0);
+        final var value = new int[]{0};
+        final var command = new SimpleCommand(SET_TO_ONE_DESCRIPTION, () -> value[0] = 1, () -> value[0] = 0);
         command.execute();
         command.undo();
         assertEquals(0, value[0]);
     }
 
+    /**
+     * Checks that {@link SimpleCommand#getDescription()} returns the description passed to the constructor.
+     */
     @Test
     public void testGetDescription() {
-        var command = new SimpleCommand("Set to 1", () -> {
+        final var command = new SimpleCommand(SET_TO_ONE_DESCRIPTION, () -> {
         }, () -> {
         });
-        assertEquals("Set to 1", command.getDescription());
+        assertEquals(SET_TO_ONE_DESCRIPTION, command.getDescription());
     }
 
+    /**
+     * Checks a full {@link UndoManager#execute(Command)}, {@link UndoManager#undo()}, {@link UndoManager#redo()}
+     * cycle.
+     */
     @Test
     public void testUndoManagerRoundTrip() {
-        var value = new int[]{0};
-        var command = new SimpleCommand("Set to 42", () -> value[0] = 42, () -> value[0] = 0);
+        final var value = new int[]{0};
+        final var target = 42;
+        final var command = new SimpleCommand("Set to target", () -> value[0] = target, () -> value[0] = 0);
         //
         UndoManager.execute(command);
-        assertEquals(42, value[0]);
+        assertEquals(target, value[0]);
         assertTrue(UndoManager.canUndo());
         assertFalse(UndoManager.canRedo());
         //
@@ -81,7 +107,7 @@ public class SimpleCommandTest {
         assertTrue(UndoManager.canRedo());
         //
         UndoManager.redo();
-        assertEquals(42, value[0]);
+        assertEquals(target, value[0]);
         assertTrue(UndoManager.canUndo());
         assertFalse(UndoManager.canRedo());
     }

--- a/src/test/java/com/github/noony/app/timelinefx/undo/package-info.java
+++ b/src/test/java/com/github/noony/app/timelinefx/undo/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2026 NoOnY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Unit tests for the undo/redo infrastructure.
+ */
+package com.github.noony.app.timelinefx.undo;


### PR DESCRIPTION
## Summary
- Extends the undo/redo pattern established in #43/#44 to seven more clean-commit-point actions across three feature areas:
  - **Picture chronology**: dragging a miniature (`ChronologyPictureMiniatureDrawing`), dragging each cubic link control point (`ChronologyLinkDrawing`), toggling "use custom date" and picking a date via the date picker (`ChronologyMiniatureConfiguratorController`)
  - **Gallery**: reordering a person up/down within a picture (`GalleryViewController`) — `movePersonUp`/`movePersonDown` are exact mutual inverses, so no old-value capture needed
  - **Place editing**: the existing-place "Validate" commit in `PlaceCreationViewController` now wraps all four field setters (name/parent/level/color) as one command
- No model classes changed — every site reuses an existing setter and (where needed) getter
- Surveyed the rest of the app (frieze content editor, byplace/byperson, person/place/picture creation, a repo-wide create/delete sweep) and deliberately excluded several categories that don't meet the same bar yet — see the PR-adjacent plan for the specific reasons (transient view-only state, no press/release commit boundary, creation/deletion with no clean model-level reverse, per-keystroke text fields)

Builds on #44 (not yet merged) — based against that branch rather than `main`.

## Test plan
- [x] `mvn -q -o compile`
- [x] `mvn -q -o test` (full suite green)
- [ ] Manual: drag a picture-chronology miniature and each link control point, toggle/pick a custom date, move a person up/down in the Gallery view, edit an existing place's name/parent/level/color — confirm Edit ▸ Undo/Redo reverses each correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)