### PR TITLE
Add undo/redo for Frieze View's time-window slider

### DIFF
--- a/src/main/java/com/github/noony/app/timelinefx/hmi/FriezePeopleViewController.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/FriezePeopleViewController.java
@@ -77,8 +77,14 @@ public class FriezePeopleViewController implements Initializable {
 
     private FriezePeopleLinearDrawing friezePeopleLinearDrawing = null;
 
+    /**
+     * The slider's low value when the current drag gesture started.
+     */
     private double lowValueAtDragStart;
 
+    /**
+     * The slider's high value when the current drag gesture started.
+     */
     private double highValueAtDragStart;
 
     @Override
@@ -121,34 +127,38 @@ public class FriezePeopleViewController implements Initializable {
                 updateUpperTimeValue();
             }
         });
-        peopleViewTimeSlider.lowValueChangingProperty().addListener((ov, wasChanging, isChanging) -> {
-            if (isChanging) {
-                lowValueAtDragStart = peopleViewTimeSlider.getLowValue();
-            } else {
-                final var oldLowValue = lowValueAtDragStart;
-                final var newLowValue = peopleViewTimeSlider.getLowValue();
-                if (oldLowValue != newLowValue) {
-                    UndoManager.execute(new SimpleCommand("Change lower time window",
-                            () -> peopleViewTimeSlider.setLowValue(newLowValue),
-                            () -> peopleViewTimeSlider.setLowValue(oldLowValue)));
-                }
-            }
-        });
-        peopleViewTimeSlider.highValueChangingProperty().addListener((ov, wasChanging, isChanging) -> {
-            if (isChanging) {
-                highValueAtDragStart = peopleViewTimeSlider.getHighValue();
-            } else {
-                final var oldHighValue = highValueAtDragStart;
-                final var newHighValue = peopleViewTimeSlider.getHighValue();
-                if (oldHighValue != newHighValue) {
-                    UndoManager.execute(new SimpleCommand("Change upper time window",
-                            () -> peopleViewTimeSlider.setHighValue(newHighValue),
-                            () -> peopleViewTimeSlider.setHighValue(oldHighValue)));
-                }
-            }
-        });
+        peopleViewTimeSlider.lowValueChangingProperty().addListener((ov, wasChanging, isChanging) -> handleLowValueChanging(isChanging));
+        peopleViewTimeSlider.highValueChangingProperty().addListener((ov, wasChanging, isChanging) -> handleHighValueChanging(isChanging));
         peopleViewMinDateLabel.setText("");
         peopleViewMaxDateLabel.setText("");
+    }
+
+    private void handleLowValueChanging(final boolean isChanging) {
+        if (isChanging) {
+            lowValueAtDragStart = peopleViewTimeSlider.getLowValue();
+        } else {
+            final var oldLowValue = lowValueAtDragStart;
+            final var newLowValue = peopleViewTimeSlider.getLowValue();
+            if (oldLowValue != newLowValue) {
+                UndoManager.execute(new SimpleCommand("Change lower time window",
+                        () -> peopleViewTimeSlider.setLowValue(newLowValue),
+                        () -> peopleViewTimeSlider.setLowValue(oldLowValue)));
+            }
+        }
+    }
+
+    private void handleHighValueChanging(final boolean isChanging) {
+        if (isChanging) {
+            highValueAtDragStart = peopleViewTimeSlider.getHighValue();
+        } else {
+            final var oldHighValue = highValueAtDragStart;
+            final var newHighValue = peopleViewTimeSlider.getHighValue();
+            if (oldHighValue != newHighValue) {
+                UndoManager.execute(new SimpleCommand("Change upper time window",
+                        () -> peopleViewTimeSlider.setHighValue(newHighValue),
+                        () -> peopleViewTimeSlider.setHighValue(oldHighValue)));
+            }
+        }
     }
 
     private void updateFriezeWidth() {

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/FriezePeopleViewController.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/FriezePeopleViewController.java
@@ -19,6 +19,8 @@ package com.github.noony.app.timelinefx.hmi;
 
 import com.github.noony.app.timelinefx.core.Frieze;
 import com.github.noony.app.timelinefx.hmi.byperson.FriezePeopleLinearDrawing;
+import com.github.noony.app.timelinefx.undo.SimpleCommand;
+import com.github.noony.app.timelinefx.undo.UndoManager;
 import com.github.noony.app.timelinefx.utils.TimeFormatToString;
 import java.net.URL;
 import java.time.format.DateTimeFormatter;
@@ -75,6 +77,10 @@ public class FriezePeopleViewController implements Initializable {
 
     private FriezePeopleLinearDrawing friezePeopleLinearDrawing = null;
 
+    private double lowValueAtDragStart;
+
+    private double highValueAtDragStart;
+
     @Override
     public void initialize(URL location, ResourceBundle resources) {
         peopleViewScrollPane.widthProperty().addListener((ObservableValue<? extends Number> observable, Number oldValue, Number newValue) -> {
@@ -113,6 +119,32 @@ public class FriezePeopleViewController implements Initializable {
         peopleViewTimeSlider.highValueProperty().addListener(o -> {
             if (!peopleViewTimeSlider.isLowValueChanging()) {
                 updateUpperTimeValue();
+            }
+        });
+        peopleViewTimeSlider.lowValueChangingProperty().addListener((ov, wasChanging, isChanging) -> {
+            if (isChanging) {
+                lowValueAtDragStart = peopleViewTimeSlider.getLowValue();
+            } else {
+                final var oldLowValue = lowValueAtDragStart;
+                final var newLowValue = peopleViewTimeSlider.getLowValue();
+                if (oldLowValue != newLowValue) {
+                    UndoManager.execute(new SimpleCommand("Change lower time window",
+                            () -> peopleViewTimeSlider.setLowValue(newLowValue),
+                            () -> peopleViewTimeSlider.setLowValue(oldLowValue)));
+                }
+            }
+        });
+        peopleViewTimeSlider.highValueChangingProperty().addListener((ov, wasChanging, isChanging) -> {
+            if (isChanging) {
+                highValueAtDragStart = peopleViewTimeSlider.getHighValue();
+            } else {
+                final var oldHighValue = highValueAtDragStart;
+                final var newHighValue = peopleViewTimeSlider.getHighValue();
+                if (oldHighValue != newHighValue) {
+                    UndoManager.execute(new SimpleCommand("Change upper time window",
+                            () -> peopleViewTimeSlider.setHighValue(newHighValue),
+                            () -> peopleViewTimeSlider.setHighValue(oldHighValue)));
+                }
             }
         });
         peopleViewMinDateLabel.setText("");

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/byplace/FriezePlaceViewController.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/byplace/FriezePlaceViewController.java
@@ -18,6 +18,8 @@
 package com.github.noony.app.timelinefx.hmi.byplace;
 
 import com.github.noony.app.timelinefx.core.Frieze;
+import com.github.noony.app.timelinefx.undo.SimpleCommand;
+import com.github.noony.app.timelinefx.undo.UndoManager;
 import com.github.noony.app.timelinefx.utils.TimeFormatToString;
 import java.net.URL;
 import java.util.Optional;
@@ -69,6 +71,10 @@ public class FriezePlaceViewController implements Initializable {
 
     private FriezeSpaceLinearDrawing friezeSpaceLinearDrawing = null;
 
+    private double lowValueAtDragStart;
+
+    private double highValueAtDragStart;
+
     @Override
     public void initialize(URL location, ResourceBundle resources) {
         scrollPane.widthProperty().addListener((ObservableValue<? extends Number> observable, Number oldValue, Number newValue) -> {
@@ -108,6 +114,32 @@ public class FriezePlaceViewController implements Initializable {
         timeSlider.highValueProperty().addListener(o -> {
             if (!timeSlider.isLowValueChanging()) {
                 updateUpperTimeValue();
+            }
+        });
+        timeSlider.lowValueChangingProperty().addListener((ov, wasChanging, isChanging) -> {
+            if (isChanging) {
+                lowValueAtDragStart = timeSlider.getLowValue();
+            } else {
+                final var oldLowValue = lowValueAtDragStart;
+                final var newLowValue = timeSlider.getLowValue();
+                if (oldLowValue != newLowValue) {
+                    UndoManager.execute(new SimpleCommand("Change lower time window",
+                            () -> timeSlider.setLowValue(newLowValue),
+                            () -> timeSlider.setLowValue(oldLowValue)));
+                }
+            }
+        });
+        timeSlider.highValueChangingProperty().addListener((ov, wasChanging, isChanging) -> {
+            if (isChanging) {
+                highValueAtDragStart = timeSlider.getHighValue();
+            } else {
+                final var oldHighValue = highValueAtDragStart;
+                final var newHighValue = timeSlider.getHighValue();
+                if (oldHighValue != newHighValue) {
+                    UndoManager.execute(new SimpleCommand("Change upper time window",
+                            () -> timeSlider.setHighValue(newHighValue),
+                            () -> timeSlider.setHighValue(oldHighValue)));
+                }
             }
         });
         minDateLabel.setText("");

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/byplace/FriezePlaceViewController.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/byplace/FriezePlaceViewController.java
@@ -71,8 +71,14 @@ public class FriezePlaceViewController implements Initializable {
 
     private FriezeSpaceLinearDrawing friezeSpaceLinearDrawing = null;
 
+    /**
+     * The slider's low value when the current drag gesture started.
+     */
     private double lowValueAtDragStart;
 
+    /**
+     * The slider's high value when the current drag gesture started.
+     */
     private double highValueAtDragStart;
 
     @Override
@@ -116,34 +122,38 @@ public class FriezePlaceViewController implements Initializable {
                 updateUpperTimeValue();
             }
         });
-        timeSlider.lowValueChangingProperty().addListener((ov, wasChanging, isChanging) -> {
-            if (isChanging) {
-                lowValueAtDragStart = timeSlider.getLowValue();
-            } else {
-                final var oldLowValue = lowValueAtDragStart;
-                final var newLowValue = timeSlider.getLowValue();
-                if (oldLowValue != newLowValue) {
-                    UndoManager.execute(new SimpleCommand("Change lower time window",
-                            () -> timeSlider.setLowValue(newLowValue),
-                            () -> timeSlider.setLowValue(oldLowValue)));
-                }
-            }
-        });
-        timeSlider.highValueChangingProperty().addListener((ov, wasChanging, isChanging) -> {
-            if (isChanging) {
-                highValueAtDragStart = timeSlider.getHighValue();
-            } else {
-                final var oldHighValue = highValueAtDragStart;
-                final var newHighValue = timeSlider.getHighValue();
-                if (oldHighValue != newHighValue) {
-                    UndoManager.execute(new SimpleCommand("Change upper time window",
-                            () -> timeSlider.setHighValue(newHighValue),
-                            () -> timeSlider.setHighValue(oldHighValue)));
-                }
-            }
-        });
+        timeSlider.lowValueChangingProperty().addListener((ov, wasChanging, isChanging) -> handleLowValueChanging(isChanging));
+        timeSlider.highValueChangingProperty().addListener((ov, wasChanging, isChanging) -> handleHighValueChanging(isChanging));
         minDateLabel.setText("");
         maxDateLabel.setText("");
+    }
+
+    private void handleLowValueChanging(final boolean isChanging) {
+        if (isChanging) {
+            lowValueAtDragStart = timeSlider.getLowValue();
+        } else {
+            final var oldLowValue = lowValueAtDragStart;
+            final var newLowValue = timeSlider.getLowValue();
+            if (oldLowValue != newLowValue) {
+                UndoManager.execute(new SimpleCommand("Change lower time window",
+                        () -> timeSlider.setLowValue(newLowValue),
+                        () -> timeSlider.setLowValue(oldLowValue)));
+            }
+        }
+    }
+
+    private void handleHighValueChanging(final boolean isChanging) {
+        if (isChanging) {
+            highValueAtDragStart = timeSlider.getHighValue();
+        } else {
+            final var oldHighValue = highValueAtDragStart;
+            final var newHighValue = timeSlider.getHighValue();
+            if (oldHighValue != newHighValue) {
+                UndoManager.execute(new SimpleCommand("Change upper time window",
+                        () -> timeSlider.setHighValue(newHighValue),
+                        () -> timeSlider.setHighValue(oldHighValue)));
+            }
+        }
     }
 
     private void updateFriezeWidth() {


### PR DESCRIPTION
## Summary
- Both Frieze View variants (\`FriezePeopleViewController\`, \`hmi/byplace/FriezePlaceViewController\`) show a ControlsFX \`RangeSlider\` that drives \`frieze.setMinDateWindow\`/\`setMaxDateWindow\` — previously on every intermediate drag tick, with no commit boundary
- Wrapping every tick would flood the undo stack, so this gates on the slider's own \`lowValueChangingProperty\`/\`highValueChangingProperty\` (already used elsewhere in the same files via \`isLowValueChanging()\`/\`isHighValueChanging()\`): capture the value when a drag starts, push exactly one \`SimpleCommand\` when it ends, skip pushing anything if the value didn't actually move
- No changes to \`Frieze\` or any other model class — reuses the existing \`setLowValue\`/\`setHighValue\` on the slider itself, whose already-wired property listeners handle propagating into the model and the min/max date labels

This is the same "Frieze View" the user asked about by name — distinct from \`FriezeContentEditorController\` (the "Content Edition View"), whose people/place/stay selection checkboxes and FreeMap create/delete were surveyed and deliberately excluded in earlier PRs (#46) for needing more plumbing than a single commit-point wrap.

Builds on #47 (not yet merged) — based against that branch rather than \`main\`.

## Test plan
- [x] \`mvn -q -o compile\`
- [x] \`mvn -q -o test\` (full suite green)
- [ ] Manual: open Frieze View (people and place variants), drag each end of the time-window slider, confirm Edit ▸ Undo/Redo reverses/reapplies the window and the min/max labels update correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)