### PR TITLE
Clean up leftover TODO in FriezeFreeMap.addFreeMapStay

### DIFF
--- a/src/main/java/com/github/noony/app/timelinefx/core/freemap/FriezeFreeMap.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/freemap/FriezeFreeMap.java
@@ -570,13 +570,7 @@ public final class FriezeFreeMap implements FriezeObject {
         var startDate = freeMapStay.getStartDate();
         createDateHandle(startDate, FreeMapDateHandle.TimeType.START);
         var endDate = freeMapStay.getEndDate();
-        var endDateHandle = endDateHandles.get(endDate);
-        if (endDateHandle == null) {
-            throw new IllegalStateException("Cannot ");
-        }
-        //
-        System.err.println(" TODO FIX MY CODE");
-        //
+        createDateHandle(endDate, FreeMapDateHandle.TimeType.END);
         freeMapPerson.addFreeMapStay(freeMapStay);
     }
 


### PR DESCRIPTION
## Summary
- \`addFreeMapStay\` (used every time a project loads a freemap — its sole caller always passes \`allStays=false\`) had drifted from its sibling method \`addStay\`: the start date used the idempotent \`createDateHandle(...)\` helper, but the end date instead did a strict \`endDateHandles.get(endDate)\` lookup that threw \`IllegalStateException\` on a miss (with an unfinished message, \`"Cannot "\`), computed a handle that was never used for anything afterward, and printed \`" TODO FIX MY CODE"\` to stderr — once per stay, on every project load, for over three years (introduced 2023-03-26).
- Confirmed the fetched handle was genuinely dead: the next call, \`FreeMapPerson.addFreeMapStay\`, works off the stay's own \`getStartPlot()\`/\`getEndPlot()\`, not a date-handle reference passed in from here.
- Fix: align the end-date handling with the start-date handling — just \`createDateHandle(endDate, TimeType.END)\`, result discarded, same as the start date and same as the sibling \`addStay\` method.

## Test plan
- [x] \`mvn -q -o compile\`
- [x] \`mvn -q -o test\` (full suite green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)