### PR TITLE
Extend Command pattern to Person/Place creation and Person editing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>org.controlsfx</groupId>
             <artifactId>controlsfx</artifactId>
-            <version>11.2.3</version>
+            <version>11.2.4</version>
         </dependency>
         <!--javafx-controls-->
         <dependency>

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/ContentEditionViewController.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/ContentEditionViewController.java
@@ -21,6 +21,8 @@ import com.github.noony.app.timelinefx.core.Person;
 import com.github.noony.app.timelinefx.core.Place;
 import com.github.noony.app.timelinefx.core.PlaceFactory;
 import com.github.noony.app.timelinefx.core.TimeLineProject;
+import com.github.noony.app.timelinefx.undo.SimpleCommand;
+import com.github.noony.app.timelinefx.undo.UndoManager;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.io.IOException;
@@ -373,7 +375,10 @@ public final class ContentEditionViewController implements Initializable {
             case PlaceCreationViewController.PLACE_CREATED -> {
                 place = (Place) event.getNewValue();
                 customModalWindow.hide();
-                timeLineProject.addPlace(place);
+                final var createdPlace = place;
+                UndoManager.execute(new SimpleCommand("Create place",
+                        () -> timeLineProject.addPlace(createdPlace),
+                        () -> timeLineProject.removePlace(createdPlace)));
                 updatePlacesTab();
             }
 
@@ -415,7 +420,10 @@ public final class ContentEditionViewController implements Initializable {
             case PersonCreationViewController.PERSON_CREATED -> {
                 person = (Person) event.getNewValue();
                 customModalWindow.hide();
-                timeLineProject.addPerson(person);
+                final var createdPerson = person;
+                UndoManager.execute(new SimpleCommand("Create person",
+                        () -> timeLineProject.addPerson(createdPerson),
+                        () -> timeLineProject.removePerson(createdPerson)));
                 updatePersonTab();
             }
             case PersonCreationViewController.PERSON_EDITIED -> {

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/FriezePeopleViewController.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/FriezePeopleViewController.java
@@ -77,8 +77,14 @@ public class FriezePeopleViewController implements Initializable {
 
     private FriezePeopleLinearDrawing friezePeopleLinearDrawing = null;
 
+    /**
+     * The slider's low value when the current drag gesture started.
+     */
     private double lowValueAtDragStart;
 
+    /**
+     * The slider's high value when the current drag gesture started.
+     */
     private double highValueAtDragStart;
 
     @Override
@@ -121,34 +127,38 @@ public class FriezePeopleViewController implements Initializable {
                 updateUpperTimeValue();
             }
         });
-        peopleViewTimeSlider.lowValueChangingProperty().addListener((ov, wasChanging, isChanging) -> {
-            if (isChanging) {
-                lowValueAtDragStart = peopleViewTimeSlider.getLowValue();
-            } else {
-                final var oldLowValue = lowValueAtDragStart;
-                final var newLowValue = peopleViewTimeSlider.getLowValue();
-                if (oldLowValue != newLowValue) {
-                    UndoManager.execute(new SimpleCommand("Change lower time window",
-                            () -> peopleViewTimeSlider.setLowValue(newLowValue),
-                            () -> peopleViewTimeSlider.setLowValue(oldLowValue)));
-                }
-            }
-        });
-        peopleViewTimeSlider.highValueChangingProperty().addListener((ov, wasChanging, isChanging) -> {
-            if (isChanging) {
-                highValueAtDragStart = peopleViewTimeSlider.getHighValue();
-            } else {
-                final var oldHighValue = highValueAtDragStart;
-                final var newHighValue = peopleViewTimeSlider.getHighValue();
-                if (oldHighValue != newHighValue) {
-                    UndoManager.execute(new SimpleCommand("Change upper time window",
-                            () -> peopleViewTimeSlider.setHighValue(newHighValue),
-                            () -> peopleViewTimeSlider.setHighValue(oldHighValue)));
-                }
-            }
-        });
+        peopleViewTimeSlider.lowValueChangingProperty().addListener((ov, wasChanging, isChanging) -> handleLowValueChanging(isChanging));
+        peopleViewTimeSlider.highValueChangingProperty().addListener((ov, wasChanging, isChanging) -> handleHighValueChanging(isChanging));
         peopleViewMinDateLabel.setText("");
         peopleViewMaxDateLabel.setText("");
+    }
+
+    private void handleLowValueChanging(final boolean isChanging) {
+        if (isChanging) {
+            lowValueAtDragStart = peopleViewTimeSlider.getLowValue();
+        } else {
+            final var oldLowValue = lowValueAtDragStart;
+            final var newLowValue = peopleViewTimeSlider.getLowValue();
+            if (oldLowValue != newLowValue) {
+                UndoManager.execute(new SimpleCommand("Change lower time window",
+                        () -> peopleViewTimeSlider.setLowValue(newLowValue),
+                        () -> peopleViewTimeSlider.setLowValue(oldLowValue)));
+            }
+        }
+    }
+
+    private void handleHighValueChanging(final boolean isChanging) {
+        if (isChanging) {
+            highValueAtDragStart = peopleViewTimeSlider.getHighValue();
+        } else {
+            final var oldHighValue = highValueAtDragStart;
+            final var newHighValue = peopleViewTimeSlider.getHighValue();
+            if (oldHighValue != newHighValue) {
+                UndoManager.execute(new SimpleCommand("Change upper time window",
+                        () -> peopleViewTimeSlider.setHighValue(newHighValue),
+                        () -> peopleViewTimeSlider.setHighValue(oldHighValue)));
+            }
+        }
     }
 
     private void updateFriezeWidth() {

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/FriezePeopleViewController.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/FriezePeopleViewController.java
@@ -19,6 +19,8 @@ package com.github.noony.app.timelinefx.hmi;
 
 import com.github.noony.app.timelinefx.core.Frieze;
 import com.github.noony.app.timelinefx.hmi.byperson.FriezePeopleLinearDrawing;
+import com.github.noony.app.timelinefx.undo.SimpleCommand;
+import com.github.noony.app.timelinefx.undo.UndoManager;
 import com.github.noony.app.timelinefx.utils.TimeFormatToString;
 import java.net.URL;
 import java.time.format.DateTimeFormatter;
@@ -75,6 +77,10 @@ public class FriezePeopleViewController implements Initializable {
 
     private FriezePeopleLinearDrawing friezePeopleLinearDrawing = null;
 
+    private double lowValueAtDragStart;
+
+    private double highValueAtDragStart;
+
     @Override
     public void initialize(URL location, ResourceBundle resources) {
         peopleViewScrollPane.widthProperty().addListener((ObservableValue<? extends Number> observable, Number oldValue, Number newValue) -> {
@@ -113,6 +119,32 @@ public class FriezePeopleViewController implements Initializable {
         peopleViewTimeSlider.highValueProperty().addListener(o -> {
             if (!peopleViewTimeSlider.isLowValueChanging()) {
                 updateUpperTimeValue();
+            }
+        });
+        peopleViewTimeSlider.lowValueChangingProperty().addListener((ov, wasChanging, isChanging) -> {
+            if (isChanging) {
+                lowValueAtDragStart = peopleViewTimeSlider.getLowValue();
+            } else {
+                final var oldLowValue = lowValueAtDragStart;
+                final var newLowValue = peopleViewTimeSlider.getLowValue();
+                if (oldLowValue != newLowValue) {
+                    UndoManager.execute(new SimpleCommand("Change lower time window",
+                            () -> peopleViewTimeSlider.setLowValue(newLowValue),
+                            () -> peopleViewTimeSlider.setLowValue(oldLowValue)));
+                }
+            }
+        });
+        peopleViewTimeSlider.highValueChangingProperty().addListener((ov, wasChanging, isChanging) -> {
+            if (isChanging) {
+                highValueAtDragStart = peopleViewTimeSlider.getHighValue();
+            } else {
+                final var oldHighValue = highValueAtDragStart;
+                final var newHighValue = peopleViewTimeSlider.getHighValue();
+                if (oldHighValue != newHighValue) {
+                    UndoManager.execute(new SimpleCommand("Change upper time window",
+                            () -> peopleViewTimeSlider.setHighValue(newHighValue),
+                            () -> peopleViewTimeSlider.setHighValue(oldHighValue)));
+                }
             }
         });
         peopleViewMinDateLabel.setText("");

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/PersonCreationViewController.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/PersonCreationViewController.java
@@ -26,6 +26,8 @@ import com.github.noony.app.timelinefx.core.PortraitFactory;
 import com.github.noony.app.timelinefx.core.TimeFormat;
 import com.github.noony.app.timelinefx.core.TimeLineProject;
 import com.github.noony.app.timelinefx.drawings.GalleryTiles;
+import com.github.noony.app.timelinefx.undo.SimpleCommand;
+import com.github.noony.app.timelinefx.undo.UndoManager;
 import com.github.noony.app.timelinefx.utils.CustomFileUtils;
 import com.github.noony.app.timelinefx.utils.MathUtils;
 import java.beans.PropertyChangeEvent;
@@ -37,6 +39,7 @@ import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -229,8 +232,14 @@ public final class PersonCreationViewController implements Initializable {
                 propertyChangeSupport.firePropertyChange(PERSON_CREATED, null, currentEditedPerson);
             }
             case EDITION -> {
-                updatePerson(currentEditedPerson);
-                propertyChangeSupport.firePropertyChange(PERSON_EDITIED, null, currentEditedPerson);
+                final var editedPerson = currentEditedPerson;
+                final var oldSnapshot = capturePersonSnapshot(editedPerson);
+                updatePerson(editedPerson);
+                final var newSnapshot = capturePersonSnapshot(editedPerson);
+                UndoManager.execute(new SimpleCommand("Edit person",
+                        () -> applyPersonSnapshot(editedPerson, newSnapshot),
+                        () -> applyPersonSnapshot(editedPerson, oldSnapshot)));
+                propertyChangeSupport.firePropertyChange(PERSON_EDITIED, null, editedPerson);
                 reset();
             }
             default ->
@@ -408,6 +417,46 @@ public final class PersonCreationViewController implements Initializable {
                 LOG.log(Level.SEVERE, "Exception while updating image foPicturer {0} : {1}", new Object[]{defaultPortrait, e});
                 LOG.log(Level.SEVERE, "> file name was: {0}", new Object[]{path});
             }
+        }
+    }
+
+    private record PersonSnapshot(String name, List<Portrait> portraits, Portrait defaultPortrait, Color color,
+            TimeFormat timeFormat, LocalDate dateOfBirth, LocalDate dateOfDeath, long timeOfBirth, long timeOfDeath,
+            Map<Portrait, LocalDate> portraitDates, Map<Portrait, Double> portraitTimestamps) {
+    }
+
+    private PersonSnapshot capturePersonSnapshot(Person person) {
+        var portraitDates = new HashMap<Portrait, LocalDate>();
+        updatedPortraitDates.keySet().forEach(portrait -> portraitDates.put(portrait, portrait.getDate()));
+        var portraitTimestamps = new HashMap<Portrait, Double>();
+        updatedPortraitTimes.keySet().forEach(portrait -> portraitTimestamps.put(portrait, portrait.getTimestamp()));
+        return new PersonSnapshot(person.getName(), new ArrayList<>(person.getPortraits()), person.getDefaultPortrait(),
+                person.getColor(), person.getTimeFormat(), person.getDateOfBirth(), person.getDateOfDeath(),
+                person.getTimeOfBirth(), person.getTimeOfDeath(), portraitDates, portraitTimestamps);
+    }
+
+    private void applyPersonSnapshot(Person person, PersonSnapshot snapshot) {
+        person.setName(snapshot.name());
+        new ArrayList<>(person.getPortraits()).stream()
+                .filter(p -> !snapshot.portraits().contains(p))
+                .forEach(person::removePortrait);
+        snapshot.portraits().forEach(person::addPortrait);
+        person.setDefaultPortrait(snapshot.defaultPortrait());
+        person.setColor(snapshot.color());
+        person.setTimeFormat(snapshot.timeFormat());
+        switch (snapshot.timeFormat()) {
+            case LOCAL_TIME -> {
+                person.setDateOfBirth(snapshot.dateOfBirth());
+                person.setDateOfDeath(snapshot.dateOfDeath());
+                snapshot.portraitDates().forEach((portrait, date) -> portrait.setDate(date));
+            }
+            case TIME_MIN -> {
+                person.setTimeOfBirth(snapshot.timeOfBirth());
+                person.setTimeOfDeath(snapshot.timeOfDeath());
+                snapshot.portraitTimestamps().forEach((portrait, timestamp) -> portrait.setTimestamp(timestamp));
+            }
+            default ->
+                throw new UnsupportedOperationException(Messages.UNSUPPORTED_TIME_FORMAT + snapshot.timeFormat());
         }
     }
 

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/byplace/FriezePlaceViewController.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/byplace/FriezePlaceViewController.java
@@ -18,6 +18,8 @@
 package com.github.noony.app.timelinefx.hmi.byplace;
 
 import com.github.noony.app.timelinefx.core.Frieze;
+import com.github.noony.app.timelinefx.undo.SimpleCommand;
+import com.github.noony.app.timelinefx.undo.UndoManager;
 import com.github.noony.app.timelinefx.utils.TimeFormatToString;
 import java.net.URL;
 import java.util.Optional;
@@ -69,6 +71,10 @@ public class FriezePlaceViewController implements Initializable {
 
     private FriezeSpaceLinearDrawing friezeSpaceLinearDrawing = null;
 
+    private double lowValueAtDragStart;
+
+    private double highValueAtDragStart;
+
     @Override
     public void initialize(URL location, ResourceBundle resources) {
         scrollPane.widthProperty().addListener((ObservableValue<? extends Number> observable, Number oldValue, Number newValue) -> {
@@ -108,6 +114,32 @@ public class FriezePlaceViewController implements Initializable {
         timeSlider.highValueProperty().addListener(o -> {
             if (!timeSlider.isLowValueChanging()) {
                 updateUpperTimeValue();
+            }
+        });
+        timeSlider.lowValueChangingProperty().addListener((ov, wasChanging, isChanging) -> {
+            if (isChanging) {
+                lowValueAtDragStart = timeSlider.getLowValue();
+            } else {
+                final var oldLowValue = lowValueAtDragStart;
+                final var newLowValue = timeSlider.getLowValue();
+                if (oldLowValue != newLowValue) {
+                    UndoManager.execute(new SimpleCommand("Change lower time window",
+                            () -> timeSlider.setLowValue(newLowValue),
+                            () -> timeSlider.setLowValue(oldLowValue)));
+                }
+            }
+        });
+        timeSlider.highValueChangingProperty().addListener((ov, wasChanging, isChanging) -> {
+            if (isChanging) {
+                highValueAtDragStart = timeSlider.getHighValue();
+            } else {
+                final var oldHighValue = highValueAtDragStart;
+                final var newHighValue = timeSlider.getHighValue();
+                if (oldHighValue != newHighValue) {
+                    UndoManager.execute(new SimpleCommand("Change upper time window",
+                            () -> timeSlider.setHighValue(newHighValue),
+                            () -> timeSlider.setHighValue(oldHighValue)));
+                }
             }
         });
         minDateLabel.setText("");

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/byplace/FriezePlaceViewController.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/byplace/FriezePlaceViewController.java
@@ -71,8 +71,14 @@ public class FriezePlaceViewController implements Initializable {
 
     private FriezeSpaceLinearDrawing friezeSpaceLinearDrawing = null;
 
+    /**
+     * The slider's low value when the current drag gesture started.
+     */
     private double lowValueAtDragStart;
 
+    /**
+     * The slider's high value when the current drag gesture started.
+     */
     private double highValueAtDragStart;
 
     @Override
@@ -116,34 +122,38 @@ public class FriezePlaceViewController implements Initializable {
                 updateUpperTimeValue();
             }
         });
-        timeSlider.lowValueChangingProperty().addListener((ov, wasChanging, isChanging) -> {
-            if (isChanging) {
-                lowValueAtDragStart = timeSlider.getLowValue();
-            } else {
-                final var oldLowValue = lowValueAtDragStart;
-                final var newLowValue = timeSlider.getLowValue();
-                if (oldLowValue != newLowValue) {
-                    UndoManager.execute(new SimpleCommand("Change lower time window",
-                            () -> timeSlider.setLowValue(newLowValue),
-                            () -> timeSlider.setLowValue(oldLowValue)));
-                }
-            }
-        });
-        timeSlider.highValueChangingProperty().addListener((ov, wasChanging, isChanging) -> {
-            if (isChanging) {
-                highValueAtDragStart = timeSlider.getHighValue();
-            } else {
-                final var oldHighValue = highValueAtDragStart;
-                final var newHighValue = timeSlider.getHighValue();
-                if (oldHighValue != newHighValue) {
-                    UndoManager.execute(new SimpleCommand("Change upper time window",
-                            () -> timeSlider.setHighValue(newHighValue),
-                            () -> timeSlider.setHighValue(oldHighValue)));
-                }
-            }
-        });
+        timeSlider.lowValueChangingProperty().addListener((ov, wasChanging, isChanging) -> handleLowValueChanging(isChanging));
+        timeSlider.highValueChangingProperty().addListener((ov, wasChanging, isChanging) -> handleHighValueChanging(isChanging));
         minDateLabel.setText("");
         maxDateLabel.setText("");
+    }
+
+    private void handleLowValueChanging(final boolean isChanging) {
+        if (isChanging) {
+            lowValueAtDragStart = timeSlider.getLowValue();
+        } else {
+            final var oldLowValue = lowValueAtDragStart;
+            final var newLowValue = timeSlider.getLowValue();
+            if (oldLowValue != newLowValue) {
+                UndoManager.execute(new SimpleCommand("Change lower time window",
+                        () -> timeSlider.setLowValue(newLowValue),
+                        () -> timeSlider.setLowValue(oldLowValue)));
+            }
+        }
+    }
+
+    private void handleHighValueChanging(final boolean isChanging) {
+        if (isChanging) {
+            highValueAtDragStart = timeSlider.getHighValue();
+        } else {
+            final var oldHighValue = highValueAtDragStart;
+            final var newHighValue = timeSlider.getHighValue();
+            if (oldHighValue != newHighValue) {
+                UndoManager.execute(new SimpleCommand("Change upper time window",
+                        () -> timeSlider.setHighValue(newHighValue),
+                        () -> timeSlider.setHighValue(oldHighValue)));
+            }
+        }
     }
 
     private void updateFriezeWidth() {


### PR DESCRIPTION
## Summary
- **Place creation** and **Person creation** (`ContentEditionViewController`): wrap the existing `addPlace`/`addPerson` call so undo calls the existing `removePlace`/`removePerson`. Safe because a freshly created object has no stays/children yet, so those methods' cascade-delete logic is a no-op — deleting an *arbitrary, already-populated* Person/Place is a different, harder problem and is intentionally not covered here.
- **Person editing** (`PersonCreationViewController`): a bigger surface than Place's 4 fields (already wired in #46) — name, portraits (add/remove), default portrait, color, time format, birth/death date-or-timestamp, and per-portrait date/timestamp overrides. Added a private `PersonSnapshot` record plus `capturePersonSnapshot`/`applyPersonSnapshot` helpers: snapshot the person before and after `updatePerson(...)` runs, then undo/redo replay one snapshot or the other — not `updatePerson` itself, since it reads transient controller fields that won't be valid at redo time.
- No changes to `Person`, `Place`, `Portrait`, `Factory`, `PersonFactory`, `PlaceFactory`, or `TimeLineProject`.
- Noted but not touched: `PersonCreationViewController` already eagerly creates a `Person` via the Factory as soon as the "New Person" dialog opens (to have a live object for the form), and Cancel doesn't clean that up — a pre-existing quirk, neither fixed nor worsened here.

Builds on #46 (not yet merged) — based against that branch rather than `main`.

## Test plan
- [x] `mvn -q -o compile`
- [x] `mvn -q -o test` (full suite green)
- [ ] Manual: create a new Place/Person, Undo (confirm it disappears), Redo (confirm it reappears); edit an existing Person's name/color/default portrait/attached portraits/birth-death date, Undo (confirm every field reverts), Redo (confirm every field re-applies)

🤖 Generated with [Claude Code](https://claude.com/claude-code)