### PR TITLE
Make unit tests use the app's logging.properties

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -321,6 +321,15 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <java.util.logging.config.file>${project.build.outputDirectory}/logging.properties</java.util.logging.config.file>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.openjfx</groupId>
                 <artifactId>javafx-maven-plugin</artifactId>
                 <version>0.0.8</version>


### PR DESCRIPTION
## Summary
- \`MainApp\` configures \`java.util.logging.LogManager\` from \`logging.properties\` (handler, level, \`CustomLogFormatter\`) in a static initializer — but that only runs when the \`MainApp\` class gets loaded, which never happens during \`mvn test\`, so tests silently fell back to the JVM's default logging format.
- Point Surefire's forked test JVM at the same properties file via the standard \`java.util.logging.config.file\` system property (\`\${project.build.outputDirectory}/logging.properties\`, i.e. the copy already on the classpath after \`process-resources\`) — no code duplication, no changes to \`MainApp\` itself, tests now get the exact same logging setup as the running app.

## Test plan
- [x] \`mvn -q -o compile\`
- [x] \`mvn -q -o test\` (full suite green; log output now shows \`CustomLogFormatter\`'s format, e.g. \`[2026-08-22 22:44:00] [INFO   ] [TimeLineProject     ] [initFolders         ] ...\`, instead of the JVM default two-line format)

🤖 Generated with [Claude Code](https://claude.com/claude-code)