### PR TITLE
Persist SplitPane divider positions to the .timelines preferences file

### DIFF
--- a/src/main/java/com/github/noony/app/timelinefx/Configuration.java
+++ b/src/main/java/com/github/noony/app/timelinefx/Configuration.java
@@ -28,9 +28,11 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
+import java.util.Arrays;
 import java.util.Properties;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 import jfxtras.styles.jmetro.Style;
 
 /**
@@ -70,6 +72,12 @@ public class Configuration {
     private static final String MINIATURES_FOLDER_PROPERTY_NAME = "MiniaturesFolder";
 
     private static final String THEME_PROPERTY_NAME = "Theme";
+
+    /**
+     * Prefix for the per-{@link javafx.scene.control.SplitPane} divider-position keys, so they don't collide with
+     * unrelated properties.
+     */
+    private static final String SPLIT_PANE_PROPERTY_PREFIX = "SplitPane.";
 
     private static final String DEFAULT_TIMELINES_FOLDER_PATH = System.getProperty("user.home") + File.separator + DEFAULT_PROJECTS_FOLDER_NAME;
 
@@ -200,6 +208,17 @@ public class Configuration {
 
     public static Style getTheme() {
         return Style.valueOf(properties.getProperty(THEME_PROPERTY_NAME));
+    }
+
+    public static double[] getSplitPaneDividerPositions(String key) {
+        var value = properties.getProperty(SPLIT_PANE_PROPERTY_PREFIX + key);
+        return value == null ? null : Arrays.stream(value.split(",")).mapToDouble(Double::parseDouble).toArray();
+    }
+
+    public static void setSplitPaneDividerPositions(String key, double[] positions) {
+        var value = Arrays.stream(positions).mapToObj(Double::toString).collect(Collectors.joining(","));
+        properties.setProperty(SPLIT_PANE_PROPERTY_PREFIX + key, value);
+        savePreferences();
     }
 
     public static void setProjectsParentFolder(String newValue) {

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/ContentEditionViewController.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/ContentEditionViewController.java
@@ -23,6 +23,7 @@ import com.github.noony.app.timelinefx.core.PlaceFactory;
 import com.github.noony.app.timelinefx.core.TimeLineProject;
 import com.github.noony.app.timelinefx.undo.SimpleCommand;
 import com.github.noony.app.timelinefx.undo.UndoManager;
+import com.github.noony.app.timelinefx.utils.SplitPaneDividerPersister;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.io.IOException;
@@ -99,6 +100,7 @@ public final class ContentEditionViewController implements Initializable {
     public void initialize(URL url, ResourceBundle rb) {
         // init
         AppInstanceConfiguration.addPropertyChangeListener(this::handleAppConfigChanges);
+        SplitPaneDividerPersister.bind(splitPane, "ContentEditionSplitPane");
         loadStaysCreationView();
         //
         createButton.setDisable(false);

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/GalleryViewController.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/GalleryViewController.java
@@ -25,6 +25,7 @@ import com.github.noony.app.timelinefx.core.TimeLineProject;
 import com.github.noony.app.timelinefx.undo.SimpleCommand;
 import com.github.noony.app.timelinefx.undo.UndoManager;
 import com.github.noony.app.timelinefx.utils.CustomFileUtils;
+import com.github.noony.app.timelinefx.utils.SplitPaneDividerPersister;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
@@ -49,6 +50,7 @@ import javafx.scene.control.Button;
 import javafx.scene.control.CheckBox;
 import javafx.scene.control.ListView;
 import javafx.scene.control.SelectionMode;
+import javafx.scene.control.SplitPane;
 import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableView;
 import javafx.scene.image.Image;
@@ -77,6 +79,12 @@ public final class GalleryViewController implements Initializable, ViewControlle
     private PictureLoaderViewController pictureLoaderController = null;
 
     @FXML
+    private SplitPane mainSplitPane;
+
+    @FXML
+    private SplitPane tableDetailSplitPane;
+
+    @FXML
     private TableView<Picture> picturesTableView;
 
     @FXML
@@ -99,6 +107,8 @@ public final class GalleryViewController implements Initializable, ViewControlle
     public void initialize(URL url, ResourceBundle rb) {
         LOG.log(Level.INFO, "Loading GalleryViewController");
         // init
+        SplitPaneDividerPersister.bind(mainSplitPane, "GalleryMainSplitPane");
+        SplitPaneDividerPersister.bind(tableDetailSplitPane, "GalleryTableDetailSplitPane");
         AppInstanceConfiguration.addPropertyChangeListener(this::handleAppConfigChanges);
         PictureFactory.addPropertyChangeListener(this::handlePictureFactoryChanges);
         init();

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/PictureLoaderViewController.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/PictureLoaderViewController.java
@@ -29,6 +29,7 @@ import com.github.noony.app.timelinefx.core.PlaceFactory;
 import com.github.noony.app.timelinefx.core.TimeFormat;
 import com.github.noony.app.timelinefx.core.TimeLineProject;
 import com.github.noony.app.timelinefx.utils.MetadataParser;
+import com.github.noony.app.timelinefx.utils.SplitPaneDividerPersister;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
@@ -49,6 +50,7 @@ import javafx.fxml.Initializable;
 import javafx.scene.control.Button;
 import javafx.scene.control.ChoiceBox;
 import javafx.scene.control.SelectionMode;
+import javafx.scene.control.SplitPane;
 import javafx.scene.control.TextField;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
@@ -69,6 +71,9 @@ public final class PictureLoaderViewController implements Initializable, ViewCon
     private static final Logger LOG = Logger.getGlobal();
 
     private final PropertyChangeSupport propertyChangeSupport = new PropertyChangeSupport(PictureLoaderViewController.this);
+
+    @FXML
+    private SplitPane splitPane;
 
     @FXML
     private TextField fileField;
@@ -102,6 +107,7 @@ public final class PictureLoaderViewController implements Initializable, ViewCon
     @Override
     public void initialize(URL url, ResourceBundle rb) {
         LOG.log(Level.INFO, "Loading PictureLoaderViewController");
+        SplitPaneDividerPersister.bind(splitPane, "PictureLoaderSplitPane");
         AppInstanceConfiguration.addPropertyChangeListener(this::handleAppConfigChanges);
         peopleCheckListView.getSelectionModel().setSelectionMode(SelectionMode.MULTIPLE);
         placesCheckListView.getSelectionModel().setSelectionMode(SelectionMode.MULTIPLE);

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/PicturesChronologyViewController.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/PicturesChronologyViewController.java
@@ -30,6 +30,7 @@ import com.github.noony.app.timelinefx.core.picturechronology.PictureChronologyF
 import com.github.noony.app.timelinefx.drawings.GalleryTiles;
 import com.github.noony.app.timelinefx.drawings.IFxScalableNode;
 import com.github.noony.app.timelinefx.hmi.picturechronology.PictureChronologyDrawing;
+import com.github.noony.app.timelinefx.utils.SplitPaneDividerPersister;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
@@ -84,6 +85,8 @@ public final class PicturesChronologyViewController implements Initializable {
     @FXML
     private ListView<PictureChronology> chronologiesListView;
     @FXML
+    private SplitPane mainSplitPane;
+    @FXML
     private SplitPane leftSplitPane;
     @FXML
     private ScrollPane picturesPane, portraitsPane;
@@ -111,6 +114,8 @@ public final class PicturesChronologyViewController implements Initializable {
     @Override
     public void initialize(URL url, ResourceBundle rb) {
         // init
+        SplitPaneDividerPersister.bind(mainSplitPane, "ChronologyMainSplitPane");
+        SplitPaneDividerPersister.bind(leftSplitPane, "ChronologyLeftSplitPane");
         AppInstanceConfiguration.addPropertyChangeListener(this::handleAppConfigChanges);
         PictureFactory.addPropertyChangeListener(this::handlePictureFactoryChanges);
         PortraitFactory.addPropertyChangeListener(this::handlePortraitFactoryChanges);

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/freemap/FreeMapViewController.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/freemap/FreeMapViewController.java
@@ -26,6 +26,7 @@ import com.github.noony.app.timelinefx.hmi.PortraitSelectionViewController;
 import com.github.noony.app.timelinefx.undo.SimpleCommand;
 import com.github.noony.app.timelinefx.undo.UndoManager;
 import com.github.noony.app.timelinefx.utils.PngExporter;
+import com.github.noony.app.timelinefx.utils.SplitPaneDividerPersister;
 import java.beans.PropertyChangeEvent;
 import java.io.File;
 import java.io.IOException;
@@ -44,6 +45,7 @@ import javafx.scene.control.CheckBox;
 import javafx.scene.control.ColorPicker;
 import javafx.scene.control.Label;
 import javafx.scene.control.ScrollPane;
+import javafx.scene.control.SplitPane;
 import javafx.scene.control.TextField;
 import javafx.scene.layout.AnchorPane;
 import javafx.scene.paint.Color;
@@ -60,6 +62,9 @@ public class FreeMapViewController implements Initializable {
 
     @FXML
     private ScrollPane viewScrollPane;
+
+    @FXML
+    private SplitPane splitPane;
 
     @FXML
     private AnchorPane viewRootPane;
@@ -106,6 +111,7 @@ public class FreeMapViewController implements Initializable {
 
     @Override
     public void initialize(URL url, ResourceBundle rb) {
+        SplitPaneDividerPersister.bind(splitPane, "FreeMapPropertiesSplitPane");
         timeHandleVisibilityCB.setSelected(true);
         timeHandleVisibilityCB.selectedProperty().addListener((ObservableValue<? extends Boolean> ov, Boolean t, Boolean t1) -> {
             if (friezeFreeFormDrawing != null) {

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/frieze/FriezeContentEditorController.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/frieze/FriezeContentEditorController.java
@@ -31,6 +31,7 @@ import com.github.noony.app.timelinefx.hmi.StageFactory;
 import com.github.noony.app.timelinefx.hmi.byplace.FriezePlaceViewController;
 import com.github.noony.app.timelinefx.hmi.freemap.FreeMapListCellImpl;
 import com.github.noony.app.timelinefx.hmi.freemap.FreeMapView;
+import com.github.noony.app.timelinefx.utils.SplitPaneDividerPersister;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.io.IOException;
@@ -54,6 +55,7 @@ import javafx.scene.control.Button;
 import javafx.scene.control.CheckBoxTreeItem;
 import javafx.scene.control.ListView;
 import javafx.scene.control.SelectionMode;
+import javafx.scene.control.SplitPane;
 import javafx.scene.control.Tab;
 import javafx.scene.control.TabPane;
 import javafx.scene.control.TextField;
@@ -73,6 +75,9 @@ public class FriezeContentEditorController implements Initializable {
 
     @FXML
     private TabPane tabPane;
+
+    @FXML
+    private SplitPane contentSplitPane;
 
     @FXML
     private TextField nameField;
@@ -124,6 +129,7 @@ public class FriezeContentEditorController implements Initializable {
     @Override
     public void initialize(final URL url, final ResourceBundle rb) {
         //
+        SplitPaneDividerPersister.bind(contentSplitPane, "FriezeContentEditorSplitPane");
         tabPane.getStyleClass().add(JMetroStyleClass.BACKGROUND);
         //
         freemapTabs = new HashMap<>();

--- a/src/main/java/com/github/noony/app/timelinefx/utils/SplitPaneDividerPersister.java
+++ b/src/main/java/com/github/noony/app/timelinefx/utils/SplitPaneDividerPersister.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2026 NoOnY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.github.noony.app.timelinefx.utils;
+
+import com.github.noony.app.timelinefx.Configuration;
+import javafx.animation.PauseTransition;
+import javafx.scene.control.SplitPane;
+import javafx.util.Duration;
+
+/**
+ * Restores a {@link SplitPane}'s divider positions from {@link Configuration}, then keeps them in sync as the
+ * user drags them.
+ *
+ * @author hamon
+ */
+public final class SplitPaneDividerPersister {
+
+    /**
+     * How long to wait after the last divider move before persisting, so a drag gesture writes once.
+     */
+    private static final Duration SAVE_DELAY = Duration.millis(300);
+
+    private SplitPaneDividerPersister() {
+        // private utility constructor
+    }
+
+    /**
+     * Applies any previously saved divider positions to {@code splitPane}, then persists further changes under
+     * {@code key} (debounced, so a drag gesture writes to disk once, not on every pixel moved).
+     *
+     * @param splitPane the split pane to restore and track
+     * @param key a key unique across the whole application
+     */
+    public static void bind(final SplitPane splitPane, final String key) {
+        final var savedPositions = Configuration.getSplitPaneDividerPositions(key);
+        if (savedPositions != null) {
+            splitPane.setDividerPositions(savedPositions);
+        }
+        final var saveDelay = new PauseTransition(SAVE_DELAY);
+        saveDelay.setOnFinished(event -> Configuration.setSplitPaneDividerPositions(key, splitPane.getDividerPositions()));
+        splitPane.getDividers().forEach(divider -> divider.positionProperty().addListener((ov, oldValue, newValue) -> saveDelay.playFromStart()));
+    }
+
+}

--- a/src/main/resources/com/github/noony/app/timelinefx/hmi/GalleryView.fxml
+++ b/src/main/resources/com/github/noony/app/timelinefx/hmi/GalleryView.fxml
@@ -15,11 +15,11 @@
 
 <AnchorPane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="400.0" prefWidth="600.0" xmlns="http://javafx.com/javafx/16" xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.github.noony.app.timelinefx.hmi.GalleryViewController">
    <children>
-      <SplitPane dividerPositions="0.6202749140893471" layoutX="253.0" layoutY="84.0" prefHeight="160.0" prefWidth="200.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
+      <SplitPane fx:id="mainSplitPane" dividerPositions="0.6202749140893471" layoutX="253.0" layoutY="84.0" prefHeight="160.0" prefWidth="200.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
         <items>
           <AnchorPane minHeight="0.0" minWidth="0.0" prefWidth="304.0">
                <children>
-                  <SplitPane dividerPositions="0.7" layoutX="-58.0" layoutY="-56.0" orientation="VERTICAL" prefHeight="200.0" prefWidth="160.0" AnchorPane.bottomAnchor="8.0" AnchorPane.leftAnchor="8.0" AnchorPane.rightAnchor="8.0" AnchorPane.topAnchor="8.0">
+                  <SplitPane fx:id="tableDetailSplitPane" dividerPositions="0.7" layoutX="-58.0" layoutY="-56.0" orientation="VERTICAL" prefHeight="200.0" prefWidth="160.0" AnchorPane.bottomAnchor="8.0" AnchorPane.leftAnchor="8.0" AnchorPane.rightAnchor="8.0" AnchorPane.topAnchor="8.0">
                     <items>
                       <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="100.0" prefWidth="160.0">
                            <children>

--- a/src/main/resources/com/github/noony/app/timelinefx/hmi/PictureLoaderView.fxml
+++ b/src/main/resources/com/github/noony/app/timelinefx/hmi/PictureLoaderView.fxml
@@ -51,7 +51,7 @@
                </VBox.margin>
             </GridPane>
             <Separator prefWidth="200.0" />
-            <SplitPane dividerPositions="0.5, 0.5" VBox.vgrow="SOMETIMES">
+            <SplitPane fx:id="splitPane" dividerPositions="0.5, 0.5" VBox.vgrow="SOMETIMES">
               <items>
                   <VBox spacing="8.0">
                      <children>

--- a/src/main/resources/com/github/noony/app/timelinefx/hmi/PicturesChronologyView.fxml
+++ b/src/main/resources/com/github/noony/app/timelinefx/hmi/PicturesChronologyView.fxml
@@ -13,7 +13,7 @@
 <?import javafx.scene.layout.VBox?>
 <?import javafx.scene.text.Font?>
 
-<SplitPane dividerPositions="0.3611738148984199" xmlns="http://javafx.com/javafx/19" xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.github.noony.app.timelinefx.hmi.PicturesChronologyViewController">
+<SplitPane fx:id="mainSplitPane" dividerPositions="0.3611738148984199" xmlns="http://javafx.com/javafx/19" xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.github.noony.app.timelinefx.hmi.PicturesChronologyViewController">
    <items>
       <SplitPane fx:id="leftSplitPane" dividerPositions="0.5" orientation="VERTICAL">
          <items>

--- a/src/main/resources/com/github/noony/app/timelinefx/hmi/freemap/FreeMapView.fxml
+++ b/src/main/resources/com/github/noony/app/timelinefx/hmi/freemap/FreeMapView.fxml
@@ -19,7 +19,7 @@
 
 <AnchorPane id="AnchorPane" prefWidth="1200.0" xmlns="http://javafx.com/javafx/20.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.github.noony.app.timelinefx.hmi.freemap.FreeMapViewController">
     <children>
-        <SplitPane dividerPositions="0.3" layoutX="37.0" layoutY="22.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
+        <SplitPane fx:id="splitPane" dividerPositions="0.3" layoutX="37.0" layoutY="22.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
             <items>
             <VBox spacing="8.0">
                <children>

--- a/src/main/resources/com/github/noony/app/timelinefx/hmi/frieze/FriezeContentEditor.fxml
+++ b/src/main/resources/com/github/noony/app/timelinefx/hmi/frieze/FriezeContentEditor.fxml
@@ -83,7 +83,7 @@
           </Tab>
           <Tab text="Frieze's content">
             <content>
-                  <SplitPane dividerPositions="0.2, 0.5">
+                  <SplitPane fx:id="contentSplitPane" dividerPositions="0.2, 0.5">
                      <items>
                       <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="180.0" prefWidth="200.0">
                            <children>


### PR DESCRIPTION
## Summary
- Adds \`SplitPaneDividerPersister.bind(SplitPane, key)\`, a small reusable helper: restores a saved divider position from \`Configuration\` when a view opens, then keeps it in sync as the user drags — debounced via \`PauseTransition\` (300ms) so a drag gesture writes to disk once, not on every pixel moved.
- \`Configuration.java\` gets one generic \`getSplitPaneDividerPositions(key)\`/\`setSplitPaneDividerPositions(key, double[])\` pair (comma-joined string under a namespaced key), rather than 8 near-duplicate named settings — nothing outside the owning \`SplitPane\` needs to react to a divider moving, unlike e.g. the theme setting.
- Wired into all 8 \`SplitPane\`s across the 6 active FXML/controller pairs that have them: \`ContentEditionView\`, \`freemap/FreeMapView\`, \`GalleryView\` (2 nested panes), \`frieze/FriezeContentEditor\`, \`PictureLoaderView\`, \`PicturesChronologyView\` (2 panes) — adding an \`fx:id\` where one didn't already exist.
- \`FriezeView.fxml\`/\`FriezeViewController\` is excluded: the controller class doesn't exist anywhere in the repo and the FXML is never loaded — dead code, not something to wire persistence into.

## Test plan
- [x] \`mvn -q -o compile\`
- [x] \`mvn -q -o test\` (full suite green)
- [x] All 5 edited FXML files verified well-formed XML
- [x] Manual: open each of the 6 views, drag a divider, close and relaunch the app, confirm the divider reopens at the dragged position

🤖 Generated with [Claude Code](https://claude.com/claude-code)