### PR TITLE
Display project/frieze date ranges and add frieze date constraints

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -323,6 +323,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.5.6</version>
                 <configuration>
                     <systemPropertyVariables>
                         <java.util.logging.config.file>${project.build.outputDirectory}/logging.properties</java.util.logging.config.file>

--- a/src/main/java/com/github/noony/app/timelinefx/core/AbstractPicture.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/AbstractPicture.java
@@ -14,7 +14,6 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-
 package com.github.noony.app.timelinefx.core;
 
 import com.github.noony.app.timelinefx.utils.MathUtils;
@@ -110,7 +109,7 @@ public abstract class AbstractPicture implements IPicture {
         filePath = aFilePath;
         //
         timeFormat = TimeFormat.LOCAL_TIME;
-        date = aDate != null ? aDate : LocalDate.MIN;
+        date = aDate != null ? aDate : LocalDate.EPOCH;
         timestamp = -1;
         //
         name = aName;
@@ -133,11 +132,13 @@ public abstract class AbstractPicture implements IPicture {
         name = aName;
     }
 
-    @Override public long getId() {
+    @Override
+    public long getId() {
         return id;
     }
 
-    @Override public String getName() {
+    @Override
+    public String getName() {
         return name;
     }
 
@@ -217,6 +218,7 @@ public abstract class AbstractPicture implements IPicture {
     @Override
     public void setTimeFormat(final TimeFormat aTimeFormat) {
         timeFormat = aTimeFormat;
+        System.err.println(" changing time format for " + getName() + " ==> " + aTimeFormat);
         switch (timeFormat) {
             case LOCAL_TIME ->
                 propertyChangeSupport.firePropertyChange(DATE_CHANGED, timeFormat, date);

--- a/src/main/java/com/github/noony/app/timelinefx/core/AbstractPicture.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/AbstractPicture.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.core;
 
 import com.github.noony.app.timelinefx.utils.MathUtils;
@@ -109,7 +110,11 @@ public abstract class AbstractPicture implements IPicture {
         filePath = aFilePath;
         //
         timeFormat = TimeFormat.LOCAL_TIME;
-        date = aDate != null ? aDate : LocalDate.EPOCH;
+        if (aDate != null) {
+            date = aDate;
+        } else {
+            date = LocalDate.EPOCH;
+        }
         timestamp = -1;
         //
         name = aName;

--- a/src/main/java/com/github/noony/app/timelinefx/core/AbstractPicture.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/AbstractPicture.java
@@ -223,7 +223,6 @@ public abstract class AbstractPicture implements IPicture {
     @Override
     public void setTimeFormat(final TimeFormat aTimeFormat) {
         timeFormat = aTimeFormat;
-        System.err.println(" changing time format for " + getName() + " ==> " + aTimeFormat);
         switch (timeFormat) {
             case LOCAL_TIME ->
                 propertyChangeSupport.firePropertyChange(DATE_CHANGED, timeFormat, date);

--- a/src/main/java/com/github/noony/app/timelinefx/core/Frieze.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/Frieze.java
@@ -762,7 +762,7 @@ public final class Frieze implements FriezeObject {
             case TimeLineProject.HIGH_LEVEL_PLACE_ADDED, TimeLineProject.PLACE_ADDED -> {
                 // Nothing to do
             }
-            case TimeLineProject.PERSON_ADDED, TimeLineProject.STAY_ADDED -> {
+            case TimeLineProject.PERSON_ADDED, TimeLineProject.STAY_ADDED, TimeLineProject.TIME_FORMAT_CHANGED -> {
                 // Nothing to do
             }
             //            case TimeLineProject.STAY_ADDED ->

--- a/src/main/java/com/github/noony/app/timelinefx/core/Frieze.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/Frieze.java
@@ -663,7 +663,7 @@ public final class Frieze implements FriezeObject {
      * @param newMinDateWindow the new earliest visible date
      */
     public void setMinDateWindow(final double newMinDateWindow) {
-        minDateWindow = newMinDateWindow;
+        minDateWindow = Math.max(newMinDateWindow, constraintMinDate);
         propertyChangeSupport.firePropertyChange(DATE_WINDOW_CHANGED, minDateWindow, maxDateWindow);
     }
 
@@ -671,8 +671,76 @@ public final class Frieze implements FriezeObject {
      * @param newMaxDateWindow the new latest visible date
      */
     public void setMaxDateWindow(final double newMaxDateWindow) {
-        maxDateWindow = newMaxDateWindow;
+        maxDateWindow = Math.min(newMaxDateWindow, constraintMaxDate);
         propertyChangeSupport.firePropertyChange(DATE_WINDOW_CHANGED, minDateWindow, maxDateWindow);
+    }
+
+    /**
+     * @return whether the visible date window's lower bound is currently constrained
+     */
+    public boolean isMinDateConstrained() {
+        return constraintMinDate != Double.NEGATIVE_INFINITY;
+    }
+
+    /**
+     * @return whether the visible date window's upper bound is currently constrained
+     */
+    public boolean isMaxDateConstrained() {
+        return constraintMaxDate != Double.POSITIVE_INFINITY;
+    }
+
+    /**
+     * @return the lowest date allowed in the visible date window
+     */
+    public double getConstraintMinDate() {
+        return constraintMinDate;
+    }
+
+    /**
+     * @return the highest date allowed in the visible date window
+     */
+    public double getConstraintMaxDate() {
+        return constraintMaxDate;
+    }
+
+    /**
+     * Constrains the visible date window to never go below the given date, pushing the current window's
+     * lower bound up to it if needed.
+     *
+     * @param newConstraintMinDate the new lowest date allowed in the visible date window
+     */
+    public void setConstraintMinDate(final double newConstraintMinDate) {
+        constraintMinDate = newConstraintMinDate;
+        if (minDateWindow < constraintMinDate) {
+            setMinDateWindow(constraintMinDate);
+        }
+    }
+
+    /**
+     * Constrains the visible date window to never go above the given date, pulling the current window's
+     * upper bound down to it if needed.
+     *
+     * @param newConstraintMaxDate the new highest date allowed in the visible date window
+     */
+    public void setConstraintMaxDate(final double newConstraintMaxDate) {
+        constraintMaxDate = newConstraintMaxDate;
+        if (maxDateWindow > constraintMaxDate) {
+            setMaxDateWindow(constraintMaxDate);
+        }
+    }
+
+    /**
+     * Removes the lower-bound constraint on the visible date window.
+     */
+    public void clearConstraintMinDate() {
+        constraintMinDate = Double.NEGATIVE_INFINITY;
+    }
+
+    /**
+     * Removes the upper-bound constraint on the visible date window.
+     */
+    public void clearConstraintMaxDate() {
+        constraintMaxDate = Double.POSITIVE_INFINITY;
     }
 
     /**

--- a/src/main/java/com/github/noony/app/timelinefx/core/IDateObject.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/IDateObject.java
@@ -41,7 +41,7 @@ public interface IDateObject {
     /**
      * The default date.
      */
-    final LocalDate DEFAULT_DATE = LocalDate.EPOCH;
+    LocalDate DEFAULT_DATE = LocalDate.EPOCH;
 
     /**
      * The default time stamp.

--- a/src/main/java/com/github/noony/app/timelinefx/core/IDateObject.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/IDateObject.java
@@ -41,7 +41,7 @@ public interface IDateObject {
     /**
      * The default date.
      */
-    LocalDate DEFAULT_DATE = LocalDate.EPOCH;
+    final LocalDate DEFAULT_DATE = LocalDate.EPOCH;
 
     /**
      * The default time stamp.

--- a/src/main/java/com/github/noony/app/timelinefx/core/IDateObject.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/IDateObject.java
@@ -22,8 +22,7 @@ import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 
 /**
- * Contract for objects holding a date/time value that can be represented either as a
- * calendar date or as a raw numeric timestamp.
+ * Contract for objects holding a date/time value that can be represented either as a calendar date or as a raw numeric timestamp.
  *
  * @author hamon
  */
@@ -38,6 +37,11 @@ public interface IDateObject {
      * Formatter used to parse/format date-time values.
      */
     DateTimeFormatter DEFAULT_DATE_TIME_FORMATTER = DateTimeFormatter.ISO_DATE_TIME;
+
+    /**
+     * The default date.
+     */
+    LocalDate DEFAULT_DATE = LocalDate.EPOCH;
 
     /**
      * The default time stamp.
@@ -62,8 +66,7 @@ public interface IDateObject {
 
     /**
      *
-     * @return the instance date value, or null if not set or if the time format is
-     *         not compatible
+     * @return the instance date value, or null if not set or if the time format is not compatible
      */
     LocalDate getDate();
 
@@ -99,8 +102,7 @@ public interface IDateObject {
 
     /**
      *
-     * @return an absolute time value to compare dateObjects no matter their time
-     *         format
+     * @return an absolute time value to compare dateObjects no matter their time format
      */
     double getAbsoluteTime();
 

--- a/src/main/java/com/github/noony/app/timelinefx/core/PortraitFactory.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/PortraitFactory.java
@@ -166,11 +166,11 @@ public final class PortraitFactory {
         Portrait portrait;
         switch (person.getProject().getTimeFormat()) {
             case LOCAL_TIME -> {
-                final var date = picInfo.getCreationDate() == null ? picInfo.getCreationDate().toLocalDate() : IDateObject.DEFAULT_DATE;
+                final var date = picInfo.getCreationDate() == null ? IDateObject.DEFAULT_DATE : picInfo.getCreationDate().toLocalDate();
                 portrait = new Portrait(id, person, filePath, picInfo.getWidth(), picInfo.getHeight(), date);
             }
             case TIME_MIN -> {
-                final var time = picInfo.getCreationDate() == null ? picInfo.getCreationDate().toLocalDate().toEpochDay() : IDateObject.DEFAULT_TIMESTAMP;
+                final var time = picInfo.getCreationDate() == null ? IDateObject.DEFAULT_TIMESTAMP : picInfo.getCreationDate().toLocalDate().toEpochDay();
                 portrait = new Portrait(id, person, filePath, picInfo.getWidth(), picInfo.getHeight(), time);
             }
             default ->

--- a/src/main/java/com/github/noony/app/timelinefx/core/PortraitFactory.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/PortraitFactory.java
@@ -17,15 +17,16 @@
 
 package com.github.noony.app.timelinefx.core;
 
-import static com.github.noony.app.timelinefx.core.TimeFormat.LOCAL_TIME;
-import static com.github.noony.app.timelinefx.core.TimeFormat.TIME_MIN;
 import com.github.noony.app.timelinefx.utils.CustomFileUtils;
 import com.github.noony.app.timelinefx.utils.MetadataParser;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
 import java.io.File;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.logging.Logger;
+import static com.github.noony.app.timelinefx.core.TimeFormat.LOCAL_TIME;
+import static com.github.noony.app.timelinefx.core.TimeFormat.TIME_MIN;
 
 /**
  * Entry point for creating and retrieving {@link Portrait} instances.
@@ -158,19 +159,29 @@ public final class PortraitFactory {
     }
 
 
-    private static Portrait createPortraitImpl(Person person, PictureInfo picInfo, String filePath){
+    private static Portrait createPortraitImpl(final Person person, final PictureInfo picInfo, final String filePath) {
         return createPortraitImpl(FACTORY.getNextID(), person, picInfo, filePath);
     }
 
-    private static Portrait createPortraitImpl(long id, Person person, PictureInfo picInfo, String filePath){
+    private static Portrait createPortraitImpl(final long id, final Person person, final PictureInfo picInfo, final String filePath) {
         Portrait portrait;
         switch (person.getProject().getTimeFormat()) {
             case LOCAL_TIME -> {
-                final var date = picInfo.getCreationDate() == null ? IDateObject.DEFAULT_DATE : picInfo.getCreationDate().toLocalDate();
+                final LocalDate date;
+                if (picInfo.getCreationDate() == null) {
+                    date = IDateObject.DEFAULT_DATE;
+                } else {
+                    date = picInfo.getCreationDate().toLocalDate();
+                }
                 portrait = new Portrait(id, person, filePath, picInfo.getWidth(), picInfo.getHeight(), date);
             }
             case TIME_MIN -> {
-                final var time = picInfo.getCreationDate() == null ? IDateObject.DEFAULT_TIMESTAMP : picInfo.getCreationDate().toLocalDate().toEpochDay();
+                final long time;
+                if (picInfo.getCreationDate() == null) {
+                    time = IDateObject.DEFAULT_TIMESTAMP;
+                } else {
+                    time = picInfo.getCreationDate().toLocalDate().toEpochDay();
+                }
                 portrait = new Portrait(id, person, filePath, picInfo.getWidth(), picInfo.getHeight(), time);
             }
             default ->

--- a/src/main/java/com/github/noony/app/timelinefx/core/PortraitFactory.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/PortraitFactory.java
@@ -17,6 +17,8 @@
 
 package com.github.noony.app.timelinefx.core;
 
+import static com.github.noony.app.timelinefx.core.TimeFormat.LOCAL_TIME;
+import static com.github.noony.app.timelinefx.core.TimeFormat.TIME_MIN;
 import com.github.noony.app.timelinefx.utils.CustomFileUtils;
 import com.github.noony.app.timelinefx.utils.MetadataParser;
 import java.beans.PropertyChangeListener;
@@ -86,7 +88,7 @@ public final class PortraitFactory {
         final var file = new File(filePath);
         final var picInfo = MetadataParser.parseMetadata(person.getProject(), file);
         assert picInfo != null;
-        final var portrait = new Portrait(FACTORY.getNextID(), person, fileRelativePath, picInfo.getWidth(), picInfo.getHeight());
+        final var portrait = createPortraitImpl(person, picInfo, fileRelativePath);
         FACTORY.addObject(portrait);
         PROPERTY_CHANGE_SUPPORT.firePropertyChange(PORTRAIT_CREATED, null, portrait);
         return portrait;
@@ -104,7 +106,7 @@ public final class PortraitFactory {
         final var file = new File(CustomFileUtils.fromProjectRelativeToAbsolute(person.getProject(), filePath));
         final var picInfo = MetadataParser.parseMetadata(person.getProject(), file);
         assert picInfo != null;
-        final var portrait = new Portrait(FACTORY.getNextID(), person, filePath, picInfo.getWidth(), picInfo.getHeight());
+        final var portrait = createPortraitImpl(person, picInfo, filePath);
         FACTORY.addObject(portrait);
         PROPERTY_CHANGE_SUPPORT.firePropertyChange(PORTRAIT_CREATED, null, portrait);
         return portrait;
@@ -128,7 +130,7 @@ public final class PortraitFactory {
             throw new IllegalArgumentException("Trying to create portrait for " + person + " with missing file=" + filePath);
         }
         var picInfo = MetadataParser.parseMetadata(person.getProject(), file);
-        final var portrait = new Portrait(id, person, filePath, picInfo.getWidth(), picInfo.getHeight());
+        final var portrait = createPortraitImpl(id, person, picInfo, filePath);
         FACTORY.addObject(portrait);
         PROPERTY_CHANGE_SUPPORT.firePropertyChange(PORTRAIT_CREATED, null, portrait);
         return portrait;
@@ -153,6 +155,28 @@ public final class PortraitFactory {
      */
     public static void removePropertyChangeListener(final PropertyChangeListener listener) {
         PROPERTY_CHANGE_SUPPORT.removePropertyChangeListener(listener);
+    }
+
+
+    private static Portrait createPortraitImpl(Person person, PictureInfo picInfo, String filePath){
+        return createPortraitImpl(FACTORY.getNextID(), person, picInfo, filePath);
+    }
+
+    private static Portrait createPortraitImpl(long id, Person person, PictureInfo picInfo, String filePath){
+        Portrait portrait;
+        switch (person.getProject().getTimeFormat()) {
+            case LOCAL_TIME -> {
+                final var date = picInfo.getCreationDate() == null ? picInfo.getCreationDate().toLocalDate() : IDateObject.DEFAULT_DATE;
+                portrait = new Portrait(id, person, filePath, picInfo.getWidth(), picInfo.getHeight(), date);
+            }
+            case TIME_MIN -> {
+                final var time = picInfo.getCreationDate() == null ? picInfo.getCreationDate().toLocalDate().toEpochDay() : IDateObject.DEFAULT_TIMESTAMP;
+                portrait = new Portrait(id, person, filePath, picInfo.getWidth(), picInfo.getHeight(), time);
+            }
+            default ->
+                throw new AssertionError();
+        }
+        return portrait;
     }
 
 }

--- a/src/main/java/com/github/noony/app/timelinefx/core/PortraitFactory.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/PortraitFactory.java
@@ -164,7 +164,7 @@ public final class PortraitFactory {
     }
 
     private static Portrait createPortraitImpl(final long id, final Person person, final PictureInfo picInfo, final String filePath) {
-        Portrait portrait;
+        final Portrait portrait;
         switch (person.getProject().getTimeFormat()) {
             case LOCAL_TIME -> {
                 final LocalDate date;

--- a/src/main/java/com/github/noony/app/timelinefx/core/TimeLineProject.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/TimeLineProject.java
@@ -481,6 +481,20 @@ public final class TimeLineProject {
         return Collections.unmodifiableList(stays);
     }
 
+    /**
+     * @return the earliest start date across every stay in the project, or {@code 0} if it has no stays
+     */
+    public double getMinDate() {
+        return stays.stream().mapToDouble(StayPeriod::getStartDate).min().orElse(0);
+    }
+
+    /**
+     * @return the latest end date across every stay in the project, or {@code 0} if it has no stays
+     */
+    public double getMaxDate() {
+        return stays.stream().mapToDouble(StayPeriod::getEndDate).max().orElse(0);
+    }
+
     protected boolean addFrieze(final Frieze frieze) {
         if (!friezes.contains(frieze)) {
             frieze.addListener(this::handleFriezeChange);

--- a/src/main/java/com/github/noony/app/timelinefx/core/TimeLineProject.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/TimeLineProject.java
@@ -115,6 +115,11 @@ public final class TimeLineProject {
     public static final String PORTRAIT_FOLDER_KEY = "portraitsFolderKey";
 
     /**
+     * Configuration key for the project's time format.
+     */
+    public static final String TIME_FORMAT_KEY = "timeFormatKey";
+
+    /**
      * Default portraits folder name, relative to the project folder.
      */
     public static final String DEFAULT_PORTRAIT_FOLDER = "portraits";
@@ -213,9 +218,22 @@ public final class TimeLineProject {
     /**
      * The time format used for stays created in this project.
      */
-    private TimeFormat timeFormat = TimeFormat.LOCAL_TIME;
+    private TimeFormat timeFormat;
 
+    /**
+     * @param projectName the project's name
+     * @param configParams optional configuration overrides (folder locations, etc.)
+     */
     protected TimeLineProject(final String projectName, final Map<String, String> configParams) {
+        this(projectName, configParams, TimeFormat.LOCAL_TIME);
+    }
+
+    /**
+     * @param projectName the project's name
+     * @param configParams optional configuration overrides (folder locations, etc.)
+     * @param aTimeFormat the time format to use for stays created in this project
+     */
+    protected TimeLineProject(final String projectName, final Map<String, String> configParams, final TimeFormat aTimeFormat) {
         name = projectName;
         initFolders(configParams);
         propertyChangeSupport = new PropertyChangeSupport(TimeLineProject.this);
@@ -225,6 +243,7 @@ public final class TimeLineProject {
         stays = new LinkedList<>();
         friezes = new LinkedList<>();
         pictureChronologies = new LinkedList<>();
+        timeFormat = aTimeFormat;
     }
 
     private void initFolders(final Map<String, String> configParams) {

--- a/src/main/java/com/github/noony/app/timelinefx/core/TimeLineProject.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/TimeLineProject.java
@@ -82,6 +82,11 @@ public final class TimeLineProject {
      * Name of the property change event fired when a stay is removed.
      */
     public static final String STAY_REMOVED = "stayRemoved";
+
+    /**
+     * Name of the property change event fired when the project's time format changes.
+     */
+    public static final String TIME_FORMAT_CHANGED = "timeFormatChanged";
     //
 
     /**
@@ -204,6 +209,11 @@ public final class TimeLineProject {
      * The picture chronologies built from this project.
      */
     private final List<PictureChronology> pictureChronologies;
+
+    /**
+     * The time format used for stays created in this project.
+     */
+    private TimeFormat timeFormat = TimeFormat.LOCAL_TIME;
 
     protected TimeLineProject(final String projectName, final Map<String, String> configParams) {
         name = projectName;
@@ -367,6 +377,21 @@ public final class TimeLineProject {
      */
     public String getName() {
         return name;
+    }
+
+    /**
+     * @return the time format used for stays created in this project
+     */
+    public TimeFormat getTimeFormat() {
+        return timeFormat;
+    }
+
+    /**
+     * @param newTimeFormat the new time format to use for stays created in this project
+     */
+    public void setTimeFormat(final TimeFormat newTimeFormat) {
+        timeFormat = newTimeFormat;
+        propertyChangeSupport.firePropertyChange(TIME_FORMAT_CHANGED, this, timeFormat);
     }
 
     /**

--- a/src/main/java/com/github/noony/app/timelinefx/core/TimeLineProjectFactory.java
+++ b/src/main/java/com/github/noony/app/timelinefx/core/TimeLineProjectFactory.java
@@ -49,7 +49,19 @@ public final class TimeLineProjectFactory {
      * @return the created project
      */
     public static TimeLineProject createProject(final String name, final Map<String, String> configParams) {
-        final TimeLineProject timeLineProject = new TimeLineProject(name, configParams);
+        return createProject(name, configParams, TimeFormat.LOCAL_TIME);
+    }
+
+    /**
+     * Creates a new, empty project with an explicit time format.
+     *
+     * @param name the project's name
+     * @param configParams optional configuration overrides (folder locations, etc.)
+     * @param timeFormat the time format to use for stays created in this project
+     * @return the created project
+     */
+    public static TimeLineProject createProject(final String name, final Map<String, String> configParams, final TimeFormat timeFormat) {
+        final TimeLineProject timeLineProject = new TimeLineProject(name, configParams, timeFormat);
         FriezeObjectFactory.reset();
         return timeLineProject;
     }

--- a/src/main/java/com/github/noony/app/timelinefx/examples/StarWars.java
+++ b/src/main/java/com/github/noony/app/timelinefx/examples/StarWars.java
@@ -27,6 +27,7 @@ import com.github.noony.app.timelinefx.core.PlaceLevel;
 import com.github.noony.app.timelinefx.core.PortraitFactory;
 import com.github.noony.app.timelinefx.core.StayFactory;
 import com.github.noony.app.timelinefx.core.StayPeriod;
+import com.github.noony.app.timelinefx.core.TimeFormat;
 import com.github.noony.app.timelinefx.core.TimeLineProject;
 import com.github.noony.app.timelinefx.core.TimeLineProjectFactory;
 import java.io.File;
@@ -97,7 +98,7 @@ public class StarWars {
         Map<String, String> configParams = Map.of(
                 TimeLineProject.PROJECT_FOLDER_KEY, projectFolderPath
         );
-        var timeLineProject = TimeLineProjectFactory.createProject("Star Wars", configParams);
+        var timeLineProject = TimeLineProjectFactory.createProject("Star Wars", configParams, TimeFormat.TIME_MIN);
         //
         var pictureFolder = timeLineProject.getPortraitsAbsoluteFolder();
         for (var picName : RESOURCES) {

--- a/src/main/java/com/github/noony/app/timelinefx/examples/TestExample.java
+++ b/src/main/java/com/github/noony/app/timelinefx/examples/TestExample.java
@@ -26,6 +26,7 @@ import com.github.noony.app.timelinefx.core.PlaceFactory;
 import com.github.noony.app.timelinefx.core.PlaceLevel;
 import com.github.noony.app.timelinefx.core.StayFactory;
 import com.github.noony.app.timelinefx.core.StayPeriodSimpleTime;
+import com.github.noony.app.timelinefx.core.TimeFormat;
 import com.github.noony.app.timelinefx.core.TimeLineProject;
 import com.github.noony.app.timelinefx.core.TimeLineProjectFactory;
 import java.io.File;
@@ -44,7 +45,7 @@ public class TestExample {
         Map<String, String> configParams = Map.of(
                 TimeLineProject.PROJECT_FOLDER_KEY, projectFolderPath
         );
-        TimeLineProject timeLineProject = TimeLineProjectFactory.createProject("Test Project", configParams);
+        TimeLineProject timeLineProject = TimeLineProjectFactory.createProject("Test Project", configParams, TimeFormat.TIME_MIN);
         //
         Place galaxy = PlaceFactory.createPlace("Galaxy", PlaceLevel.GALAXY, null, Color.WHEAT);
         Place placeA = PlaceFactory.createPlace("PLACE_A", PlaceLevel.INTER_SYSTEM_SPACE, galaxy, Color.LIGHTSTEELBLUE);

--- a/src/main/java/com/github/noony/app/timelinefx/examples/TestExample.java
+++ b/src/main/java/com/github/noony/app/timelinefx/examples/TestExample.java
@@ -45,7 +45,7 @@ public class TestExample {
         Map<String, String> configParams = Map.of(
                 TimeLineProject.PROJECT_FOLDER_KEY, projectFolderPath
         );
-        TimeLineProject timeLineProject = TimeLineProjectFactory.createProject("Test Project", configParams, TimeFormat.TIME_MIN);
+        final TimeLineProject timeLineProject = TimeLineProjectFactory.createProject("Test Project", configParams, TimeFormat.TIME_MIN);
         //
         Place galaxy = PlaceFactory.createPlace("Galaxy", PlaceLevel.GALAXY, null, Color.WHEAT);
         Place placeA = PlaceFactory.createPlace("PLACE_A", PlaceLevel.INTER_SYSTEM_SPACE, galaxy, Color.LIGHTSTEELBLUE);

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/ContentEditionViewController.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/ContentEditionViewController.java
@@ -210,6 +210,7 @@ public final class ContentEditionViewController implements Initializable {
         }
         timeLineProject = aTimeLineProject;
         timeLineProject.addListener(timelineChangeListener);
+        updateCreateButtonState();
         //
         if (staysCreationViewController != null) {
             staysCreationViewController.setTimelineProject(aTimeLineProject);
@@ -266,9 +267,15 @@ public final class ContentEditionViewController implements Initializable {
 
     private void setEditMode(EditType mode) {
         editType = mode;
+        updateCreateButtonState();
+    }
+
+    private void updateCreateButtonState() {
         switch (editType) {
             case PERSON, PLACE ->
-                createButton.setDisable(false);
+                // creating a person/place needs an active project (its default portrait, or its
+                // registration in the project, both dereference it) -- see updateCreateButtonState callers
+                createButton.setDisable(timeLineProject == null);
             case NONE ->
                 createButton.setDisable(true);
             default ->

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/ContentEditionViewController.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/ContentEditionViewController.java
@@ -418,7 +418,7 @@ public final class ContentEditionViewController implements Initializable {
 
     private void handleTimelineChanges(PropertyChangeEvent event) {
         switch (event.getPropertyName()) {
-            case TimeLineProject.PLACE_REMOVED, TimeLineProject.PLACE_ADDED ->
+            case TimeLineProject.PLACE_REMOVED, TimeLineProject.PLACE_ADDED, TimeLineProject.HIGH_LEVEL_PLACE_ADDED ->
                 runLater(this::updatePlacesTab);
             case TimeLineProject.PERSON_ADDED, TimeLineProject.PERSON_REMOVED ->
                 runLater(this::updatePersonTab);

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/ContentEditionViewController.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/ContentEditionViewController.java
@@ -411,6 +411,9 @@ public final class ContentEditionViewController implements Initializable {
             case TimeLineProject.STAY_ADDED, TimeLineProject.STAY_REMOVED -> {
                 // TODO : see if ignoring is OK
             }
+            case TimeLineProject.TIME_FORMAT_CHANGED -> {
+                // nothing to do
+            }
             default ->
                 throw new UnsupportedOperationException(this.getClass().getSimpleName() + " :: " + event);
         }

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/ContentEditionViewController.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/ContentEditionViewController.java
@@ -234,12 +234,18 @@ public final class ContentEditionViewController implements Initializable {
     }
 
     private void updatePersonTab() {
+        if (timeLineProject == null) {
+            personCheckListView.getItems().clear();
+            return;
+        }
         personCheckListView.getItems().setAll(timeLineProject.getPersons());
     }
 
     private void updatePlacesTab() {
         var rootPlaceItem = createRootPlaceItem();
-        timeLineProject.getHighLevelPlaces().forEach(p -> rootPlaceItem.getChildren().add(createTreeItemPlace(p)));
+        if (timeLineProject != null) {
+            timeLineProject.getHighLevelPlaces().forEach(p -> rootPlaceItem.getChildren().add(createTreeItemPlace(p)));
+        }
         placesCheckTreeView.setRoot(rootPlaceItem);
         rootPlaceItem.setExpanded(true);
         placesCheckTreeView.refresh();
@@ -378,18 +384,19 @@ public final class ContentEditionViewController implements Initializable {
                 place = (Place) event.getNewValue();
                 customModalWindow.hide();
                 final var createdPlace = place;
-                UndoManager.execute(new SimpleCommand("Create place",
-                        () -> timeLineProject.addPlace(createdPlace),
-                        () -> timeLineProject.removePlace(createdPlace)));
+                if (timeLineProject != null) {
+                    UndoManager.execute(new SimpleCommand("Create place",
+                            () -> timeLineProject.addPlace(createdPlace),
+                            () -> timeLineProject.removePlace(createdPlace)));
+                }
                 updatePlacesTab();
             }
 
             case PlaceCreationViewController.PLACE_EDITIED -> {
                 place = (Place) event.getNewValue();
-                if (place.isRootPlace()) {
+                if (place.isRootPlace() && timeLineProject != null) {
                     timeLineProject.addHighLevelPlace(place);
                 } else {
-//                    timeLineProject.addHighLevelPlace(place);
 // nothing is needed since the parent place will take care of things
                 }
                 customModalWindow.hide();
@@ -426,9 +433,11 @@ public final class ContentEditionViewController implements Initializable {
                 person = (Person) event.getNewValue();
                 customModalWindow.hide();
                 final var createdPerson = person;
-                UndoManager.execute(new SimpleCommand("Create person",
-                        () -> timeLineProject.addPerson(createdPerson),
-                        () -> timeLineProject.removePerson(createdPerson)));
+                if (timeLineProject != null) {
+                    UndoManager.execute(new SimpleCommand("Create person",
+                            () -> timeLineProject.addPerson(createdPerson),
+                            () -> timeLineProject.removePerson(createdPerson)));
+                }
                 updatePersonTab();
             }
             case PersonCreationViewController.PERSON_EDITIED -> {

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/PicturesChronologyViewController.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/PicturesChronologyViewController.java
@@ -220,7 +220,7 @@ public final class PicturesChronologyViewController implements Initializable {
 
     private void handleProjectChanges(PropertyChangeEvent event) {
         switch (event.getPropertyName()) {
-            case TimeLineProject.PERSON_ADDED, TimeLineProject.PERSON_REMOVED, TimeLineProject.PLACE_ADDED, TimeLineProject.PLACE_REMOVED, TimeLineProject.STAY_ADDED, TimeLineProject.STAY_REMOVED, TimeLineProject.TIME_FORMAT_CHANGED -> {
+            case TimeLineProject.PERSON_ADDED, TimeLineProject.PERSON_REMOVED, TimeLineProject.PLACE_ADDED, TimeLineProject.PLACE_REMOVED, TimeLineProject.HIGH_LEVEL_PLACE_ADDED, TimeLineProject.STAY_ADDED, TimeLineProject.STAY_REMOVED, TimeLineProject.TIME_FORMAT_CHANGED -> {
             }
             default ->
                 throw new UnsupportedOperationException(this.getClass().getSimpleName() + " :: " + event);

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/PicturesChronologyViewController.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/PicturesChronologyViewController.java
@@ -220,7 +220,7 @@ public final class PicturesChronologyViewController implements Initializable {
 
     private void handleProjectChanges(PropertyChangeEvent event) {
         switch (event.getPropertyName()) {
-            case TimeLineProject.PERSON_ADDED, TimeLineProject.PERSON_REMOVED, TimeLineProject.PLACE_ADDED, TimeLineProject.PLACE_REMOVED, TimeLineProject.STAY_ADDED, TimeLineProject.STAY_REMOVED -> {
+            case TimeLineProject.PERSON_ADDED, TimeLineProject.PERSON_REMOVED, TimeLineProject.PLACE_ADDED, TimeLineProject.PLACE_REMOVED, TimeLineProject.STAY_ADDED, TimeLineProject.STAY_REMOVED, TimeLineProject.TIME_FORMAT_CHANGED -> {
             }
             default ->
                 throw new UnsupportedOperationException(this.getClass().getSimpleName() + " :: " + event);

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/ProjectCreationWizardController.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/ProjectCreationWizardController.java
@@ -18,6 +18,7 @@
 package com.github.noony.app.timelinefx.hmi;
 
 import com.github.noony.app.timelinefx.Configuration;
+import com.github.noony.app.timelinefx.core.TimeFormat;
 import com.github.noony.app.timelinefx.core.TimeLineProject;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
@@ -26,10 +27,12 @@ import java.net.URL;
 import java.util.Map;
 import java.util.ResourceBundle;
 import javafx.beans.value.ObservableValue;
+import javafx.collections.FXCollections;
 import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
 import javafx.fxml.Initializable;
 import javafx.scene.control.Button;
+import javafx.scene.control.ChoiceBox;
 import javafx.scene.control.TextField;
 import javafx.stage.DirectoryChooser;
 
@@ -60,6 +63,8 @@ public final class ProjectCreationWizardController implements Initializable {
     private TextField picturesField;
     @FXML
     private TextField miniaturesField;
+    @FXML
+    private ChoiceBox<TimeFormat> timeFormatCB;
 
     private String name = "";
 
@@ -77,6 +82,7 @@ public final class ProjectCreationWizardController implements Initializable {
 
     @Override
     public void initialize(URL url, ResourceBundle rb) {
+        timeFormatCB.setItems(FXCollections.observableArrayList(TimeFormat.values()));
         nameField.textProperty().addListener((ObservableValue<? extends String> ov, String t, String t1) -> {
             name = t1.trim();
             if (incompleteProjectFolder != null) {
@@ -112,6 +118,7 @@ public final class ProjectCreationWizardController implements Initializable {
         portraitsField.setText(portraitsFolderName);
         picturesField.setText(picturesFolderName);
         miniaturesField.setText(miniaturesFolderName);
+        timeFormatCB.getSelectionModel().select(TimeFormat.LOCAL_TIME);
         update();
     }
 
@@ -143,7 +150,8 @@ public final class ProjectCreationWizardController implements Initializable {
                 TimeLineProject.PROJECT_FOLDER_KEY, projectFolderPath,
                 TimeLineProject.PORTRAIT_FOLDER_KEY, portraitsFolderName,
                 TimeLineProject.PICTURES_FOLDER_KEY, picturesFolderName,
-                TimeLineProject.MINIATURES_FOLDER_KEY, miniaturesFolderName
+                TimeLineProject.MINIATURES_FOLDER_KEY, miniaturesFolderName,
+                TimeLineProject.TIME_FORMAT_KEY, timeFormatCB.getValue().name()
         );
         propertyChangeSupport.firePropertyChange(CREATE, this, configParams);
     }

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/ProjectViewController.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/ProjectViewController.java
@@ -594,7 +594,8 @@ public final class ProjectViewController implements Initializable {
                 @SuppressWarnings("unchecked")
                 var configParams = (Map<String, String>) event.getNewValue();
                 String projectName = configParams.get(TimeLineProject.PROJECT_NAME_KEY);
-                TimeLineProject project = TimeLineProjectFactory.createProject(projectName, configParams);
+                var timeFormat = TimeFormat.valueOf(configParams.get(TimeLineProject.TIME_FORMAT_KEY));
+                TimeLineProject project = TimeLineProjectFactory.createProject(projectName, configParams, timeFormat);
                 loadProject(project);
                 contentEditionView.setDisable(false);
                 friezeContentEditorView.setDisable(false);

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/ProjectViewController.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/ProjectViewController.java
@@ -600,6 +600,7 @@ public final class ProjectViewController implements Initializable {
                 contentEditionView.setDisable(false);
                 friezeContentEditorView.setDisable(false);
                 displayContentEditionView();
+                AppInstanceConfiguration.setSelectedTimeline(project);
             }
             default ->
                 throw new UnsupportedOperationException("" + event);

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/ProjectViewController.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/ProjectViewController.java
@@ -20,6 +20,7 @@ package com.github.noony.app.timelinefx.hmi;
 import com.github.noony.app.timelinefx.Configuration;
 import com.github.noony.app.timelinefx.core.Frieze;
 import com.github.noony.app.timelinefx.core.FriezeFactory;
+import com.github.noony.app.timelinefx.core.TimeFormat;
 import com.github.noony.app.timelinefx.core.TimeLineProject;
 import com.github.noony.app.timelinefx.core.TimeLineProjectFactory;
 import com.github.noony.app.timelinefx.examples.StarWars;
@@ -27,6 +28,7 @@ import com.github.noony.app.timelinefx.examples.TestExample;
 import static com.github.noony.app.timelinefx.hmi.AppInstanceConfiguration.ANCHOR_CONSTRAINT_ZERO;
 import com.github.noony.app.timelinefx.hmi.frieze.FriezeContentEditorController;
 import com.github.noony.app.timelinefx.save.XMLHandler;
+import com.github.noony.app.timelinefx.undo.SimpleCommand;
 import com.github.noony.app.timelinefx.undo.UndoManager;
 import com.github.noony.app.timelinefx.utils.CustomProfiler;
 import java.beans.PropertyChangeEvent;
@@ -98,6 +100,10 @@ public final class ProjectViewController implements Initializable {
     private MenuItem undoMenuItem;
     @FXML
     private MenuItem redoMenuItem;
+    @FXML
+    private RadioMenuItem dateTimeFormatMI;
+    @FXML
+    private RadioMenuItem minTimeFormatMI;
 
     private final Map<CheckMenuItem, Frieze> friezeMenuItems = new HashMap<>();
 
@@ -138,6 +144,10 @@ public final class ProjectViewController implements Initializable {
     private ToggleGroup toolbarToggleGroup;
 
     private ToggleGroup viewToggleGroup;
+
+    private ToggleGroup timeFormatToggleGroup;
+
+    private boolean updatingTimeFormatSelection = false;
 
     private ACTION_ON_HOLD actionOnHold = ACTION_ON_HOLD.NONE;
 
@@ -193,6 +203,20 @@ public final class ProjectViewController implements Initializable {
             } else {
                 throw new UnsupportedOperationException("View not supported, action on " + t1);
             }
+        });
+        //
+        timeFormatToggleGroup = new ToggleGroup();
+        dateTimeFormatMI.setToggleGroup(timeFormatToggleGroup);
+        minTimeFormatMI.setToggleGroup(timeFormatToggleGroup);
+        timeFormatToggleGroup.selectedToggleProperty().addListener((ObservableValue<? extends Toggle> ov, Toggle t, Toggle t1) -> {
+            if (timeLineProject == null || updatingTimeFormatSelection) {
+                return;
+            }
+            final var newFormat = t1 == dateTimeFormatMI ? TimeFormat.LOCAL_TIME : TimeFormat.TIME_MIN;
+            final var oldFormat = timeLineProject.getTimeFormat();
+            UndoManager.execute(new SimpleCommand("Change time format",
+                    () -> applyTimeFormat(newFormat),
+                    () -> applyTimeFormat(oldFormat)));
         });
         //
         AppInstanceConfiguration.addPropertyChangeListener(this::handleAppInstanceConfigChanges);
@@ -278,6 +302,20 @@ public final class ProjectViewController implements Initializable {
         redoMenuItem.setDisable(!UndoManager.canRedo());
     }
 
+    private void applyTimeFormat(final TimeFormat format) {
+        updatingTimeFormatSelection = true;
+        switch (format) {
+            case LOCAL_TIME ->
+                dateTimeFormatMI.setSelected(true);
+            case TIME_MIN ->
+                minTimeFormatMI.setSelected(true);
+            default ->
+                throw new UnsupportedOperationException();
+        }
+        timeLineProject.setTimeFormat(format);
+        updatingTimeFormatSelection = false;
+    }
+
     @FXML
     protected void handleFriezeCreation(ActionEvent event) {
         LOG.log(Level.INFO, "handleFriezeCreation {0}", event);
@@ -316,11 +354,25 @@ public final class ProjectViewController implements Initializable {
             // TODO: each view
             contentEditionView.setDisable(true);
             friezeContentEditorView.setDisable(true);
+            dateTimeFormatMI.setDisable(true);
+            minTimeFormatMI.setDisable(true);
         } else {
             contentEditionView.setDisable(false);
             friezeContentEditorView.setDisable(false);
             timeLineProject.getFriezes().forEach(this::createFriezeCheckMenuItem);
             updateFrizeMenuItemsSelection(AppInstanceConfiguration.getSelectedFrieze());
+            dateTimeFormatMI.setDisable(false);
+            minTimeFormatMI.setDisable(false);
+            updatingTimeFormatSelection = true;
+            switch (timeLineProject.getTimeFormat()) {
+                case LOCAL_TIME ->
+                    dateTimeFormatMI.setSelected(true);
+                case TIME_MIN ->
+                    minTimeFormatMI.setSelected(true);
+                default ->
+                    throw new UnsupportedOperationException();
+            }
+            updatingTimeFormatSelection = false;
         }
     }
 

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/StaysCreationViewController.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/StaysCreationViewController.java
@@ -151,6 +151,9 @@ public final class StaysCreationViewController implements Initializable {
             }
         });
         dateRB.setSelected(true);
+        // The time format is now chosen at the project level (Edit menu), not per-stay.
+        timeRB.setDisable(true);
+        dateRB.setDisable(true);
         //
         personCB.getSelectionModel().selectedItemProperty().addListener((ObservableValue<? extends Person> ov, Person t, Person t1) -> {
             personOK = t1 != null;
@@ -187,6 +190,7 @@ public final class StaysCreationViewController implements Initializable {
                 selectedStayPeriod = null;
                 updateB.setDisable(true);
                 clearFields();
+                applyProjectTimeFormat();
             }
         });
         //
@@ -261,6 +265,7 @@ public final class StaysCreationViewController implements Initializable {
         timeline = aTimeline;
         if (timeline != null) {
             timeline.addListener(timelineListener);
+            applyProjectTimeFormat();
             runLater(() -> {
                 personCB.getItems().setAll(timeline.getPersons());
                 chronologyListView.getItems().setAll(timeline.getStays());
@@ -315,8 +320,31 @@ public final class StaysCreationViewController implements Initializable {
                 chronologyListView.getItems().add((StayPeriod) event.getNewValue());
             case TimeLineProject.STAY_REMOVED ->
                 chronologyListView.getItems().remove((StayPeriod) event.getNewValue());
+            case TimeLineProject.TIME_FORMAT_CHANGED -> {
+                if (selectedStayPeriod == null) {
+                    applyProjectTimeFormat();
+                }
+            }
             default ->
                 throw new UnsupportedOperationException(event.toString());
+        }
+    }
+
+    /**
+     * Selects the radio button (and shows the corresponding fields) matching the project's own time format,
+     * used as the format for the next stay to be created.
+     */
+    private void applyProjectTimeFormat() {
+        if (timeline == null) {
+            return;
+        }
+        switch (timeline.getTimeFormat()) {
+            case LOCAL_TIME ->
+                dateRB.setSelected(true);
+            case TIME_MIN ->
+                timeRB.setSelected(true);
+            default ->
+                throw new UnsupportedOperationException();
         }
     }
 

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/frieze/FriezeContentEditorController.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/frieze/FriezeContentEditorController.java
@@ -53,7 +53,9 @@ import javafx.fxml.FXML;
 import javafx.fxml.FXMLLoader;
 import javafx.fxml.Initializable;
 import javafx.scene.control.Button;
+import javafx.scene.control.CheckBox;
 import javafx.scene.control.CheckBoxTreeItem;
+import javafx.scene.control.Label;
 import javafx.scene.control.ListView;
 import javafx.scene.control.SelectionMode;
 import javafx.scene.control.SplitPane;
@@ -101,6 +103,14 @@ public class FriezeContentEditorController implements Initializable {
     // properties
     @FXML
     private GridPane timeGrid;
+    @FXML
+    private Label projectStartDateLabel;
+    @FXML
+    private Label projectEndDateLabel;
+    @FXML
+    private CheckBox constraintStartCB;
+    @FXML
+    private CheckBox constraintEndCB;
 
     private List<CheckBoxTreeItem<Place>> allTreeItems = new LinkedList<>();
 
@@ -118,6 +128,12 @@ public class FriezeContentEditorController implements Initializable {
     private TextField friezeStartTimeField;
 
     private TextField friezeEndTimeField;
+
+    private TextField constraintStartDateField;
+
+    private TextField constraintEndDateField;
+
+    private boolean updatingConstraintControls = false;
 
     private AnchorPane spatialViewRootPane;
 
@@ -146,6 +162,31 @@ public class FriezeContentEditorController implements Initializable {
             if (frieze != null) {
                 frieze.setName(t1);
                 nameField.setText(frieze.getName());
+            }
+        });
+        //
+        constraintStartCB.setSelected(false);
+        constraintStartCB.selectedProperty().addListener((var ov, var t, var t1) -> {
+            constraintStartDateField.setDisable(!t1);
+            if (updatingConstraintControls || frieze == null) {
+                return;
+            }
+            if (t1) {
+                applyConstraintMinDate();
+            } else {
+                frieze.clearConstraintMinDate();
+            }
+        });
+        constraintEndCB.setSelected(false);
+        constraintEndCB.selectedProperty().addListener((var ov, var t, var t1) -> {
+            constraintEndDateField.setDisable(!t1);
+            if (updatingConstraintControls || frieze == null) {
+                return;
+            }
+            if (t1) {
+                applyConstraintMaxDate();
+            } else {
+                frieze.clearConstraintMaxDate();
             }
         });
         //
@@ -265,6 +306,7 @@ public class FriezeContentEditorController implements Initializable {
         }
         timeLineProject = aTimeLineProject;
         timeLineProject.addListener(projectListener);
+        updateProjectDatesDisplay();
         updatePeoplePane();
         updatePlacesPane();
         updatePeoplePane();
@@ -279,6 +321,7 @@ public class FriezeContentEditorController implements Initializable {
         frieze = aFrieze;
         frieze.addListener(friezeListener);
         updatePropertiesTab();
+        updateConstraintControls();
         updatePeoplePane();
         updatePlacesPane();
         updateStaysPane();
@@ -294,32 +337,70 @@ public class FriezeContentEditorController implements Initializable {
         updatePeoplePane();
         updatePlacesPane();
         updatePropertiesTab();
+        updateProjectDatesDisplay();
     }
 
     private void updatePropertiesTab() {
         if (frieze != null) {
             nameField.setText(frieze.getName());
-            switch (frieze.getTimeFormat()) {
-                case LOCAL_TIME -> {
-//                    throw new AssertionError();
-                    System.err.println("TODO:: updatePropertiesTab -> LOCAL_TIME");
-                }
-                case TIME_MIN -> {
-                    friezeStartTimeField.setText(Double.toString(frieze.getMinDate()));
-                    friezeEndTimeField.setText(Double.toString(frieze.getMaxDate()));
-                    if (!timeGrid.getChildren().contains(friezeStartTimeField)) {
-                        timeGrid.add(friezeStartTimeField, 1, 2);
-                    }
-                    if (!timeGrid.getChildren().contains(friezeEndTimeField)) {
-                        timeGrid.add(friezeEndTimeField, 4, 2);
-                    }
-                }
-                default ->
-                    throw new AssertionError();
-            }
+            updateFriezeDatesDisplay();
         } else {
             nameField.setText("");
         }
+    }
+
+    private void updateFriezeDatesDisplay() {
+        if (frieze == null) {
+            return;
+        }
+        switch (frieze.getTimeFormat()) {
+            case LOCAL_TIME -> {
+//                    throw new AssertionError();
+                System.err.println("TODO:: updateFriezeDatesDisplay -> LOCAL_TIME");
+            }
+            case TIME_MIN -> {
+                friezeStartTimeField.setText(Double.toString(frieze.getMinDate()));
+                friezeEndTimeField.setText(Double.toString(frieze.getMaxDate()));
+                if (!timeGrid.getChildren().contains(friezeStartTimeField)) {
+                    timeGrid.add(friezeStartTimeField, 1, 2);
+                }
+                if (!timeGrid.getChildren().contains(friezeEndTimeField)) {
+                    timeGrid.add(friezeEndTimeField, 4, 2);
+                }
+            }
+            default ->
+                throw new AssertionError();
+        }
+    }
+
+    private void updateProjectDatesDisplay() {
+        if (timeLineProject == null || timeLineProject.getStays().isEmpty()) {
+            projectStartDateLabel.setText("");
+            projectEndDateLabel.setText("");
+        } else {
+            projectStartDateLabel.setText(Double.toString(timeLineProject.getMinDate()));
+            projectEndDateLabel.setText(Double.toString(timeLineProject.getMaxDate()));
+        }
+    }
+
+    private void updateConstraintControls() {
+        if (frieze == null) {
+            return;
+        }
+        if (!timeGrid.getChildren().contains(constraintStartDateField)) {
+            timeGrid.add(constraintStartDateField, 1, 3);
+        }
+        if (!timeGrid.getChildren().contains(constraintEndDateField)) {
+            timeGrid.add(constraintEndDateField, 4, 3);
+        }
+        updatingConstraintControls = true;
+        constraintStartCB.setSelected(frieze.isMinDateConstrained());
+        constraintStartDateField.setDisable(!frieze.isMinDateConstrained());
+        constraintStartDateField.setText(frieze.isMinDateConstrained() ? Double.toString(frieze.getConstraintMinDate()) : "");
+        constraintEndCB.setSelected(frieze.isMaxDateConstrained());
+        constraintEndDateField.setDisable(!frieze.isMaxDateConstrained());
+        constraintEndDateField.setText(frieze.isMaxDateConstrained() ? Double.toString(frieze.getConstraintMaxDate()) : "");
+        updatingConstraintControls = false;
     }
 
     private void updatePeoplePane() {
@@ -485,7 +566,46 @@ public class FriezeContentEditorController implements Initializable {
         friezeStartTimeField = new TextField();
         //
         friezeEndTimeField = new TextField();
+        //
+        constraintStartDateField = new TextField();
+        constraintStartDateField.setDisable(true);
+        constraintStartDateField.textProperty().addListener((var ov, var t, var t1) -> {
+            if (!updatingConstraintControls && constraintStartCB.isSelected() && frieze != null) {
+                applyConstraintMinDate();
+            }
+        });
+        //
+        constraintEndDateField = new TextField();
+        constraintEndDateField.setDisable(true);
+        constraintEndDateField.textProperty().addListener((var ov, var t, var t1) -> {
+            if (!updatingConstraintControls && constraintEndCB.isSelected() && frieze != null) {
+                applyConstraintMaxDate();
+            }
+        });
+    }
 
+    private void applyConstraintMinDate() {
+        final var text = constraintStartDateField.getText();
+        if (text.isBlank()) {
+            return;
+        }
+        try {
+            frieze.setConstraintMinDate(Double.parseDouble(text));
+        } catch (NumberFormatException e) {
+            LOG.log(Level.FINEST, "The following value is not a valid constraint start date {0}. {1}", new Object[]{text, e});
+        }
+    }
+
+    private void applyConstraintMaxDate() {
+        final var text = constraintEndDateField.getText();
+        if (text.isBlank()) {
+            return;
+        }
+        try {
+            frieze.setConstraintMaxDate(Double.parseDouble(text));
+        } catch (NumberFormatException e) {
+            LOG.log(Level.FINEST, "The following value is not a valid constraint end date {0}. {1}", new Object[]{text, e});
+        }
     }
 
     private void createSpatialView() {
@@ -522,9 +642,8 @@ public class FriezeContentEditorController implements Initializable {
                 removePersonFromPeoplePane((Person) event.getNewValue());
             case TimeLineProject.PLACE_ADDED, TimeLineProject.PLACE_REMOVED ->
                 updatePlacesPane();
-            case TimeLineProject.STAY_ADDED, TimeLineProject.STAY_REMOVED -> {
-                // ignored
-            }
+            case TimeLineProject.STAY_ADDED, TimeLineProject.STAY_REMOVED ->
+                updateProjectDatesDisplay();
             default ->
                 throw new UnsupportedOperationException(this.getClass().getSimpleName() + " :: " + event);
         }
@@ -537,8 +656,10 @@ public class FriezeContentEditorController implements Initializable {
             }
             case Frieze.PLACE_ADDED, Frieze.PLACE_REMOVED ->
                 updatePlacesPane();
-            case Frieze.STAY_ADDED, Frieze.STAY_REMOVED, Frieze.STAY_UPDATED ->
+            case Frieze.STAY_ADDED, Frieze.STAY_REMOVED, Frieze.STAY_UPDATED -> {
                 updateStaysPane();
+                updateFriezeDatesDisplay();
+            }
             case Frieze.DATE_WINDOW_CHANGED -> {
                 // TODO
             }

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/frieze/FriezeContentEditorController.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/frieze/FriezeContentEditorController.java
@@ -640,7 +640,7 @@ public class FriezeContentEditorController implements Initializable {
                 addPeopleToPeoplePane((Person) event.getNewValue());
             case TimeLineProject.PERSON_REMOVED ->
                 removePersonFromPeoplePane((Person) event.getNewValue());
-            case TimeLineProject.PLACE_ADDED, TimeLineProject.PLACE_REMOVED ->
+            case TimeLineProject.PLACE_ADDED, TimeLineProject.PLACE_REMOVED, TimeLineProject.HIGH_LEVEL_PLACE_ADDED ->
                 updatePlacesPane();
             case TimeLineProject.STAY_ADDED, TimeLineProject.STAY_REMOVED ->
                 updateProjectDatesDisplay();

--- a/src/main/java/com/github/noony/app/timelinefx/hmi/frieze/FriezeContentEditorController.java
+++ b/src/main/java/com/github/noony/app/timelinefx/hmi/frieze/FriezeContentEditorController.java
@@ -644,6 +644,9 @@ public class FriezeContentEditorController implements Initializable {
                 updatePlacesPane();
             case TimeLineProject.STAY_ADDED, TimeLineProject.STAY_REMOVED ->
                 updateProjectDatesDisplay();
+            case TimeLineProject.TIME_FORMAT_CHANGED -> {
+                // nothing to do
+            }
             default ->
                 throw new UnsupportedOperationException(this.getClass().getSimpleName() + " :: " + event);
         }

--- a/src/main/java/com/github/noony/app/timelinefx/save/XMLHandler.java
+++ b/src/main/java/com/github/noony/app/timelinefx/save/XMLHandler.java
@@ -58,9 +58,8 @@ public final class XMLHandler {
         saveProvider = providers.get(0);
         saveVersion = saveProvider.getSupportedVersions().get(0);
         providers.forEach(candidateparser -> {
-            String mostRecentVersion = candidateparser.getSupportedVersions().stream()
-                    .max(XMLHandler::compareVersions).get();
-            int versionComparison = compareVersions(mostRecentVersion, saveVersion);
+            String mostRecentVersion = candidateparser.getSupportedVersions().stream().max(XMLHandler::compareVersions).get();
+            final int versionComparison = compareVersions(mostRecentVersion, saveVersion);
             if (versionComparison > 0) {
                 saveProvider = candidateparser;
                 saveVersion = mostRecentVersion;

--- a/src/main/java/com/github/noony/app/timelinefx/save/XMLHandler.java
+++ b/src/main/java/com/github/noony/app/timelinefx/save/XMLHandler.java
@@ -58,7 +58,7 @@ public final class XMLHandler {
         saveProvider = providers.get(0);
         saveVersion = saveProvider.getSupportedVersions().get(0);
         providers.forEach(candidateparser -> {
-            String mostRecentVersion = candidateparser.getSupportedVersions().stream().max(XMLHandler::compareVersions).get();
+            final String mostRecentVersion = candidateparser.getSupportedVersions().stream().max(XMLHandler::compareVersions).get();
             final int versionComparison = compareVersions(mostRecentVersion, saveVersion);
             if (versionComparison > 0) {
                 saveProvider = candidateparser;

--- a/src/main/java/com/github/noony/app/timelinefx/save/XMLHandler.java
+++ b/src/main/java/com/github/noony/app/timelinefx/save/XMLHandler.java
@@ -69,6 +69,7 @@ public final class XMLHandler {
     }
 
     public static TimeLineProject loadFile(File file) {
+        LOG.log(Level.INFO, "Trying to load file {0}.", new Object[]{file});
         TimeLineProject project = null;
         if (file != null) {
             FriezeObjectFactory.reset();
@@ -86,8 +87,9 @@ public final class XMLHandler {
                 boolean foundProvider = false;
                 for (TimelineProjectProvider candidateprovider : INSTANCE.providers) {
                     if (candidateprovider.getSupportedVersions().contains(version)) {
-                        project = candidateprovider.load(file, e);
                         foundProvider = true;
+                        LOG.log(Level.INFO, "Using provider {0}.", new Object[]{candidateprovider});
+                        project = candidateprovider.load(file, e);
                         break;
                     }
                 }

--- a/src/main/java/com/github/noony/app/timelinefx/save/XMLHandler.java
+++ b/src/main/java/com/github/noony/app/timelinefx/save/XMLHandler.java
@@ -59,9 +59,8 @@ public final class XMLHandler {
         saveVersion = saveProvider.getSupportedVersions().get(0);
         providers.forEach(candidateparser -> {
             String mostRecentVersion = candidateparser.getSupportedVersions().stream()
-                    .sorted((v1, v2) -> compareVersions(v1, v2))
-                    .findFirst().get();
-            int versionComparison = compareVersions(saveVersion, mostRecentVersion);
+                    .max(XMLHandler::compareVersions).get();
+            int versionComparison = compareVersions(mostRecentVersion, saveVersion);
             if (versionComparison > 0) {
                 saveProvider = candidateparser;
                 saveVersion = mostRecentVersion;

--- a/src/main/java/com/github/noony/app/timelinefx/save/v3/TimeProjectProviderV3.java
+++ b/src/main/java/com/github/noony/app/timelinefx/save/v3/TimeProjectProviderV3.java
@@ -195,6 +195,8 @@ public class TimeProjectProviderV3 implements TimelineProjectProvider {
                 TimeLineProject.MINIATURES_FOLDER_KEY, miniaturesFolderValue
         );
         TimeLineProject project = TimeLineProjectFactory.createProject(projectName, configParams);
+        var timeFormatValue = e.hasAttribute(TIME_FORMAT_ATR) ? TimeFormat.valueOf(e.getAttribute(TIME_FORMAT_ATR)) : TimeFormat.LOCAL_TIME;
+        project.setTimeFormat(timeFormatValue);
         //
         List<String> relativePathLoaded = new LinkedList<>();
         //
@@ -289,6 +291,7 @@ public class TimeProjectProviderV3 implements TimelineProjectProvider {
             rootElement.setAttribute(PORTRAIT_FOLDER_ATR, portraitsFolderName);
             rootElement.setAttribute(PICTURES_LOCATION_ATR, picturesFolderName);
             rootElement.setAttribute(MINIATURES_FOLDER_ATR, miniaturesFolderName);
+            rootElement.setAttribute(TIME_FORMAT_ATR, project.getTimeFormat().name());
             doc.appendChild(rootElement);
             // save places
             Element placesGroupElement = doc.createElement(PLACES_GROUP);

--- a/src/main/java/com/github/noony/app/timelinefx/save/v3/TimeProjectProviderV3.java
+++ b/src/main/java/com/github/noony/app/timelinefx/save/v3/TimeProjectProviderV3.java
@@ -194,9 +194,8 @@ public class TimeProjectProviderV3 implements TimelineProjectProvider {
                 TimeLineProject.PICTURES_FOLDER_KEY, picturesFolderValue,
                 TimeLineProject.MINIATURES_FOLDER_KEY, miniaturesFolderValue
         );
-        TimeLineProject project = TimeLineProjectFactory.createProject(projectName, configParams);
         var timeFormatValue = e.hasAttribute(TIME_FORMAT_ATR) ? TimeFormat.valueOf(e.getAttribute(TIME_FORMAT_ATR)) : TimeFormat.LOCAL_TIME;
-        project.setTimeFormat(timeFormatValue);
+        TimeLineProject project = TimeLineProjectFactory.createProject(projectName, configParams, timeFormatValue);
         //
         List<String> relativePathLoaded = new LinkedList<>();
         //

--- a/src/main/java/com/github/noony/app/timelinefx/save/v4/FreeMapProviderV4.java
+++ b/src/main/java/com/github/noony/app/timelinefx/save/v4/FreeMapProviderV4.java
@@ -35,7 +35,6 @@ import com.github.noony.app.timelinefx.core.freemap.connectors.FreeMapConnector;
 import com.github.noony.app.timelinefx.core.freemap.connectors.FreeMapConnectorFactory;
 import com.github.noony.app.timelinefx.core.freemap.links.FreeMapLinkFactory;
 import com.github.noony.app.timelinefx.core.freemap.links.PortraitLink;
-import static com.github.noony.app.timelinefx.save.v4.TimeProjectProviderV4.*;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -47,6 +46,7 @@ import javafx.geometry.Point2D;
 import javafx.util.Pair;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
+import static com.github.noony.app.timelinefx.save.v4.TimeProjectProviderV4.*;
 
 /**
  *

--- a/src/main/java/com/github/noony/app/timelinefx/save/v4/FreeMapProviderV4.java
+++ b/src/main/java/com/github/noony/app/timelinefx/save/v4/FreeMapProviderV4.java
@@ -1,0 +1,536 @@
+/*
+ * Copyright (C) 2023 NoOnY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.github.noony.app.timelinefx.save.v4;
+
+import com.github.noony.app.timelinefx.core.Frieze;
+import com.github.noony.app.timelinefx.core.PersonFactory;
+import com.github.noony.app.timelinefx.core.PlaceFactory;
+import com.github.noony.app.timelinefx.core.StayFactory;
+import com.github.noony.app.timelinefx.core.freemap.FreeMapDateHandle;
+import com.github.noony.app.timelinefx.core.freemap.FreeMapPerson;
+import com.github.noony.app.timelinefx.core.freemap.FreeMapPlace;
+import com.github.noony.app.timelinefx.core.freemap.FreeMapPortrait;
+import com.github.noony.app.timelinefx.core.freemap.FreeMapPortraitFactory;
+import com.github.noony.app.timelinefx.core.freemap.FreeMapStay;
+import com.github.noony.app.timelinefx.core.freemap.FreeMapStayFactory;
+import com.github.noony.app.timelinefx.core.freemap.FriezeFreeMap;
+import com.github.noony.app.timelinefx.core.freemap.FriezeFreeMapFactory;
+import com.github.noony.app.timelinefx.core.freemap.FriezeFreeMapProperties;
+import com.github.noony.app.timelinefx.core.freemap.connectors.FreeMapConnector;
+import com.github.noony.app.timelinefx.core.freemap.connectors.FreeMapConnectorFactory;
+import com.github.noony.app.timelinefx.core.freemap.links.FreeMapLinkFactory;
+import com.github.noony.app.timelinefx.core.freemap.links.PortraitLink;
+import static com.github.noony.app.timelinefx.save.v4.TimeProjectProviderV4.*;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+import javafx.geometry.Point2D;
+import javafx.util.Pair;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+/**
+ *
+ * @author hamon
+ */
+public class FreeMapProviderV4 {
+
+    protected static final String FREEMAPS_GROUP = "freeMaps";
+
+    private static final String FREEMAP_PLACES_GROUP = "freeMapPlaces";
+
+    private static final String FREEMAP_PERSONS_GROUP = "freeMapPersons";
+
+    private static final String FREEMAP_DATE_HANDLES_GROUP = "freeMapDateHandles";
+
+    private static final String FREEMAP_PORTRAITS_GROUP = "freeMapPortraits";
+
+    private static final String FREEMAP_STAYS_GROUP = "freeMapStays";
+
+    private static final String FREEMAP_PARAMETERS_GROUP = "freeMapParameters";
+
+    private static final String FREEMAP_ELEMENT = "freeMap";
+
+    private static final String PARAMETER_ELEMENT = "parameter";
+
+    private static final String PARAMETER_NAME_ATR = "name";
+
+    private static final String PARAMETER_VALUE_ATR = "value";
+
+    private static final String FREEMAP_PERSON_ELEMENT = "freeMapPerson";
+
+    private static final String FREEMAP_PLACE_ELEMENT = "freeMapPlace";
+
+    private static final String FREEMAP_STAY_ELEMENT = "freeMapStay";
+
+    private static final String FREEMAP_DATE_HANDLE_ELEMENT = "freeMapDateHandle";
+
+    private static final String FREEMAP_CONNECTOR_ELEMENT = "connector";
+
+    private static final String FREEMAP_PORTRAIT_LINK_ELEMENT = "portraitLink";
+
+    private static final String FREEMAP_PLACE_NAME_WIDTH_ATR = "placeNameWidth";
+
+    private static final String FREEMAP_FONT_SIZE_ATR = "fontSize";
+
+    private static final String FREEMAP_LINKED_ELEMENT_ID_ATR = "linkedElementID";
+    private static final String FREEMAP_IS_MERGED_ATR = "isMerged";
+
+    private static final Logger LOG = Logger.getGlobal();
+
+    protected static Element saveFreeMapElement(Document doc, FriezeFreeMap friezeFreeMap) {
+        LOG.log(Level.INFO, "Saving FriezeFreeMap: {0}", new Object[]{friezeFreeMap});
+        //
+        var friezeFreeMapElement = doc.createElement(FREEMAP_ELEMENT);
+        friezeFreeMapElement.setAttribute(NAME_ATR, friezeFreeMap.getName());
+        friezeFreeMapElement.setAttribute(ID_ATR, Long.toString(friezeFreeMap.getId()));
+        //
+        var configGroupElement = doc.createElement(FREEMAP_PARAMETERS_GROUP);
+        friezeFreeMap.getParemeters().forEach((pName, pString) -> configGroupElement.appendChild(saveParameter(doc, pName, pString)));
+        friezeFreeMapElement.appendChild(configGroupElement);
+        // Places
+        var placeGroupElement = doc.createElement(FREEMAP_PLACES_GROUP);
+        friezeFreeMap.getPlaces().forEach(p -> placeGroupElement.appendChild(saveFreeMapPlaceElement(doc, p)));
+        friezeFreeMapElement.appendChild(placeGroupElement);
+        // Person
+        var personsGroupElement = doc.createElement(FREEMAP_PERSONS_GROUP);
+        friezeFreeMap.getPersons().forEach(p -> personsGroupElement.appendChild(saveFreeMapPersonElement(doc, p)));
+        friezeFreeMapElement.appendChild(personsGroupElement);
+        // Date handles
+        var dateHandlesGroupElement = doc.createElement(FREEMAP_DATE_HANDLES_GROUP);
+        friezeFreeMap.getStartDateHandles().forEach(s -> dateHandlesGroupElement.appendChild(saveFreeMapDateHandleElement(doc, s)));
+        friezeFreeMap.getEndDateHandles().forEach(e -> dateHandlesGroupElement.appendChild(saveFreeMapDateHandleElement(doc, e)));
+        friezeFreeMapElement.appendChild(dateHandlesGroupElement);
+        //
+        return friezeFreeMapElement;
+    }
+
+    private static Element saveParameter(Document doc, String aName, String aValueString) {
+        var paramElement = doc.createElement(PARAMETER_ELEMENT);
+        paramElement.setAttribute(PARAMETER_NAME_ATR, aName);
+        paramElement.setAttribute(PARAMETER_VALUE_ATR, aValueString);
+        return paramElement;
+    }
+
+    private static Element saveFreeMapPersonElement(Document doc, FreeMapPerson freeMapPerson) {
+        var personElement = doc.createElement(FREEMAP_PERSON_ELEMENT);
+        personElement.setAttribute(ID_ATR, Long.toString(freeMapPerson.getId()));
+        // stays
+        var staysGroupElement = doc.createElement(FREEMAP_STAYS_GROUP);
+        personElement.appendChild(staysGroupElement);
+        freeMapPerson.getFreeMapStays().forEach(fmStay -> {
+            final var fmStayElement = saveFreeMapStayElement(doc, fmStay);
+            staysGroupElement.appendChild(fmStayElement);
+        });
+        var portraitsGroupElement = doc.createElement(FREEMAP_PORTRAITS_GROUP);
+        personElement.appendChild(portraitsGroupElement);
+        freeMapPerson.getFreeMapPortraits().forEach(fmPortrait -> {
+            var fmPortraitElement = saveFreeMapPortraitElement(doc, fmPortrait);
+            portraitsGroupElement.appendChild(fmPortraitElement);
+        });
+        return personElement;
+    }
+
+    private static Element saveFreeMapPlaceElement(Document doc, FreeMapPlace freeMapPlace) {
+        var placeElement = doc.createElement(FREEMAP_PLACE_ELEMENT);
+        placeElement.setAttribute(PLACE_ID_ATR, Long.toString(freeMapPlace.getPlace().getId()));
+        placeElement.setAttribute(HEIGHT_ATR, Double.toString(freeMapPlace.getHeight()));
+        placeElement.setAttribute(Y_POS_ATR, Double.toString(freeMapPlace.getYPos()));
+        placeElement.setAttribute(FREEMAP_FONT_SIZE_ATR, Double.toString(freeMapPlace.getFontSize()));
+        placeElement.setAttribute(FREEMAP_PLACE_NAME_WIDTH_ATR, Double.toString(freeMapPlace.getNameWidth()));
+        var personsAtPlace = freeMapPlace.getPersons();
+        for (int i = 0; i < personsAtPlace.size(); i++) {
+            final var personElement = doc.createElement(FREEMAP_PERSON_ELEMENT);
+            personElement.setAttribute(INDEX_ATR, Integer.toString(i));
+            personElement.setAttribute(ID_ATR, Long.toString(personsAtPlace.get(i).getId()));
+            placeElement.appendChild(personElement);
+        }
+        return placeElement;
+    }
+
+    private static Element saveFreeMapDateHandleElement(Document doc, FreeMapDateHandle freeMapDateHandle) {
+        var freeMapDateHandleElement = doc.createElement(FREEMAP_DATE_HANDLE_ELEMENT);
+        freeMapDateHandleElement.setAttribute(DATE_ATR, Double.toString(freeMapDateHandle.getDate()));
+        freeMapDateHandleElement.setAttribute(X_POS_ATR, Double.toString(freeMapDateHandle.getXPos()));
+        freeMapDateHandleElement.setAttribute(Y_POS_ATR, Double.toString(freeMapDateHandle.getYPos()));
+        // is a bit redundant but keeping it for now since save format is not frozen
+        freeMapDateHandleElement.setAttribute(TYPE_ATR, freeMapDateHandle.getTimeType().name());
+        return freeMapDateHandleElement;
+    }
+
+    private static Element saveFreeMapStayElement(Document doc, FreeMapStay freeMapStay) {
+        // TODO, evaluate not saving stays inside persons but at freemap level ?
+        final var stayElement = doc.createElement(FREEMAP_STAY_ELEMENT);
+        stayElement.setAttribute(ID_ATR, Long.toString(freeMapStay.getId()));
+        stayElement.setAttribute(START_ID_ATR, Long.toString(freeMapStay.getStartPlot().getId()));
+        stayElement.setAttribute(END_ID_ATR, Long.toString(freeMapStay.getEndPlot().getId()));
+        stayElement.setAttribute(PERSON_REF_ATR, Long.toString(freeMapStay.getPerson().getId()));
+        stayElement.setAttribute(PLACE_REF_ATR, Long.toString(freeMapStay.getPlace().getId()));
+        var subStays = freeMapStay.getFreeMapStayPeriods();
+        // made it more readable and easy to update
+        var allStaysIncluded = freeMapStay.getStayPeriods();
+        if (subStays.isEmpty()) {
+            stayElement.setAttribute(FREEMAP_IS_MERGED_ATR, Boolean.FALSE.toString());
+            stayElement.setAttribute(STAY_ID_ATR, Long.toString(allStaysIncluded.get(0).getId()));
+
+        } else {
+            stayElement.setAttribute(FREEMAP_IS_MERGED_ATR, Boolean.TRUE.toString());
+            subStays.forEach(subStay -> stayElement.appendChild(saveFreeMapStayElement(doc, subStay)));
+            // TODO: improve, but will require to update stay management in merge stays
+            allStaysIncluded.forEach(includedStay -> {
+                final var includedStaylement = doc.createElement(STAY_ELEMENT_REF);
+                includedStaylement.setAttribute(ID_ATR, Long.toString(includedStay.getId()));
+                stayElement.appendChild(includedStaylement);
+            });
+        }
+        //
+        freeMapStay.getIntermediateConnectors().forEach(interConnector -> stayElement.appendChild(saveConnectorElement(doc, interConnector)));
+        return stayElement;
+    }
+
+    private static Element saveFreeMapPortraitElement(Document doc, FreeMapPortrait freeMapPortrait) {
+        var portraitElement = doc.createElement(PORTRAIT_ELEMENT);
+        portraitElement.setAttribute(ID_ATR, Long.toString(freeMapPortrait.getId()));
+        portraitElement.setAttribute(PERSON_ATR, Long.toString(freeMapPortrait.getPerson().getId()));
+        portraitElement.setAttribute(X_POS_ATR, Double.toString(freeMapPortrait.getX()));
+        portraitElement.setAttribute(Y_POS_ATR, Double.toString(freeMapPortrait.getY()));
+        portraitElement.setAttribute(RADIUS_ATR, Double.toString(freeMapPortrait.getRadius()));
+        portraitElement.setAttribute(PORTRAIT_REF_ATR, Long.toString(freeMapPortrait.getPortrait().getId()));
+        //
+        var portraitLink = freeMapPortrait.getPerson().getPortraitLink(freeMapPortrait);
+        //
+        var portraitLinkElement = savePortraitLinkElement(doc, portraitLink);
+        portraitElement.appendChild(portraitLinkElement);
+        return portraitElement;
+    }
+
+    private static Element savePortraitLinkElement(Document doc, PortraitLink aPortraitLink) {
+        var portraitLinkElement = doc.createElement(FREEMAP_PORTRAIT_LINK_ELEMENT);
+        portraitLinkElement.setAttribute(ID_ATR, Long.toString(aPortraitLink.getId()));
+        //
+        var stayConnetorElement = saveConnectorElement(doc, aPortraitLink.getEndConnector());
+        portraitLinkElement.appendChild(stayConnetorElement);
+
+        return portraitLinkElement;
+    }
+
+    private static Element saveConnectorElement(Document doc, FreeMapConnector connector) {
+        var connectorElement = doc.createElement(FREEMAP_CONNECTOR_ELEMENT);
+        connectorElement.setAttribute(ID_ATR, Long.toString(connector.getId()));
+        connectorElement.setAttribute(FREEMAP_LINKED_ELEMENT_ID_ATR, Long.toString(connector.getLinkedElementID()));
+        connectorElement.setAttribute(COLOR_ATR, connector.getColor().toString());
+        connectorElement.setAttribute(DATE_ATR, Double.toString(connector.getDate()));
+        connectorElement.setAttribute(X_POS_ATR, Double.toString(connector.getX()));
+        connectorElement.setAttribute(Y_POS_ATR, Double.toString(connector.getY()));
+        connectorElement.setAttribute(PLOT_SIZE_ATR, Double.toString(connector.getPlotSize()));
+        return connectorElement;
+    }
+
+    //
+    //
+    //
+    protected static void parseFreeMaps(Element freemapsRootElement, Frieze frieze) {
+        var freemapElements = freemapsRootElement.getChildNodes();
+        for (int i = 0; i < freemapElements.getLength(); i++) {
+            if (freemapElements.item(i).getNodeName().equals(FREEMAP_ELEMENT)) {
+                var e = (Element) freemapElements.item(i);
+                parseFreeMap(e, frieze);
+            }
+        }
+    }
+
+    private static void parseFreeMap(Element freemapElement, Frieze frieze) {
+        var freeMapID = Long.parseLong(freemapElement.getAttribute(ID_ATR));
+        var freeMapName = freemapElement.getAttribute(NAME_ATR);
+        // parse parameters
+        var freeMapParameters = parseFreeMapParameters(freemapElement);
+        var freeMapProperties = FriezeFreeMapProperties.fromParameterMap(freeMapParameters, FriezeFreeMap.DEFAULT_PROPERTIES);
+        LOG.log(Level.INFO, "Parsed Freemap {0}_{1} parameters: {2}", new Object[]{freeMapID, freeMapName, freeMapProperties});
+        // parse date handles
+        var dateHandles = parseFreeMapDateHandles(freemapElement, freeMapID);
+        // parse FreeMapPersons, step 01: only creation and portrait loading (no stays)
+        var freeMapPersonsAndElements = parseFreeMapPersons(freemapElement, freeMapID);
+        var freeMapPersons = freeMapPersonsAndElements.stream().map(aPair -> aPair.getKey()).collect(Collectors.toList());
+        var freeMapPersonsById = freeMapPersons.stream().collect(Collectors.toMap(FreeMapPerson::getId, p -> p));
+        // parse FreemapPlaces
+        var freeMapPlaces = parseFreeMapPlaces(freemapElement, freeMapID, freeMapProperties, freeMapPersonsById);
+        var freeMapPlacesById = freeMapPlaces.stream().collect(Collectors.toMap(FreeMapPlace::getId, p -> p));
+        //
+        // parse FreeMapStays
+        List<FreeMapStay> freeMapStays = new LinkedList<>();
+        freeMapPersonsAndElements.forEach(
+                pair -> freeMapStays.addAll(
+                        parseFreeMapPersonStep02(pair.getValue(), pair.getKey(), freeMapPlacesById))
+        );
+        var freeMapStaysById = freeMapStays.stream().collect(Collectors.toMap(FreeMapStay::getId, s -> s));
+        // create FreeMap
+        var freeMap = FriezeFreeMapFactory.createFriezeFreeMap(freeMapID, frieze, freeMapProperties, dateHandles, freeMapPersons, freeMapPlaces, freeMapStays);
+        freeMap.setName(freeMapName);
+        // create Portraits
+        freeMapPersonsAndElements.forEach(pair -> parseFreeMapPersonStep03(pair.getValue(), pair.getKey(), freeMapStaysById));
+        //
+        frieze.addFriezeFreeMap(freeMap);
+    }
+
+    private static Map<String, String> parseFreeMapParameters(Element freemapElement) {
+        Map<String, String> parameters = new HashMap<>();
+        //
+        var freemapParametersElements = freemapElement.getElementsByTagName(PARAMETER_ELEMENT);
+        for (int i = 0; i < freemapParametersElements.getLength(); i++) {
+            var paramElement = (Element) freemapParametersElements.item(i);
+            var paramName = paramElement.getAttribute(PARAMETER_NAME_ATR);
+            var paramValue = paramElement.getAttribute(PARAMETER_VALUE_ATR);
+            parameters.put(paramName, paramValue);
+        }
+        return parameters;
+    }
+
+    private static List<FreeMapDateHandle> parseFreeMapDateHandles(Element freemapElement, long parentFreeMapID) {
+        var freemapDateHandleGroupElement = firstDirectChildByTagName(freemapElement, FREEMAP_DATE_HANDLES_GROUP);
+        if (freemapDateHandleGroupElement == null) {
+            throw new IllegalStateException("Error while parsing FreeMapDateHandles: " + FREEMAP_DATE_HANDLES_GROUP + " count = 0");
+        }
+
+        List<FreeMapDateHandle> freeMapDateHandles = new LinkedList<>();
+        var freemapDateHandlesElements = freemapDateHandleGroupElement.getElementsByTagName(FREEMAP_DATE_HANDLE_ELEMENT);
+        for (int i = 0; i < freemapDateHandlesElements.getLength(); i++) {
+            var dateHandleElement = (Element) freemapDateHandlesElements.item(i);
+            var date = parseDoubleAttribute(dateHandleElement, DATE_ATR);
+            var xPos = parseDoubleAttribute(dateHandleElement, X_POS_ATR);
+            var yPos = parseDoubleAttribute(dateHandleElement, Y_POS_ATR);
+            var type = FreeMapDateHandle.TimeType.valueOf(dateHandleElement.getAttribute(TYPE_ATR));
+            var freemapDateHandle = FreeMapDateHandle.createFreeMapDateHandle(parentFreeMapID, date, type, new Point2D(xPos, yPos));
+            freeMapDateHandles.add(freemapDateHandle);
+        }
+        return freeMapDateHandles;
+    }
+
+    private static List<Pair<FreeMapPerson, Element>> parseFreeMapPersons(Element freemapElement, long parentFreeMapID) {
+        var freemapPersonsElement = firstDirectChildByTagName(freemapElement, FREEMAP_PERSONS_GROUP);
+        if (freemapPersonsElement == null) {
+            throw new IllegalStateException("Error while parsing FreeMapPersons: " + FREEMAP_PERSONS_GROUP + " count = 0");
+        }
+        //
+        List<Pair<FreeMapPerson, Element>> freeMapPersons = new LinkedList<>();
+        var freemapPersonsElements = freemapPersonsElement.getElementsByTagName(FREEMAP_PERSON_ELEMENT);
+        for (int i = 0; i < freemapPersonsElements.getLength(); i++) {
+            var personElement = (Element) freemapPersonsElements.item(i);
+            var freeMapPerson = parseFreeMapPersonStep01(personElement, parentFreeMapID);
+            freeMapPersons.add(new Pair<>(freeMapPerson, personElement));
+        }
+        return freeMapPersons;
+    }
+
+    private static FreeMapPerson parseFreeMapPersonStep01(Element freemapPersonElement, long parentFreeMapID) {
+        var personID = Long.parseLong(freemapPersonElement.getAttribute(ID_ATR));
+        // a FreeMapPerson shall always have the same id as the person it represents
+        var person = PersonFactory.getPerson(personID);
+        var freeMapPerson = FreeMapPerson.createFreeMapPerson(parentFreeMapID, person);
+        LOG.log(Level.FINE, "Created {0}", new Object[]{freeMapPerson});
+        return freeMapPerson;
+    }
+
+    private static List<FreeMapStay> parseFreeMapPersonStep02(Element freemapPersonElement, FreeMapPerson freeMapPerson, Map<Long, FreeMapPlace> freeMapPlacesById) {
+        // parse stays
+        var freemapStaysGroupElement = firstDirectChildByTagName(freemapPersonElement, FREEMAP_STAYS_GROUP);
+        if (freemapStaysGroupElement == null) {
+            throw new IllegalStateException("Error while parsing FreemapStays: " + FREEMAP_STAYS_GROUP + " count = 0");
+        }
+        //
+        List<FreeMapStay> stays = new LinkedList<>();
+        var freemapStaysElements = freemapStaysGroupElement.getElementsByTagName(FREEMAP_STAY_ELEMENT);
+        for (int i = 0; i < freemapStaysElements.getLength(); i++) {
+            var freemapStayElement = (Element) freemapStaysElements.item(i);
+            var freemapStay = parseFreeMapStay(freemapStayElement, freeMapPerson, freeMapPlacesById);
+            stays.add(freemapStay);
+        }
+        return stays;
+    }
+
+    private static FreeMapStay parseFreeMapStay(Element freemapStayElement, FreeMapPerson freeMapPerson, Map<Long, FreeMapPlace> freeMapPlacesById) {
+        var freeMapStayID = Long.parseLong(freemapStayElement.getAttribute(ID_ATR));
+        var isMerged = Boolean.parseBoolean(freemapStayElement.getAttribute(FREEMAP_IS_MERGED_ATR));
+        if (isMerged) {
+            throw new UnsupportedOperationException("TODO: handle merged freemap stays");
+        }
+        //
+        var startID = Long.parseLong(freemapStayElement.getAttribute(START_ID_ATR));
+        var endID = Long.parseLong(freemapStayElement.getAttribute(END_ID_ATR));
+        var personID = Long.parseLong(freemapStayElement.getAttribute(PERSON_REF_ATR));
+        var placeID = Long.parseLong(freemapStayElement.getAttribute(PLACE_REF_ATR));
+        //
+        if (freeMapPerson.getId() != personID) {
+            throw new IllegalStateException("Could not parse FreeMapStay: could not find corresponding FreeMapPerson " + personID + " since was give " + freeMapPerson);
+        }
+        var place = freeMapPlacesById.get(placeID);
+        if (place == null) {
+            throw new IllegalStateException("Could not parse FreeMapStay: could not find corresponding FreeMapPlace " + placeID);
+        }
+        // this is only the case since I do not handle yet merged stays
+        var stayPeriodID = Long.parseLong(freemapStayElement.getAttribute(STAY_ID_ATR));
+        var stayPeriod = StayFactory.getStay(stayPeriodID);
+        if (stayPeriod == null) {
+            /*
+            var allStaysIncluded = freeMapStay.getStayPeriods();
+            allStaysIncluded.forEach(includedStay -> {
+            final var includedStaylement = doc.createElement(STAY_ELEMENT_REF);
+                includedStaylement.setAttribute(ID_ATR, Long.toString(includedStay.getId()));
+                stayElement.appendChild(includedStaylement);
+            });
+             */
+
+            throw new IllegalStateException("Could not parse FreeMapStay: could not find corresponding StayPeriod " + stayPeriodID);
+        }
+        var freeMapStay = FreeMapStayFactory.createFreeMapStay(freeMapStayID, stayPeriod, startID, endID, freeMapPerson, place);
+        //
+        return freeMapStay;
+    }
+
+    private static void parseFreeMapPersonStep03(Element freemapPersonElement, FreeMapPerson freeMapPerson, Map<Long, FreeMapStay> freeMapStaysById) {
+        // parse portrais
+        var freemapPortraitsGroupElement = firstDirectChildByTagName(freemapPersonElement, FREEMAP_PORTRAITS_GROUP);
+        if (freemapPortraitsGroupElement == null) {
+            throw new IllegalStateException("Error while parsing FreemapPortraits: " + FREEMAP_PORTRAITS_GROUP + " count = 0");
+        }
+        //
+        var freemapPortraitsElements = freemapPortraitsGroupElement.getElementsByTagName(PORTRAIT_ELEMENT);
+        for (int i = 0; i < freemapPortraitsElements.getLength(); i++) {
+            var freemapPortraitElement = (Element) freemapPortraitsElements.item(i);
+            var freemapPortrait = parseFreeMapPortrait(freemapPortraitElement, freeMapPerson, freeMapStaysById);
+            LOG.log(Level.FINE, "Created FreeMapPortrait: {0}", new Object[]{freemapPortrait});
+        }
+    }
+
+    private static FreeMapPortrait parseFreeMapPortrait(Element freemapPortraitElement, FreeMapPerson freeMapPerson, Map<Long, FreeMapStay> freeMapStaysById) {
+        var freeMapPortraitID = Long.parseLong(freemapPortraitElement.getAttribute(ID_ATR));
+        var personID = Long.parseLong(freemapPortraitElement.getAttribute(PERSON_ATR));
+        var portraitRef = Long.parseLong(freemapPortraitElement.getAttribute(PORTRAIT_REF_ATR));
+        var xPos = parseDoubleAttribute(freemapPortraitElement, X_POS_ATR);
+        var yPos = parseDoubleAttribute(freemapPortraitElement, Y_POS_ATR);
+        var radius = parseDoubleAttribute(freemapPortraitElement, RADIUS_ATR);
+        //
+        var person = PersonFactory.getPerson(personID);
+        var portrait = person.getPortrait(portraitRef);
+        //
+        var freemapPortrait = FreeMapPortraitFactory.createFreeMapPortrait(freeMapPortraitID, portrait, freeMapPerson, radius);
+        //
+        var aPortraitLink = parsePortraitLink(freemapPortraitElement, freemapPortrait, freeMapStaysById);
+        //
+        freeMapPerson.addFreeMapPortrait(freemapPortrait, aPortraitLink);
+        //
+        freemapPortrait.setRadius(radius);
+        freemapPortrait.setX(xPos);
+        freemapPortrait.setY(yPos);
+        //
+        return freemapPortrait;
+    }
+
+    private static PortraitLink parsePortraitLink(Element freeMapPortraitElement, FreeMapPortrait aFreeMapPortrait, Map<Long, FreeMapStay> freeMapStaysById) {
+        var portraitLinkElement = firstDirectChildByTagName(freeMapPortraitElement, FREEMAP_PORTRAIT_LINK_ELEMENT);
+        if (portraitLinkElement == null) {
+            throw new IllegalStateException("Not 1 " + FREEMAP_PORTRAIT_LINK_ELEMENT + " in freeMapPortraitElement but 0.");
+        }
+        var anID = Long.parseLong(portraitLinkElement.getAttribute(ID_ATR));
+        //
+        //
+        var stayConnectorElement = firstDirectChildByTagName(portraitLinkElement, FREEMAP_CONNECTOR_ELEMENT);
+        if (stayConnectorElement == null) {
+            throw new IllegalStateException("Not 1 " + FREEMAP_CONNECTOR_ELEMENT + " in freeMapPortraitElement but 0.");
+        }
+        var stayConnector = parseConnectorElement(stayConnectorElement, freeMapStaysById);
+        //
+        var portraitLink = FreeMapLinkFactory.createPortraitLink(anID, aFreeMapPortrait, stayConnector);
+        LOG.log(Level.INFO, "Created protrait link: {0}.", new Object[]{portraitLink});
+        return portraitLink;
+    }
+
+    private static List<FreeMapPlace> parseFreeMapPlaces(Element freemapElement, long parentFreeMapID, FriezeFreeMapProperties freeMapProperties, Map<Long, FreeMapPerson> freeMapPersonsById) {
+        var freemapPlacesElement = firstDirectChildByTagName(freemapElement, FREEMAP_PLACES_GROUP);
+        if (freemapPlacesElement == null) {
+            throw new IllegalStateException("Error while parsing FreeMapPlaces: " + FREEMAP_PERSONS_GROUP + " count = 0");
+        }
+        //
+        List<FreeMapPlace> freeMapPlaces = new LinkedList<>();
+        var freemapPlacesElements = freemapPlacesElement.getElementsByTagName(FREEMAP_PLACE_ELEMENT);
+        for (int i = 0; i < freemapPlacesElements.getLength(); i++) {
+            var placeElement = (Element) freemapPlacesElements.item(i);
+            var freeMapPlace = parseFreeMapPlace(placeElement, parentFreeMapID, freeMapProperties, freeMapPersonsById);
+            freeMapPlaces.add(freeMapPlace);
+        }
+        return freeMapPlaces;
+    }
+
+    private static FreeMapPlace parseFreeMapPlace(Element freemapPlaceElement, long parentFreeMapID, FriezeFreeMapProperties freeMapProperties, Map<Long, FreeMapPerson> freeMapPersonsById) {
+        var placeID = Long.parseLong(freemapPlaceElement.getAttribute(PLACE_ID_ATR));
+        var height = parseDoubleAttribute(freemapPlaceElement, HEIGHT_ATR);
+        var yPos = parseDoubleAttribute(freemapPlaceElement, Y_POS_ATR);
+        var fontSize = parseDoubleAttribute(freemapPlaceElement, FREEMAP_FONT_SIZE_ATR);
+        var nameWidth = parseDoubleAttribute(freemapPlaceElement, FREEMAP_PLACE_NAME_WIDTH_ATR);
+        //
+        var place = PlaceFactory.getPlace(placeID);
+        //
+        var freeMapPlace = FreeMapPlace.createFreeMapPlace(parentFreeMapID, place, freeMapProperties.plotSeparation(), nameWidth, fontSize);
+        //
+        freeMapPlace.setHeight(height);
+        freeMapPlace.setY(yPos);
+        //
+        var freemapPersonsElements = freemapPlaceElement.getElementsByTagName(FREEMAP_PERSON_ELEMENT);
+        FreeMapPerson[] sortedPersonsInPlace = new FreeMapPerson[freemapPersonsElements.getLength()];
+        for (int i = 0; i < freemapPersonsElements.getLength(); i++) {
+            var personElement = (Element) freemapPersonsElements.item(i);
+            var personId = Long.parseLong(personElement.getAttribute(ID_ATR));
+            var personIndex = Integer.parseInt(personElement.getAttribute(INDEX_ATR));
+            var person = freeMapPersonsById.get(personId);
+            sortedPersonsInPlace[personIndex] = person;
+        }
+        freeMapPlace.setPersonOrder(sortedPersonsInPlace);
+        return freeMapPlace;
+    }
+
+    private static FreeMapConnector parseConnectorElement(Element freeMapConnectorElement, Map<Long, FreeMapStay> freeMapStaysById) {
+        var connectorID = Long.parseLong(freeMapConnectorElement.getAttribute(ID_ATR));
+        var date = parseDoubleAttribute(freeMapConnectorElement, DATE_ATR);
+        var colorS = freeMapConnectorElement.getAttribute(COLOR_ATR);
+        var xPos = parseDoubleAttribute(freeMapConnectorElement, X_POS_ATR);
+        var yPos = parseDoubleAttribute(freeMapConnectorElement, Y_POS_ATR);
+        LOG.log(Level.FINE, "parseConnectorElement ignoring field color: {0}.", new Object[]{colorS});
+        LOG.log(Level.FINE, "parseConnectorElement ignoring field xPos: {0}.", new Object[]{xPos});
+        LOG.log(Level.FINE, "parseConnectorElement ignoring field yPos: {0}.", new Object[]{yPos});
+        var plotSize = parseDoubleAttribute(freeMapConnectorElement, PLOT_SIZE_ATR);
+        var linkedElementID = Long.parseLong(freeMapConnectorElement.getAttribute(FREEMAP_LINKED_ELEMENT_ID_ATR));
+        //
+        var stayLink = freeMapStaysById.get(linkedElementID);
+        if (stayLink == null) {
+            throw new IllegalStateException("Could not find stay with id=" + linkedElementID + "for connectorID=" + connectorID);
+        }
+        var stayLinkConnector = FreeMapConnectorFactory.createFreeMapLinkConnector(connectorID, stayLink, date, plotSize);
+        LOG.log(Level.INFO, "Created freemapConnector {0}.", new Object[]{stayLinkConnector});
+        //
+        return stayLinkConnector;
+    }
+
+    @Override
+    public String toString() {
+        return this.getClass().getSimpleName();
+    }
+
+}

--- a/src/main/java/com/github/noony/app/timelinefx/save/v4/FreeMapProviderV4.java
+++ b/src/main/java/com/github/noony/app/timelinefx/save/v4/FreeMapProviderV4.java
@@ -53,7 +53,7 @@ import static com.github.noony.app.timelinefx.save.v4.TimeProjectProviderV4.*;
  *
  * @author hamon
  */
-public class FreeMapProviderV4 {
+public final class FreeMapProviderV4 {
 
     /**
      * XML group element name for the free maps section.
@@ -267,7 +267,7 @@ public class FreeMapProviderV4 {
         } else {
             stayElement.setAttribute(FREEMAP_IS_MERGED_ATR, Boolean.TRUE.toString());
             subStays.forEach(subStay -> stayElement.appendChild(saveFreeMapStayElement(doc, subStay)));
-            // TODO: improve, but will require to update stay management in merge stays
+            // could be improved, but will require to update stay management in merge stays first
             allStaysIncluded.forEach(includedStay -> {
                 final var includedStaylement = doc.createElement(STAY_ELEMENT_REF);
                 includedStaylement.setAttribute(ID_ATR, Long.toString(includedStay.getId()));

--- a/src/main/java/com/github/noony/app/timelinefx/save/v4/FreeMapProviderV4.java
+++ b/src/main/java/com/github/noony/app/timelinefx/save/v4/FreeMapProviderV4.java
@@ -49,74 +49,146 @@ import org.w3c.dom.Element;
 import static com.github.noony.app.timelinefx.save.v4.TimeProjectProviderV4.*;
 
 /**
+ * Reads and writes {@link FriezeFreeMap} objects for save format version 4.
  *
  * @author hamon
  */
 public class FreeMapProviderV4 {
 
+    /**
+     * XML group element name for the free maps section.
+     */
     protected static final String FREEMAPS_GROUP = "freeMaps";
 
+    /**
+     * XML group element name for a free map's places.
+     */
     private static final String FREEMAP_PLACES_GROUP = "freeMapPlaces";
 
+    /**
+     * XML group element name for a free map's persons.
+     */
     private static final String FREEMAP_PERSONS_GROUP = "freeMapPersons";
 
+    /**
+     * XML group element name for a free map's date handles.
+     */
     private static final String FREEMAP_DATE_HANDLES_GROUP = "freeMapDateHandles";
 
+    /**
+     * XML group element name for a person's portraits within a free map.
+     */
     private static final String FREEMAP_PORTRAITS_GROUP = "freeMapPortraits";
 
+    /**
+     * XML group element name for a person's stays within a free map.
+     */
     private static final String FREEMAP_STAYS_GROUP = "freeMapStays";
 
+    /**
+     * XML group element name for a free map's layout parameters.
+     */
     private static final String FREEMAP_PARAMETERS_GROUP = "freeMapParameters";
 
+    /**
+     * XML element name for a single free map.
+     */
     private static final String FREEMAP_ELEMENT = "freeMap";
 
+    /**
+     * XML element name for a single free map layout parameter.
+     */
     private static final String PARAMETER_ELEMENT = "parameter";
 
+    /**
+     * XML attribute name for a parameter's name.
+     */
     private static final String PARAMETER_NAME_ATR = "name";
 
+    /**
+     * XML attribute name for a parameter's value.
+     */
     private static final String PARAMETER_VALUE_ATR = "value";
 
+    /**
+     * XML element name for a free map person.
+     */
     private static final String FREEMAP_PERSON_ELEMENT = "freeMapPerson";
 
+    /**
+     * XML element name for a free map place.
+     */
     private static final String FREEMAP_PLACE_ELEMENT = "freeMapPlace";
 
+    /**
+     * XML element name for a free map stay.
+     */
     private static final String FREEMAP_STAY_ELEMENT = "freeMapStay";
 
+    /**
+     * XML element name for a free map date handle.
+     */
     private static final String FREEMAP_DATE_HANDLE_ELEMENT = "freeMapDateHandle";
 
+    /**
+     * XML element name for a free map connector.
+     */
     private static final String FREEMAP_CONNECTOR_ELEMENT = "connector";
 
+    /**
+     * XML element name for a portrait's link to its stay connector.
+     */
     private static final String FREEMAP_PORTRAIT_LINK_ELEMENT = "portraitLink";
 
+    /**
+     * XML attribute name for a place's name width.
+     */
     private static final String FREEMAP_PLACE_NAME_WIDTH_ATR = "placeNameWidth";
 
+    /**
+     * XML attribute name for a place's font size.
+     */
     private static final String FREEMAP_FONT_SIZE_ATR = "fontSize";
 
+    /**
+     * XML attribute name for the id of the element a connector is linked to.
+     */
     private static final String FREEMAP_LINKED_ELEMENT_ID_ATR = "linkedElementID";
+
+    /**
+     * XML attribute name for whether a free map stay is a merge of several stays.
+     */
     private static final String FREEMAP_IS_MERGED_ATR = "isMerged";
 
+    /**
+     * Logger used by this class.
+     */
     private static final Logger LOG = Logger.getGlobal();
 
-    protected static Element saveFreeMapElement(Document doc, FriezeFreeMap friezeFreeMap) {
+    private FreeMapProviderV4() {
+        // private utility constructor
+    }
+
+    protected static Element saveFreeMapElement(final Document doc, final FriezeFreeMap friezeFreeMap) {
         LOG.log(Level.INFO, "Saving FriezeFreeMap: {0}", new Object[]{friezeFreeMap});
         //
-        var friezeFreeMapElement = doc.createElement(FREEMAP_ELEMENT);
+        final var friezeFreeMapElement = doc.createElement(FREEMAP_ELEMENT);
         friezeFreeMapElement.setAttribute(NAME_ATR, friezeFreeMap.getName());
         friezeFreeMapElement.setAttribute(ID_ATR, Long.toString(friezeFreeMap.getId()));
         //
-        var configGroupElement = doc.createElement(FREEMAP_PARAMETERS_GROUP);
+        final var configGroupElement = doc.createElement(FREEMAP_PARAMETERS_GROUP);
         friezeFreeMap.getParemeters().forEach((pName, pString) -> configGroupElement.appendChild(saveParameter(doc, pName, pString)));
         friezeFreeMapElement.appendChild(configGroupElement);
         // Places
-        var placeGroupElement = doc.createElement(FREEMAP_PLACES_GROUP);
+        final var placeGroupElement = doc.createElement(FREEMAP_PLACES_GROUP);
         friezeFreeMap.getPlaces().forEach(p -> placeGroupElement.appendChild(saveFreeMapPlaceElement(doc, p)));
         friezeFreeMapElement.appendChild(placeGroupElement);
         // Person
-        var personsGroupElement = doc.createElement(FREEMAP_PERSONS_GROUP);
+        final var personsGroupElement = doc.createElement(FREEMAP_PERSONS_GROUP);
         friezeFreeMap.getPersons().forEach(p -> personsGroupElement.appendChild(saveFreeMapPersonElement(doc, p)));
         friezeFreeMapElement.appendChild(personsGroupElement);
         // Date handles
-        var dateHandlesGroupElement = doc.createElement(FREEMAP_DATE_HANDLES_GROUP);
+        final var dateHandlesGroupElement = doc.createElement(FREEMAP_DATE_HANDLES_GROUP);
         friezeFreeMap.getStartDateHandles().forEach(s -> dateHandlesGroupElement.appendChild(saveFreeMapDateHandleElement(doc, s)));
         friezeFreeMap.getEndDateHandles().forEach(e -> dateHandlesGroupElement.appendChild(saveFreeMapDateHandleElement(doc, e)));
         friezeFreeMapElement.appendChild(dateHandlesGroupElement);
@@ -124,40 +196,40 @@ public class FreeMapProviderV4 {
         return friezeFreeMapElement;
     }
 
-    private static Element saveParameter(Document doc, String aName, String aValueString) {
-        var paramElement = doc.createElement(PARAMETER_ELEMENT);
+    private static Element saveParameter(final Document doc, final String aName, final String aValueString) {
+        final var paramElement = doc.createElement(PARAMETER_ELEMENT);
         paramElement.setAttribute(PARAMETER_NAME_ATR, aName);
         paramElement.setAttribute(PARAMETER_VALUE_ATR, aValueString);
         return paramElement;
     }
 
-    private static Element saveFreeMapPersonElement(Document doc, FreeMapPerson freeMapPerson) {
-        var personElement = doc.createElement(FREEMAP_PERSON_ELEMENT);
+    private static Element saveFreeMapPersonElement(final Document doc, final FreeMapPerson freeMapPerson) {
+        final var personElement = doc.createElement(FREEMAP_PERSON_ELEMENT);
         personElement.setAttribute(ID_ATR, Long.toString(freeMapPerson.getId()));
         // stays
-        var staysGroupElement = doc.createElement(FREEMAP_STAYS_GROUP);
+        final var staysGroupElement = doc.createElement(FREEMAP_STAYS_GROUP);
         personElement.appendChild(staysGroupElement);
         freeMapPerson.getFreeMapStays().forEach(fmStay -> {
             final var fmStayElement = saveFreeMapStayElement(doc, fmStay);
             staysGroupElement.appendChild(fmStayElement);
         });
-        var portraitsGroupElement = doc.createElement(FREEMAP_PORTRAITS_GROUP);
+        final var portraitsGroupElement = doc.createElement(FREEMAP_PORTRAITS_GROUP);
         personElement.appendChild(portraitsGroupElement);
         freeMapPerson.getFreeMapPortraits().forEach(fmPortrait -> {
-            var fmPortraitElement = saveFreeMapPortraitElement(doc, fmPortrait);
+            final var fmPortraitElement = saveFreeMapPortraitElement(doc, fmPortrait);
             portraitsGroupElement.appendChild(fmPortraitElement);
         });
         return personElement;
     }
 
-    private static Element saveFreeMapPlaceElement(Document doc, FreeMapPlace freeMapPlace) {
-        var placeElement = doc.createElement(FREEMAP_PLACE_ELEMENT);
+    private static Element saveFreeMapPlaceElement(final Document doc, final FreeMapPlace freeMapPlace) {
+        final var placeElement = doc.createElement(FREEMAP_PLACE_ELEMENT);
         placeElement.setAttribute(PLACE_ID_ATR, Long.toString(freeMapPlace.getPlace().getId()));
         placeElement.setAttribute(HEIGHT_ATR, Double.toString(freeMapPlace.getHeight()));
         placeElement.setAttribute(Y_POS_ATR, Double.toString(freeMapPlace.getYPos()));
         placeElement.setAttribute(FREEMAP_FONT_SIZE_ATR, Double.toString(freeMapPlace.getFontSize()));
         placeElement.setAttribute(FREEMAP_PLACE_NAME_WIDTH_ATR, Double.toString(freeMapPlace.getNameWidth()));
-        var personsAtPlace = freeMapPlace.getPersons();
+        final var personsAtPlace = freeMapPlace.getPersons();
         for (int i = 0; i < personsAtPlace.size(); i++) {
             final var personElement = doc.createElement(FREEMAP_PERSON_ELEMENT);
             personElement.setAttribute(INDEX_ATR, Integer.toString(i));
@@ -167,8 +239,8 @@ public class FreeMapProviderV4 {
         return placeElement;
     }
 
-    private static Element saveFreeMapDateHandleElement(Document doc, FreeMapDateHandle freeMapDateHandle) {
-        var freeMapDateHandleElement = doc.createElement(FREEMAP_DATE_HANDLE_ELEMENT);
+    private static Element saveFreeMapDateHandleElement(final Document doc, final FreeMapDateHandle freeMapDateHandle) {
+        final var freeMapDateHandleElement = doc.createElement(FREEMAP_DATE_HANDLE_ELEMENT);
         freeMapDateHandleElement.setAttribute(DATE_ATR, Double.toString(freeMapDateHandle.getDate()));
         freeMapDateHandleElement.setAttribute(X_POS_ATR, Double.toString(freeMapDateHandle.getXPos()));
         freeMapDateHandleElement.setAttribute(Y_POS_ATR, Double.toString(freeMapDateHandle.getYPos()));
@@ -177,7 +249,7 @@ public class FreeMapProviderV4 {
         return freeMapDateHandleElement;
     }
 
-    private static Element saveFreeMapStayElement(Document doc, FreeMapStay freeMapStay) {
+    private static Element saveFreeMapStayElement(final Document doc, final FreeMapStay freeMapStay) {
         // TODO, evaluate not saving stays inside persons but at freemap level ?
         final var stayElement = doc.createElement(FREEMAP_STAY_ELEMENT);
         stayElement.setAttribute(ID_ATR, Long.toString(freeMapStay.getId()));
@@ -185,9 +257,9 @@ public class FreeMapProviderV4 {
         stayElement.setAttribute(END_ID_ATR, Long.toString(freeMapStay.getEndPlot().getId()));
         stayElement.setAttribute(PERSON_REF_ATR, Long.toString(freeMapStay.getPerson().getId()));
         stayElement.setAttribute(PLACE_REF_ATR, Long.toString(freeMapStay.getPlace().getId()));
-        var subStays = freeMapStay.getFreeMapStayPeriods();
+        final var subStays = freeMapStay.getFreeMapStayPeriods();
         // made it more readable and easy to update
-        var allStaysIncluded = freeMapStay.getStayPeriods();
+        final var allStaysIncluded = freeMapStay.getStayPeriods();
         if (subStays.isEmpty()) {
             stayElement.setAttribute(FREEMAP_IS_MERGED_ATR, Boolean.FALSE.toString());
             stayElement.setAttribute(STAY_ID_ATR, Long.toString(allStaysIncluded.get(0).getId()));
@@ -207,8 +279,8 @@ public class FreeMapProviderV4 {
         return stayElement;
     }
 
-    private static Element saveFreeMapPortraitElement(Document doc, FreeMapPortrait freeMapPortrait) {
-        var portraitElement = doc.createElement(PORTRAIT_ELEMENT);
+    private static Element saveFreeMapPortraitElement(final Document doc, final FreeMapPortrait freeMapPortrait) {
+        final var portraitElement = doc.createElement(PORTRAIT_ELEMENT);
         portraitElement.setAttribute(ID_ATR, Long.toString(freeMapPortrait.getId()));
         portraitElement.setAttribute(PERSON_ATR, Long.toString(freeMapPortrait.getPerson().getId()));
         portraitElement.setAttribute(X_POS_ATR, Double.toString(freeMapPortrait.getX()));
@@ -216,25 +288,25 @@ public class FreeMapProviderV4 {
         portraitElement.setAttribute(RADIUS_ATR, Double.toString(freeMapPortrait.getRadius()));
         portraitElement.setAttribute(PORTRAIT_REF_ATR, Long.toString(freeMapPortrait.getPortrait().getId()));
         //
-        var portraitLink = freeMapPortrait.getPerson().getPortraitLink(freeMapPortrait);
+        final var portraitLink = freeMapPortrait.getPerson().getPortraitLink(freeMapPortrait);
         //
-        var portraitLinkElement = savePortraitLinkElement(doc, portraitLink);
+        final var portraitLinkElement = savePortraitLinkElement(doc, portraitLink);
         portraitElement.appendChild(portraitLinkElement);
         return portraitElement;
     }
 
-    private static Element savePortraitLinkElement(Document doc, PortraitLink aPortraitLink) {
-        var portraitLinkElement = doc.createElement(FREEMAP_PORTRAIT_LINK_ELEMENT);
+    private static Element savePortraitLinkElement(final Document doc, final PortraitLink aPortraitLink) {
+        final var portraitLinkElement = doc.createElement(FREEMAP_PORTRAIT_LINK_ELEMENT);
         portraitLinkElement.setAttribute(ID_ATR, Long.toString(aPortraitLink.getId()));
         //
-        var stayConnetorElement = saveConnectorElement(doc, aPortraitLink.getEndConnector());
+        final var stayConnetorElement = saveConnectorElement(doc, aPortraitLink.getEndConnector());
         portraitLinkElement.appendChild(stayConnetorElement);
 
         return portraitLinkElement;
     }
 
-    private static Element saveConnectorElement(Document doc, FreeMapConnector connector) {
-        var connectorElement = doc.createElement(FREEMAP_CONNECTOR_ELEMENT);
+    private static Element saveConnectorElement(final Document doc, final FreeMapConnector connector) {
+        final var connectorElement = doc.createElement(FREEMAP_CONNECTOR_ELEMENT);
         connectorElement.setAttribute(ID_ATR, Long.toString(connector.getId()));
         connectorElement.setAttribute(FREEMAP_LINKED_ELEMENT_ID_ATR, Long.toString(connector.getLinkedElementID()));
         connectorElement.setAttribute(COLOR_ATR, connector.getColor().toString());
@@ -248,42 +320,42 @@ public class FreeMapProviderV4 {
     //
     //
     //
-    protected static void parseFreeMaps(Element freemapsRootElement, Frieze frieze) {
-        var freemapElements = freemapsRootElement.getChildNodes();
+    protected static void parseFreeMaps(final Element freemapsRootElement, final Frieze frieze) {
+        final var freemapElements = freemapsRootElement.getChildNodes();
         for (int i = 0; i < freemapElements.getLength(); i++) {
             if (freemapElements.item(i).getNodeName().equals(FREEMAP_ELEMENT)) {
-                var e = (Element) freemapElements.item(i);
+                final var e = (Element) freemapElements.item(i);
                 parseFreeMap(e, frieze);
             }
         }
     }
 
-    private static void parseFreeMap(Element freemapElement, Frieze frieze) {
-        var freeMapID = Long.parseLong(freemapElement.getAttribute(ID_ATR));
-        var freeMapName = freemapElement.getAttribute(NAME_ATR);
+    private static void parseFreeMap(final Element freemapElement, final Frieze frieze) {
+        final var freeMapID = Long.parseLong(freemapElement.getAttribute(ID_ATR));
+        final var freeMapName = freemapElement.getAttribute(NAME_ATR);
         // parse parameters
-        var freeMapParameters = parseFreeMapParameters(freemapElement);
-        var freeMapProperties = FriezeFreeMapProperties.fromParameterMap(freeMapParameters, FriezeFreeMap.DEFAULT_PROPERTIES);
+        final var freeMapParameters = parseFreeMapParameters(freemapElement);
+        final var freeMapProperties = FriezeFreeMapProperties.fromParameterMap(freeMapParameters, FriezeFreeMap.DEFAULT_PROPERTIES);
         LOG.log(Level.INFO, "Parsed Freemap {0}_{1} parameters: {2}", new Object[]{freeMapID, freeMapName, freeMapProperties});
         // parse date handles
-        var dateHandles = parseFreeMapDateHandles(freemapElement, freeMapID);
+        final var dateHandles = parseFreeMapDateHandles(freemapElement, freeMapID);
         // parse FreeMapPersons, step 01: only creation and portrait loading (no stays)
-        var freeMapPersonsAndElements = parseFreeMapPersons(freemapElement, freeMapID);
-        var freeMapPersons = freeMapPersonsAndElements.stream().map(aPair -> aPair.getKey()).collect(Collectors.toList());
-        var freeMapPersonsById = freeMapPersons.stream().collect(Collectors.toMap(FreeMapPerson::getId, p -> p));
+        final var freeMapPersonsAndElements = parseFreeMapPersons(freemapElement, freeMapID);
+        final var freeMapPersons = freeMapPersonsAndElements.stream().map(aPair -> aPair.getKey()).collect(Collectors.toList());
+        final var freeMapPersonsById = freeMapPersons.stream().collect(Collectors.toMap(FreeMapPerson::getId, p -> p));
         // parse FreemapPlaces
-        var freeMapPlaces = parseFreeMapPlaces(freemapElement, freeMapID, freeMapProperties, freeMapPersonsById);
-        var freeMapPlacesById = freeMapPlaces.stream().collect(Collectors.toMap(FreeMapPlace::getId, p -> p));
+        final var freeMapPlaces = parseFreeMapPlaces(freemapElement, freeMapID, freeMapProperties, freeMapPersonsById);
+        final var freeMapPlacesById = freeMapPlaces.stream().collect(Collectors.toMap(FreeMapPlace::getId, p -> p));
         //
         // parse FreeMapStays
-        List<FreeMapStay> freeMapStays = new LinkedList<>();
+        final List<FreeMapStay> freeMapStays = new LinkedList<>();
         freeMapPersonsAndElements.forEach(
                 pair -> freeMapStays.addAll(
                         parseFreeMapPersonStep02(pair.getValue(), pair.getKey(), freeMapPlacesById))
         );
-        var freeMapStaysById = freeMapStays.stream().collect(Collectors.toMap(FreeMapStay::getId, s -> s));
+        final var freeMapStaysById = freeMapStays.stream().collect(Collectors.toMap(FreeMapStay::getId, s -> s));
         // create FreeMap
-        var freeMap = FriezeFreeMapFactory.createFriezeFreeMap(freeMapID, frieze, freeMapProperties, dateHandles, freeMapPersons, freeMapPlaces, freeMapStays);
+        final var freeMap = FriezeFreeMapFactory.createFriezeFreeMap(freeMapID, frieze, freeMapProperties, dateHandles, freeMapPersons, freeMapPlaces, freeMapStays);
         freeMap.setName(freeMapName);
         // create Portraits
         freeMapPersonsAndElements.forEach(pair -> parseFreeMapPersonStep03(pair.getValue(), pair.getKey(), freeMapStaysById));
@@ -291,103 +363,103 @@ public class FreeMapProviderV4 {
         frieze.addFriezeFreeMap(freeMap);
     }
 
-    private static Map<String, String> parseFreeMapParameters(Element freemapElement) {
-        Map<String, String> parameters = new HashMap<>();
+    private static Map<String, String> parseFreeMapParameters(final Element freemapElement) {
+        final Map<String, String> parameters = new HashMap<>();
         //
-        var freemapParametersElements = freemapElement.getElementsByTagName(PARAMETER_ELEMENT);
+        final var freemapParametersElements = freemapElement.getElementsByTagName(PARAMETER_ELEMENT);
         for (int i = 0; i < freemapParametersElements.getLength(); i++) {
-            var paramElement = (Element) freemapParametersElements.item(i);
-            var paramName = paramElement.getAttribute(PARAMETER_NAME_ATR);
-            var paramValue = paramElement.getAttribute(PARAMETER_VALUE_ATR);
+            final var paramElement = (Element) freemapParametersElements.item(i);
+            final var paramName = paramElement.getAttribute(PARAMETER_NAME_ATR);
+            final var paramValue = paramElement.getAttribute(PARAMETER_VALUE_ATR);
             parameters.put(paramName, paramValue);
         }
         return parameters;
     }
 
-    private static List<FreeMapDateHandle> parseFreeMapDateHandles(Element freemapElement, long parentFreeMapID) {
-        var freemapDateHandleGroupElement = firstDirectChildByTagName(freemapElement, FREEMAP_DATE_HANDLES_GROUP);
+    private static List<FreeMapDateHandle> parseFreeMapDateHandles(final Element freemapElement, final long parentFreeMapID) {
+        final var freemapDateHandleGroupElement = firstDirectChildByTagName(freemapElement, FREEMAP_DATE_HANDLES_GROUP);
         if (freemapDateHandleGroupElement == null) {
             throw new IllegalStateException("Error while parsing FreeMapDateHandles: " + FREEMAP_DATE_HANDLES_GROUP + " count = 0");
         }
 
-        List<FreeMapDateHandle> freeMapDateHandles = new LinkedList<>();
-        var freemapDateHandlesElements = freemapDateHandleGroupElement.getElementsByTagName(FREEMAP_DATE_HANDLE_ELEMENT);
+        final List<FreeMapDateHandle> freeMapDateHandles = new LinkedList<>();
+        final var freemapDateHandlesElements = freemapDateHandleGroupElement.getElementsByTagName(FREEMAP_DATE_HANDLE_ELEMENT);
         for (int i = 0; i < freemapDateHandlesElements.getLength(); i++) {
-            var dateHandleElement = (Element) freemapDateHandlesElements.item(i);
-            var date = parseDoubleAttribute(dateHandleElement, DATE_ATR);
-            var xPos = parseDoubleAttribute(dateHandleElement, X_POS_ATR);
-            var yPos = parseDoubleAttribute(dateHandleElement, Y_POS_ATR);
-            var type = FreeMapDateHandle.TimeType.valueOf(dateHandleElement.getAttribute(TYPE_ATR));
-            var freemapDateHandle = FreeMapDateHandle.createFreeMapDateHandle(parentFreeMapID, date, type, new Point2D(xPos, yPos));
+            final var dateHandleElement = (Element) freemapDateHandlesElements.item(i);
+            final var date = parseDoubleAttribute(dateHandleElement, DATE_ATR);
+            final var xPos = parseDoubleAttribute(dateHandleElement, X_POS_ATR);
+            final var yPos = parseDoubleAttribute(dateHandleElement, Y_POS_ATR);
+            final var type = FreeMapDateHandle.TimeType.valueOf(dateHandleElement.getAttribute(TYPE_ATR));
+            final var freemapDateHandle = FreeMapDateHandle.createFreeMapDateHandle(parentFreeMapID, date, type, new Point2D(xPos, yPos));
             freeMapDateHandles.add(freemapDateHandle);
         }
         return freeMapDateHandles;
     }
 
-    private static List<Pair<FreeMapPerson, Element>> parseFreeMapPersons(Element freemapElement, long parentFreeMapID) {
-        var freemapPersonsElement = firstDirectChildByTagName(freemapElement, FREEMAP_PERSONS_GROUP);
+    private static List<Pair<FreeMapPerson, Element>> parseFreeMapPersons(final Element freemapElement, final long parentFreeMapID) {
+        final var freemapPersonsElement = firstDirectChildByTagName(freemapElement, FREEMAP_PERSONS_GROUP);
         if (freemapPersonsElement == null) {
             throw new IllegalStateException("Error while parsing FreeMapPersons: " + FREEMAP_PERSONS_GROUP + " count = 0");
         }
         //
-        List<Pair<FreeMapPerson, Element>> freeMapPersons = new LinkedList<>();
-        var freemapPersonsElements = freemapPersonsElement.getElementsByTagName(FREEMAP_PERSON_ELEMENT);
+        final List<Pair<FreeMapPerson, Element>> freeMapPersons = new LinkedList<>();
+        final var freemapPersonsElements = freemapPersonsElement.getElementsByTagName(FREEMAP_PERSON_ELEMENT);
         for (int i = 0; i < freemapPersonsElements.getLength(); i++) {
-            var personElement = (Element) freemapPersonsElements.item(i);
-            var freeMapPerson = parseFreeMapPersonStep01(personElement, parentFreeMapID);
+            final var personElement = (Element) freemapPersonsElements.item(i);
+            final var freeMapPerson = parseFreeMapPersonStep01(personElement, parentFreeMapID);
             freeMapPersons.add(new Pair<>(freeMapPerson, personElement));
         }
         return freeMapPersons;
     }
 
-    private static FreeMapPerson parseFreeMapPersonStep01(Element freemapPersonElement, long parentFreeMapID) {
-        var personID = Long.parseLong(freemapPersonElement.getAttribute(ID_ATR));
+    private static FreeMapPerson parseFreeMapPersonStep01(final Element freemapPersonElement, final long parentFreeMapID) {
+        final var personID = Long.parseLong(freemapPersonElement.getAttribute(ID_ATR));
         // a FreeMapPerson shall always have the same id as the person it represents
-        var person = PersonFactory.getPerson(personID);
-        var freeMapPerson = FreeMapPerson.createFreeMapPerson(parentFreeMapID, person);
+        final var person = PersonFactory.getPerson(personID);
+        final var freeMapPerson = FreeMapPerson.createFreeMapPerson(parentFreeMapID, person);
         LOG.log(Level.FINE, "Created {0}", new Object[]{freeMapPerson});
         return freeMapPerson;
     }
 
-    private static List<FreeMapStay> parseFreeMapPersonStep02(Element freemapPersonElement, FreeMapPerson freeMapPerson, Map<Long, FreeMapPlace> freeMapPlacesById) {
+    private static List<FreeMapStay> parseFreeMapPersonStep02(final Element freemapPersonElement, final FreeMapPerson freeMapPerson, final Map<Long, FreeMapPlace> freeMapPlacesById) {
         // parse stays
-        var freemapStaysGroupElement = firstDirectChildByTagName(freemapPersonElement, FREEMAP_STAYS_GROUP);
+        final var freemapStaysGroupElement = firstDirectChildByTagName(freemapPersonElement, FREEMAP_STAYS_GROUP);
         if (freemapStaysGroupElement == null) {
             throw new IllegalStateException("Error while parsing FreemapStays: " + FREEMAP_STAYS_GROUP + " count = 0");
         }
         //
-        List<FreeMapStay> stays = new LinkedList<>();
-        var freemapStaysElements = freemapStaysGroupElement.getElementsByTagName(FREEMAP_STAY_ELEMENT);
+        final List<FreeMapStay> stays = new LinkedList<>();
+        final var freemapStaysElements = freemapStaysGroupElement.getElementsByTagName(FREEMAP_STAY_ELEMENT);
         for (int i = 0; i < freemapStaysElements.getLength(); i++) {
-            var freemapStayElement = (Element) freemapStaysElements.item(i);
-            var freemapStay = parseFreeMapStay(freemapStayElement, freeMapPerson, freeMapPlacesById);
+            final var freemapStayElement = (Element) freemapStaysElements.item(i);
+            final var freemapStay = parseFreeMapStay(freemapStayElement, freeMapPerson, freeMapPlacesById);
             stays.add(freemapStay);
         }
         return stays;
     }
 
-    private static FreeMapStay parseFreeMapStay(Element freemapStayElement, FreeMapPerson freeMapPerson, Map<Long, FreeMapPlace> freeMapPlacesById) {
-        var freeMapStayID = Long.parseLong(freemapStayElement.getAttribute(ID_ATR));
-        var isMerged = Boolean.parseBoolean(freemapStayElement.getAttribute(FREEMAP_IS_MERGED_ATR));
+    private static FreeMapStay parseFreeMapStay(final Element freemapStayElement, final FreeMapPerson freeMapPerson, final Map<Long, FreeMapPlace> freeMapPlacesById) {
+        final var freeMapStayID = Long.parseLong(freemapStayElement.getAttribute(ID_ATR));
+        final var isMerged = Boolean.parseBoolean(freemapStayElement.getAttribute(FREEMAP_IS_MERGED_ATR));
         if (isMerged) {
             throw new UnsupportedOperationException("TODO: handle merged freemap stays");
         }
         //
-        var startID = Long.parseLong(freemapStayElement.getAttribute(START_ID_ATR));
-        var endID = Long.parseLong(freemapStayElement.getAttribute(END_ID_ATR));
-        var personID = Long.parseLong(freemapStayElement.getAttribute(PERSON_REF_ATR));
-        var placeID = Long.parseLong(freemapStayElement.getAttribute(PLACE_REF_ATR));
+        final var startID = Long.parseLong(freemapStayElement.getAttribute(START_ID_ATR));
+        final var endID = Long.parseLong(freemapStayElement.getAttribute(END_ID_ATR));
+        final var personID = Long.parseLong(freemapStayElement.getAttribute(PERSON_REF_ATR));
+        final var placeID = Long.parseLong(freemapStayElement.getAttribute(PLACE_REF_ATR));
         //
         if (freeMapPerson.getId() != personID) {
             throw new IllegalStateException("Could not parse FreeMapStay: could not find corresponding FreeMapPerson " + personID + " since was give " + freeMapPerson);
         }
-        var place = freeMapPlacesById.get(placeID);
+        final var place = freeMapPlacesById.get(placeID);
         if (place == null) {
             throw new IllegalStateException("Could not parse FreeMapStay: could not find corresponding FreeMapPlace " + placeID);
         }
         // this is only the case since I do not handle yet merged stays
-        var stayPeriodID = Long.parseLong(freemapStayElement.getAttribute(STAY_ID_ATR));
-        var stayPeriod = StayFactory.getStay(stayPeriodID);
+        final var stayPeriodID = Long.parseLong(freemapStayElement.getAttribute(STAY_ID_ATR));
+        final var stayPeriod = StayFactory.getStay(stayPeriodID);
         if (stayPeriod == null) {
             /*
             var allStaysIncluded = freeMapStay.getStayPeriods();
@@ -400,40 +472,40 @@ public class FreeMapProviderV4 {
 
             throw new IllegalStateException("Could not parse FreeMapStay: could not find corresponding StayPeriod " + stayPeriodID);
         }
-        var freeMapStay = FreeMapStayFactory.createFreeMapStay(freeMapStayID, stayPeriod, startID, endID, freeMapPerson, place);
+        final var freeMapStay = FreeMapStayFactory.createFreeMapStay(freeMapStayID, stayPeriod, startID, endID, freeMapPerson, place);
         //
         return freeMapStay;
     }
 
-    private static void parseFreeMapPersonStep03(Element freemapPersonElement, FreeMapPerson freeMapPerson, Map<Long, FreeMapStay> freeMapStaysById) {
+    private static void parseFreeMapPersonStep03(final Element freemapPersonElement, final FreeMapPerson freeMapPerson, final Map<Long, FreeMapStay> freeMapStaysById) {
         // parse portrais
-        var freemapPortraitsGroupElement = firstDirectChildByTagName(freemapPersonElement, FREEMAP_PORTRAITS_GROUP);
+        final var freemapPortraitsGroupElement = firstDirectChildByTagName(freemapPersonElement, FREEMAP_PORTRAITS_GROUP);
         if (freemapPortraitsGroupElement == null) {
             throw new IllegalStateException("Error while parsing FreemapPortraits: " + FREEMAP_PORTRAITS_GROUP + " count = 0");
         }
         //
-        var freemapPortraitsElements = freemapPortraitsGroupElement.getElementsByTagName(PORTRAIT_ELEMENT);
+        final var freemapPortraitsElements = freemapPortraitsGroupElement.getElementsByTagName(PORTRAIT_ELEMENT);
         for (int i = 0; i < freemapPortraitsElements.getLength(); i++) {
-            var freemapPortraitElement = (Element) freemapPortraitsElements.item(i);
-            var freemapPortrait = parseFreeMapPortrait(freemapPortraitElement, freeMapPerson, freeMapStaysById);
+            final var freemapPortraitElement = (Element) freemapPortraitsElements.item(i);
+            final var freemapPortrait = parseFreeMapPortrait(freemapPortraitElement, freeMapPerson, freeMapStaysById);
             LOG.log(Level.FINE, "Created FreeMapPortrait: {0}", new Object[]{freemapPortrait});
         }
     }
 
-    private static FreeMapPortrait parseFreeMapPortrait(Element freemapPortraitElement, FreeMapPerson freeMapPerson, Map<Long, FreeMapStay> freeMapStaysById) {
-        var freeMapPortraitID = Long.parseLong(freemapPortraitElement.getAttribute(ID_ATR));
-        var personID = Long.parseLong(freemapPortraitElement.getAttribute(PERSON_ATR));
-        var portraitRef = Long.parseLong(freemapPortraitElement.getAttribute(PORTRAIT_REF_ATR));
-        var xPos = parseDoubleAttribute(freemapPortraitElement, X_POS_ATR);
-        var yPos = parseDoubleAttribute(freemapPortraitElement, Y_POS_ATR);
-        var radius = parseDoubleAttribute(freemapPortraitElement, RADIUS_ATR);
+    private static FreeMapPortrait parseFreeMapPortrait(final Element freemapPortraitElement, final FreeMapPerson freeMapPerson, final Map<Long, FreeMapStay> freeMapStaysById) {
+        final var freeMapPortraitID = Long.parseLong(freemapPortraitElement.getAttribute(ID_ATR));
+        final var personID = Long.parseLong(freemapPortraitElement.getAttribute(PERSON_ATR));
+        final var portraitRef = Long.parseLong(freemapPortraitElement.getAttribute(PORTRAIT_REF_ATR));
+        final var xPos = parseDoubleAttribute(freemapPortraitElement, X_POS_ATR);
+        final var yPos = parseDoubleAttribute(freemapPortraitElement, Y_POS_ATR);
+        final var radius = parseDoubleAttribute(freemapPortraitElement, RADIUS_ATR);
         //
-        var person = PersonFactory.getPerson(personID);
-        var portrait = person.getPortrait(portraitRef);
+        final var person = PersonFactory.getPerson(personID);
+        final var portrait = person.getPortrait(portraitRef);
         //
-        var freemapPortrait = FreeMapPortraitFactory.createFreeMapPortrait(freeMapPortraitID, portrait, freeMapPerson, radius);
+        final var freemapPortrait = FreeMapPortraitFactory.createFreeMapPortrait(freeMapPortraitID, portrait, freeMapPerson, radius);
         //
-        var aPortraitLink = parsePortraitLink(freemapPortraitElement, freemapPortrait, freeMapStaysById);
+        final var aPortraitLink = parsePortraitLink(freemapPortraitElement, freemapPortrait, freeMapStaysById);
         //
         freeMapPerson.addFreeMapPortrait(freemapPortrait, aPortraitLink);
         //
@@ -444,85 +516,85 @@ public class FreeMapProviderV4 {
         return freemapPortrait;
     }
 
-    private static PortraitLink parsePortraitLink(Element freeMapPortraitElement, FreeMapPortrait aFreeMapPortrait, Map<Long, FreeMapStay> freeMapStaysById) {
-        var portraitLinkElement = firstDirectChildByTagName(freeMapPortraitElement, FREEMAP_PORTRAIT_LINK_ELEMENT);
+    private static PortraitLink parsePortraitLink(final Element freeMapPortraitElement, final FreeMapPortrait aFreeMapPortrait, final Map<Long, FreeMapStay> freeMapStaysById) {
+        final var portraitLinkElement = firstDirectChildByTagName(freeMapPortraitElement, FREEMAP_PORTRAIT_LINK_ELEMENT);
         if (portraitLinkElement == null) {
             throw new IllegalStateException("Not 1 " + FREEMAP_PORTRAIT_LINK_ELEMENT + " in freeMapPortraitElement but 0.");
         }
-        var anID = Long.parseLong(portraitLinkElement.getAttribute(ID_ATR));
+        final var anID = Long.parseLong(portraitLinkElement.getAttribute(ID_ATR));
         //
         //
-        var stayConnectorElement = firstDirectChildByTagName(portraitLinkElement, FREEMAP_CONNECTOR_ELEMENT);
+        final var stayConnectorElement = firstDirectChildByTagName(portraitLinkElement, FREEMAP_CONNECTOR_ELEMENT);
         if (stayConnectorElement == null) {
             throw new IllegalStateException("Not 1 " + FREEMAP_CONNECTOR_ELEMENT + " in freeMapPortraitElement but 0.");
         }
-        var stayConnector = parseConnectorElement(stayConnectorElement, freeMapStaysById);
+        final var stayConnector = parseConnectorElement(stayConnectorElement, freeMapStaysById);
         //
-        var portraitLink = FreeMapLinkFactory.createPortraitLink(anID, aFreeMapPortrait, stayConnector);
+        final var portraitLink = FreeMapLinkFactory.createPortraitLink(anID, aFreeMapPortrait, stayConnector);
         LOG.log(Level.INFO, "Created protrait link: {0}.", new Object[]{portraitLink});
         return portraitLink;
     }
 
-    private static List<FreeMapPlace> parseFreeMapPlaces(Element freemapElement, long parentFreeMapID, FriezeFreeMapProperties freeMapProperties, Map<Long, FreeMapPerson> freeMapPersonsById) {
-        var freemapPlacesElement = firstDirectChildByTagName(freemapElement, FREEMAP_PLACES_GROUP);
+    private static List<FreeMapPlace> parseFreeMapPlaces(final Element freemapElement, final long parentFreeMapID, final FriezeFreeMapProperties freeMapProperties, final Map<Long, FreeMapPerson> freeMapPersonsById) {
+        final var freemapPlacesElement = firstDirectChildByTagName(freemapElement, FREEMAP_PLACES_GROUP);
         if (freemapPlacesElement == null) {
             throw new IllegalStateException("Error while parsing FreeMapPlaces: " + FREEMAP_PERSONS_GROUP + " count = 0");
         }
         //
-        List<FreeMapPlace> freeMapPlaces = new LinkedList<>();
-        var freemapPlacesElements = freemapPlacesElement.getElementsByTagName(FREEMAP_PLACE_ELEMENT);
+        final List<FreeMapPlace> freeMapPlaces = new LinkedList<>();
+        final var freemapPlacesElements = freemapPlacesElement.getElementsByTagName(FREEMAP_PLACE_ELEMENT);
         for (int i = 0; i < freemapPlacesElements.getLength(); i++) {
-            var placeElement = (Element) freemapPlacesElements.item(i);
-            var freeMapPlace = parseFreeMapPlace(placeElement, parentFreeMapID, freeMapProperties, freeMapPersonsById);
+            final var placeElement = (Element) freemapPlacesElements.item(i);
+            final var freeMapPlace = parseFreeMapPlace(placeElement, parentFreeMapID, freeMapProperties, freeMapPersonsById);
             freeMapPlaces.add(freeMapPlace);
         }
         return freeMapPlaces;
     }
 
-    private static FreeMapPlace parseFreeMapPlace(Element freemapPlaceElement, long parentFreeMapID, FriezeFreeMapProperties freeMapProperties, Map<Long, FreeMapPerson> freeMapPersonsById) {
-        var placeID = Long.parseLong(freemapPlaceElement.getAttribute(PLACE_ID_ATR));
-        var height = parseDoubleAttribute(freemapPlaceElement, HEIGHT_ATR);
-        var yPos = parseDoubleAttribute(freemapPlaceElement, Y_POS_ATR);
-        var fontSize = parseDoubleAttribute(freemapPlaceElement, FREEMAP_FONT_SIZE_ATR);
-        var nameWidth = parseDoubleAttribute(freemapPlaceElement, FREEMAP_PLACE_NAME_WIDTH_ATR);
+    private static FreeMapPlace parseFreeMapPlace(final Element freemapPlaceElement, final long parentFreeMapID, final FriezeFreeMapProperties freeMapProperties, final Map<Long, FreeMapPerson> freeMapPersonsById) {
+        final var placeID = Long.parseLong(freemapPlaceElement.getAttribute(PLACE_ID_ATR));
+        final var height = parseDoubleAttribute(freemapPlaceElement, HEIGHT_ATR);
+        final var yPos = parseDoubleAttribute(freemapPlaceElement, Y_POS_ATR);
+        final var fontSize = parseDoubleAttribute(freemapPlaceElement, FREEMAP_FONT_SIZE_ATR);
+        final var nameWidth = parseDoubleAttribute(freemapPlaceElement, FREEMAP_PLACE_NAME_WIDTH_ATR);
         //
-        var place = PlaceFactory.getPlace(placeID);
+        final var place = PlaceFactory.getPlace(placeID);
         //
-        var freeMapPlace = FreeMapPlace.createFreeMapPlace(parentFreeMapID, place, freeMapProperties.plotSeparation(), nameWidth, fontSize);
+        final var freeMapPlace = FreeMapPlace.createFreeMapPlace(parentFreeMapID, place, freeMapProperties.plotSeparation(), nameWidth, fontSize);
         //
         freeMapPlace.setHeight(height);
         freeMapPlace.setY(yPos);
         //
-        var freemapPersonsElements = freemapPlaceElement.getElementsByTagName(FREEMAP_PERSON_ELEMENT);
-        FreeMapPerson[] sortedPersonsInPlace = new FreeMapPerson[freemapPersonsElements.getLength()];
+        final var freemapPersonsElements = freemapPlaceElement.getElementsByTagName(FREEMAP_PERSON_ELEMENT);
+        final FreeMapPerson[] sortedPersonsInPlace = new FreeMapPerson[freemapPersonsElements.getLength()];
         for (int i = 0; i < freemapPersonsElements.getLength(); i++) {
-            var personElement = (Element) freemapPersonsElements.item(i);
-            var personId = Long.parseLong(personElement.getAttribute(ID_ATR));
-            var personIndex = Integer.parseInt(personElement.getAttribute(INDEX_ATR));
-            var person = freeMapPersonsById.get(personId);
+            final var personElement = (Element) freemapPersonsElements.item(i);
+            final var personId = Long.parseLong(personElement.getAttribute(ID_ATR));
+            final var personIndex = Integer.parseInt(personElement.getAttribute(INDEX_ATR));
+            final var person = freeMapPersonsById.get(personId);
             sortedPersonsInPlace[personIndex] = person;
         }
         freeMapPlace.setPersonOrder(sortedPersonsInPlace);
         return freeMapPlace;
     }
 
-    private static FreeMapConnector parseConnectorElement(Element freeMapConnectorElement, Map<Long, FreeMapStay> freeMapStaysById) {
-        var connectorID = Long.parseLong(freeMapConnectorElement.getAttribute(ID_ATR));
-        var date = parseDoubleAttribute(freeMapConnectorElement, DATE_ATR);
-        var colorS = freeMapConnectorElement.getAttribute(COLOR_ATR);
-        var xPos = parseDoubleAttribute(freeMapConnectorElement, X_POS_ATR);
-        var yPos = parseDoubleAttribute(freeMapConnectorElement, Y_POS_ATR);
+    private static FreeMapConnector parseConnectorElement(final Element freeMapConnectorElement, final Map<Long, FreeMapStay> freeMapStaysById) {
+        final var connectorID = Long.parseLong(freeMapConnectorElement.getAttribute(ID_ATR));
+        final var date = parseDoubleAttribute(freeMapConnectorElement, DATE_ATR);
+        final var colorS = freeMapConnectorElement.getAttribute(COLOR_ATR);
+        final var xPos = parseDoubleAttribute(freeMapConnectorElement, X_POS_ATR);
+        final var yPos = parseDoubleAttribute(freeMapConnectorElement, Y_POS_ATR);
         LOG.log(Level.FINE, "parseConnectorElement ignoring field color: {0}.", new Object[]{colorS});
         LOG.log(Level.FINE, "parseConnectorElement ignoring field xPos: {0}.", new Object[]{xPos});
         LOG.log(Level.FINE, "parseConnectorElement ignoring field yPos: {0}.", new Object[]{yPos});
-        var plotSize = parseDoubleAttribute(freeMapConnectorElement, PLOT_SIZE_ATR);
-        var linkedElementID = Long.parseLong(freeMapConnectorElement.getAttribute(FREEMAP_LINKED_ELEMENT_ID_ATR));
+        final var plotSize = parseDoubleAttribute(freeMapConnectorElement, PLOT_SIZE_ATR);
+        final var linkedElementID = Long.parseLong(freeMapConnectorElement.getAttribute(FREEMAP_LINKED_ELEMENT_ID_ATR));
         //
-        var stayLink = freeMapStaysById.get(linkedElementID);
+        final var stayLink = freeMapStaysById.get(linkedElementID);
         if (stayLink == null) {
             throw new IllegalStateException("Could not find stay with id=" + linkedElementID + "for connectorID=" + connectorID);
         }
-        var stayLinkConnector = FreeMapConnectorFactory.createFreeMapLinkConnector(connectorID, stayLink, date, plotSize);
+        final var stayLinkConnector = FreeMapConnectorFactory.createFreeMapLinkConnector(connectorID, stayLink, date, plotSize);
         LOG.log(Level.INFO, "Created freemapConnector {0}.", new Object[]{stayLinkConnector});
         //
         return stayLinkConnector;

--- a/src/main/java/com/github/noony/app/timelinefx/save/v4/TimeProjectProviderV4.java
+++ b/src/main/java/com/github/noony/app/timelinefx/save/v4/TimeProjectProviderV4.java
@@ -50,6 +50,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeParseException;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
@@ -394,6 +395,11 @@ public class TimeProjectProviderV4 implements TimelineProjectProvider {
     private static final String TARGET_VERSION = "4";
 
     /**
+     * Regex matching any file name, used when scanning the portraits/pictures folders for unused files.
+     */
+    private static final String ANY_FILE_REGEX = "^(.*?)";
+
+    /**
      * Default constructor, required for this provider to be discoverable as a service.
      */
     public TimeProjectProviderV4() {
@@ -410,9 +416,9 @@ public class TimeProjectProviderV4 implements TimelineProjectProvider {
         CustomProfiler.start(loadMethodName);
         final String projectName = e.getAttribute(NAME_ATR);
         // Load project properties
-        final var portraitsFolderValue = e.hasAttribute(PORTRAIT_FOLDER_ATR) ? e.getAttribute(PORTRAIT_FOLDER_ATR) : TimeLineProject.DEFAULT_PORTRAIT_FOLDER;
-        final var picturesFolderValue = e.hasAttribute(PICTURES_FOLDER_ATR) ? e.getAttribute(PICTURES_FOLDER_ATR) : TimeLineProject.DEFAULT_PICTURES_FOLDER;
-        final var miniaturesFolderValue = e.hasAttribute(MINIATURES_FOLDER_ATR) ? e.getAttribute(MINIATURES_FOLDER_ATR) : TimeLineProject.DEFAULT_MINIATURES_FOLDER;
+        final var portraitsFolderValue = attributeOrDefault(e, PORTRAIT_FOLDER_ATR, TimeLineProject.DEFAULT_PORTRAIT_FOLDER);
+        final var picturesFolderValue = attributeOrDefault(e, PICTURES_FOLDER_ATR, TimeLineProject.DEFAULT_PICTURES_FOLDER);
+        final var miniaturesFolderValue = attributeOrDefault(e, MINIATURES_FOLDER_ATR, TimeLineProject.DEFAULT_MINIATURES_FOLDER);
         //
         final Map<String, String> configParams = Map.of(
                 TimeLineProject.PROJECT_FOLDER_KEY, projectFile.getParent(),
@@ -420,7 +426,7 @@ public class TimeProjectProviderV4 implements TimelineProjectProvider {
                 TimeLineProject.PICTURES_FOLDER_KEY, picturesFolderValue,
                 TimeLineProject.MINIATURES_FOLDER_KEY, miniaturesFolderValue
         );
-        final var timeFormatValue = e.hasAttribute(TIME_FORMAT_ATR) ? TimeFormat.valueOf(e.getAttribute(TIME_FORMAT_ATR)) : TimeFormat.LOCAL_TIME;
+        final var timeFormatValue = timeFormatOrDefault(e, TimeFormat.LOCAL_TIME);
         final TimeLineProject project = TimeLineProjectFactory.createProject(projectName, configParams, timeFormatValue);
         //
         final List<String> relativePathLoaded = new LinkedList<>();
@@ -456,41 +462,7 @@ public class TimeProjectProviderV4 implements TimelineProjectProvider {
                 }
             }
         }
-        // check every file exists
-        relativePathLoaded.forEach(path -> {
-            final var absolutePath = CustomFileUtils.fromProjectRelativeToAbsolute(project, path);
-            // not optimal ...
-            final File file = new File(absolutePath);
-            if (!file.exists()) {
-                LOG.log(Level.SEVERE, "The file {0} does not exists. (saved as {1})", new Object[]{absolutePath, path});
-            }
-        });
-        //
-        final Set<Path> absolutePathsLoaded = relativePathLoaded
-                .stream()
-                .map(p -> Paths.get(CustomFileUtils.fromProjectRelativeToAbsolute(project, p)))
-                .map(p -> p.normalize())
-                .collect(Collectors.toSet());
-        // * Portraits
-        final File portraitFolder = project.getPortraitsAbsoluteFolder();
-        FileUtils.listFiles(portraitFolder, new RegexFileFilter("^(.*?)"), DirectoryFileFilter.DIRECTORY)
-                .stream()
-                .map(portraitFile -> Paths.get(portraitFile.toURI()))
-                .filter(portraitAbsolutePath -> !absolutePathsLoaded.contains(portraitAbsolutePath))
-                .forEach(portraitAbsolutePath
-                        -> // FUTURE IMPROVMENT : create actions
-                        LOG.log(Level.WARNING, "Found unused portrait file: {0}", new Object[]{portraitAbsolutePath})
-                );
-        // * Pictures
-        final File picturesFolder = project.getPicturesFolder();
-        FileUtils.listFiles(picturesFolder, new RegexFileFilter("^(.*?)"), DirectoryFileFilter.DIRECTORY)
-                .stream()
-                .map(pictureFile -> Paths.get(pictureFile.toURI()))
-                .filter(pictureAbsolutePath -> !absolutePathsLoaded.contains(pictureAbsolutePath))
-                .forEach(pictureAbsolutePath
-                        -> // FUTURE IMPROVMENT : create actions
-                        LOG.log(Level.WARNING, "Found unused picture file: {0}", new Object[]{pictureAbsolutePath})
-                );
+        warnAboutFileIssues(project, relativePathLoaded);
         //
         // FUTURE IMPROVMENT : ENABLE AUTO IMPORT => in config
         //
@@ -595,6 +567,74 @@ public class TimeProjectProviderV4 implements TimelineProjectProvider {
         }
     }
 
+    /**
+     * Returns the given attribute's value, or a default value if the attribute is absent.
+     *
+     * @param element the element carrying the attribute
+     * @param attributeName the attribute to look up
+     * @param defaultValue the value to return if the attribute is absent
+     * @return the attribute's value, or {@code defaultValue}
+     */
+    private static String attributeOrDefault(final Element element, final String attributeName, final String defaultValue) {
+        if (element.hasAttribute(attributeName)) {
+            return element.getAttribute(attributeName);
+        }
+        return defaultValue;
+    }
+
+    /**
+     * Returns the {@link TimeFormat} held by the {@link #TIME_FORMAT_ATR} attribute, or a default value if the
+     * attribute is absent.
+     *
+     * @param element the element possibly carrying the {@link #TIME_FORMAT_ATR} attribute
+     * @param defaultValue the value to return if the attribute is absent
+     * @return the parsed time format, or {@code defaultValue}
+     */
+    private static TimeFormat timeFormatOrDefault(final Element element, final TimeFormat defaultValue) {
+        if (element.hasAttribute(TIME_FORMAT_ATR)) {
+            return TimeFormat.valueOf(element.getAttribute(TIME_FORMAT_ATR));
+        }
+        return defaultValue;
+    }
+
+    /**
+     * Checks that every loaded file still exists, and warns about portrait/picture files present on disk but
+     * referenced by nothing that was loaded.
+     *
+     * @param project the project being loaded
+     * @param relativePathLoaded the project-relative file paths that were referenced while loading
+     */
+    private static void warnAboutFileIssues(final TimeLineProject project, final List<String> relativePathLoaded) {
+        // check every file exists
+        relativePathLoaded.forEach(path -> {
+            final var absolutePath = CustomFileUtils.fromProjectRelativeToAbsolute(project, path);
+            // not optimal ...
+            final File file = new File(absolutePath);
+            if (!file.exists()) {
+                LOG.log(Level.SEVERE, "The file {0} does not exists. (saved as {1})", new Object[]{absolutePath, path});
+            }
+        });
+        //
+        final Set<Path> absolutePathsLoaded = relativePathLoaded.stream().
+                map(p -> Paths.get(CustomFileUtils.fromProjectRelativeToAbsolute(project, p))).
+                map(p -> p.normalize()).
+                collect(Collectors.toSet());
+        // * Portraits
+        final File portraitFolder = project.getPortraitsAbsoluteFolder();
+        // FUTURE IMPROVMENT : create actions for unused portrait files instead of just warning
+        FileUtils.listFiles(portraitFolder, new RegexFileFilter(ANY_FILE_REGEX), DirectoryFileFilter.DIRECTORY).stream().
+                map(portraitFile -> Paths.get(portraitFile.toURI())).
+                filter(portraitAbsolutePath -> !absolutePathsLoaded.contains(portraitAbsolutePath)).
+                forEach(portraitAbsolutePath -> LOG.log(Level.WARNING, "Found unused portrait file: {0}", new Object[]{portraitAbsolutePath}));
+        // * Pictures
+        final File picturesFolder = project.getPicturesFolder();
+        // FUTURE IMPROVMENT : create actions for unused picture files instead of just warning
+        FileUtils.listFiles(picturesFolder, new RegexFileFilter(ANY_FILE_REGEX), DirectoryFileFilter.DIRECTORY).stream().
+                map(pictureFile -> Paths.get(pictureFile.toURI())).
+                filter(pictureAbsolutePath -> !absolutePathsLoaded.contains(pictureAbsolutePath)).
+                forEach(pictureAbsolutePath -> LOG.log(Level.WARNING, "Found unused picture file: {0}", new Object[]{pictureAbsolutePath}));
+    }
+
     private static List<Place> parsePlaces(final Element placesRootElement, final Place parentPlace) {
         final List<Place> places = new LinkedList<>();
         final NodeList placeElements = placesRootElement.getChildNodes();
@@ -642,6 +682,27 @@ public class TimeProjectProviderV4 implements TimelineProjectProvider {
             defaultPortraitRef = Long.parseLong(personElement.getAttribute(DEFAULT_PORTRAIT_REF_ATR));
         }
         final var person = PersonFactory.createPerson(project, id, name, color);
+        parsePersonPortraits(personElement, person, defaultPortraitRef, relativePathLoaded, project.getTimeFormat());
+        //
+        if (personElement.hasAttribute(TIME_FORMAT_ATR)) {
+            final var timeFormat = TimeFormat.valueOf(personElement.getAttribute(TIME_FORMAT_ATR));
+            person.setTimeFormat(timeFormat);
+            parsePersonDates(personElement, person, timeFormat);
+        }
+        return person;
+    }
+
+    /**
+     * Parses a person's {@code <portrait>} children, registering each one and its default-portrait status.
+     *
+     * @param personElement the {@code <person>} element being parsed
+     * @param person the person the portraits belong to
+     * @param defaultPortraitRef the id of the portrait to use as the default one, or {@code Long.MIN_VALUE} if none was specified
+     * @param relativePathLoaded accumulator of project-relative file paths referenced while loading
+     * @param timeFormat the project's time format, used to parse each portrait's own time value
+     */
+    private static void parsePersonPortraits(final Element personElement, final Person person, final long defaultPortraitRef,
+            final List<String> relativePathLoaded, final TimeFormat timeFormat) {
         final var childrenElements = personElement.getChildNodes();
         for (int i = 0; i < childrenElements.getLength(); i++) {
             if (childrenElements.item(i).getNodeName().equals(PORTRAIT_ELEMENT)) {
@@ -655,44 +716,48 @@ public class TimeProjectProviderV4 implements TimelineProjectProvider {
                 } else {
                     person.addPortrait(portrait);
                 }
-                parseObjectTimeValue(portraitElement, portrait, project.getTimeFormat());
+                parseObjectTimeValue(portraitElement, portrait, timeFormat);
                 relativePathLoaded.add(portraitPath);
             }
         }
-        //
-        if (personElement.hasAttribute(TIME_FORMAT_ATR)) {
-            final var timeFormat = TimeFormat.valueOf(personElement.getAttribute(TIME_FORMAT_ATR));
-            person.setTimeFormat(timeFormat);
-            switch (timeFormat) {
-                case LOCAL_TIME -> {
-                    if (personElement.hasAttribute(DATE_OF_BIRTH_ATR)) {
-                        final var dateOfBirthS = personElement.getAttribute(DATE_OF_BIRTH_ATR);
-                        final var dateOfBirth = LocalDate.parse(dateOfBirthS);
-                        person.setDateOfBirth(dateOfBirth);
-                    }
-                    if (personElement.hasAttribute(DATE_OF_DEATH_ATR)) {
-                        final var dateOfDeathS = personElement.getAttribute(DATE_OF_DEATH_ATR);
-                        final var dateOfDeath = LocalDate.parse(dateOfDeathS);
-                        person.setDateOfDeath(dateOfDeath);
-                    }
+    }
+
+    /**
+     * Parses a person's birth/death date or time value, in whichever form matches the given time format.
+     *
+     * @param personElement the {@code <person>} element being parsed
+     * @param person the person the dates belong to
+     * @param timeFormat the time format the dates are expressed in
+     */
+    private static void parsePersonDates(final Element personElement, final Person person, final TimeFormat timeFormat) {
+        switch (timeFormat) {
+            case LOCAL_TIME -> {
+                if (personElement.hasAttribute(DATE_OF_BIRTH_ATR)) {
+                    final var dateOfBirthS = personElement.getAttribute(DATE_OF_BIRTH_ATR);
+                    final var dateOfBirth = LocalDate.parse(dateOfBirthS);
+                    person.setDateOfBirth(dateOfBirth);
                 }
-                case TIME_MIN -> {
-                    if (personElement.hasAttribute(DATE_OF_BIRTH_ATR)) {
-                        final var timeOfBirthS = personElement.getAttribute(DATE_OF_BIRTH_ATR);
-                        final var timeOfBirth = Long.parseLong(timeOfBirthS);
-                        person.setTimeOfBirth(timeOfBirth);
-                    }
-                    if (personElement.hasAttribute(DATE_OF_DEATH_ATR)) {
-                        final var timeOfDeathS = personElement.getAttribute(DATE_OF_DEATH_ATR);
-                        final var timeOfDeath = Long.parseLong(timeOfDeathS);
-                        person.setTimeOfDeath(timeOfDeath);
-                    }
+                if (personElement.hasAttribute(DATE_OF_DEATH_ATR)) {
+                    final var dateOfDeathS = personElement.getAttribute(DATE_OF_DEATH_ATR);
+                    final var dateOfDeath = LocalDate.parse(dateOfDeathS);
+                    person.setDateOfDeath(dateOfDeath);
                 }
-                default ->
-                    throw new UnsupportedOperationException(Messages.UNSUPPORTED_TIME_FORMAT + timeFormat);
             }
+            case TIME_MIN -> {
+                if (personElement.hasAttribute(DATE_OF_BIRTH_ATR)) {
+                    final var timeOfBirthS = personElement.getAttribute(DATE_OF_BIRTH_ATR);
+                    final var timeOfBirth = Long.parseLong(timeOfBirthS);
+                    person.setTimeOfBirth(timeOfBirth);
+                }
+                if (personElement.hasAttribute(DATE_OF_DEATH_ATR)) {
+                    final var timeOfDeathS = personElement.getAttribute(DATE_OF_DEATH_ATR);
+                    final var timeOfDeath = Long.parseLong(timeOfDeathS);
+                    person.setTimeOfDeath(timeOfDeath);
+                }
+            }
+            default ->
+                throw new UnsupportedOperationException(Messages.UNSUPPORTED_TIME_FORMAT + timeFormat);
         }
-        return person;
     }
 
     protected static void parseObjectTimeValue(final Element sourceElement, final IDateObject aDateObject, final TimeFormat aTimeFormat) {
@@ -704,7 +769,7 @@ public class TimeProjectProviderV4 implements TimelineProjectProvider {
                     try {
                         final var date = LocalDate.parse(dateS);
                         aDateObject.setDate(date);
-                    } catch (Exception e) {
+                    } catch (DateTimeParseException e) {
                         LOG.log(Level.SEVERE, "Could not parse date {0}, for element {1}, using default date.", new Object[]{e.getMessage(), sourceElement});
                         aDateObject.setDate(LocalDate.EPOCH);
                     }
@@ -818,7 +883,7 @@ public class TimeProjectProviderV4 implements TimelineProjectProvider {
                 final Element e = (Element) stayElements.item(i);
                 // a stay keeps the time format it was created with, which may predate a later change to the
                 // project's own time format, so prefer its own attribute over the project's current default
-                final var stayTimeFormat = e.hasAttribute(TIME_FORMAT_ATR) ? TimeFormat.valueOf(e.getAttribute(TIME_FORMAT_ATR)) : aTimeFormat;
+                final var stayTimeFormat = timeFormatOrDefault(e, aTimeFormat);
                 switch (stayTimeFormat) {
                     case LOCAL_TIME ->
                         stayPeriods.add(parseStayPeriodLocalTime(e));
@@ -929,7 +994,7 @@ public class TimeProjectProviderV4 implements TimelineProjectProvider {
     }
 
     private ChronologyPictureMiniature parseChronologyPictureMiniature(final Element miniatureElement, final TimeFormat aTimeFormat) {
-//        <pictureChronologyMiniature id="138" pictureRef="125" xPos="897.0" yPos="329.0" scale="0.5"/>
+        // <pictureChronologyMiniature id="138" pictureRef="125" xPos="897.0" yPos="329.0" scale="0.5"/>
         final long id = Long.parseLong(miniatureElement.getAttribute(ID_ATR));
         final long pictureRef = Long.parseLong(miniatureElement.getAttribute(PICTURE_REF_ELEMENT));
         final double xPos = parseDoubleAttribute(miniatureElement, X_POS_ATR);

--- a/src/main/java/com/github/noony/app/timelinefx/save/v4/TimeProjectProviderV4.java
+++ b/src/main/java/com/github/noony/app/timelinefx/save/v4/TimeProjectProviderV4.java
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.github.noony.app.timelinefx.save.v4;
 
 import com.github.noony.app.timelinefx.core.Frieze;
@@ -80,98 +81,323 @@ import org.w3c.dom.NodeList;
 import static com.github.noony.app.timelinefx.core.TimeFormat.LOCAL_TIME;
 
 /**
+ * Reads and writes {@link TimeLineProject} objects for save format version 4.
  *
  * @author hamon
  */
 @ServiceProvider(service = TimelineProjectProvider.class)
 public class TimeProjectProviderV4 implements TimelineProjectProvider {
 
+    /**
+     * XML root element name for a project.
+     */
     public static final String PROJECT_GROUP = "PROJECT";
 
+    /**
+     * XML group element name for the project's places.
+     */
     public static final String PLACES_GROUP = "PLACES";
 
+    /**
+     * XML group element name for the project's persons.
+     */
     public static final String PERSONS_GROUP = "PERSONS";
 
+    /**
+     * XML group element name for the project's pictures.
+     */
     public static final String PICTURES_GROUP = "PICTURES";
 
+    /**
+     * XML group element name for the project's friezes.
+     */
     public static final String FRIEZES_GROUP = "FRIEZES";
 
+    /**
+     * XML group element name for the project's stays.
+     */
     public static final String STAYS_GROUP = "STAYS";
 
+    /**
+     * XML group element name for a frieze's stay references.
+     */
     public static final String STAYS_REF_GROUP = "stays";
 
+    /**
+     * XML group element name for a person's portraits.
+     */
     public static final String PORTRAITS_GROUP = "portraits";
 
+    /**
+     * XML group element name for the project's picture chronologies.
+     */
     public static final String PICTURE_CHRONOLOGIES_GROUP = "PICTURE_CHRONOLOGIES";
 
+    /**
+     * XML element name for a place.
+     */
     public static final String PLACE_ELEMENT = "place";
 
+    /**
+     * XML element name for a reference to a place.
+     */
     public static final String PLACE_REF_ELEMENT = "placeRef";
 
+    /**
+     * XML element name for a person.
+     */
     public static final String PERSON_ELEMENT = "person";
 
+    /**
+     * XML element name for a reference to a person.
+     */
     public static final String PERSON_REF_ELEMENT = "personRef";
 
+    /**
+     * XML element name for a picture.
+     */
     public static final String PICTURE_ELEMENT = "picture";
 
+    /**
+     * XML element name for a reference to a picture.
+     */
     public static final String PICTURE_REF_ELEMENT = "pictureRef";
 
+    /**
+     * XML element name for a frieze.
+     */
     public static final String FRIEZE_ELEMENT = "frieze";
 
+    /**
+     * XML element name for a stay.
+     */
     public static final String STAY_ELEMENT = "stay";
 
+    /**
+     * XML element name for a reference to a stay.
+     */
     public static final String STAY_ELEMENT_REF = "stayRef";
 
+    /**
+     * XML element name for a portrait.
+     */
     public static final String PORTRAIT_ELEMENT = "portrait";
 
+    /**
+     * XML element name for a picture chronology.
+     */
     public static final String PICTURE_CHRONOLOGY_ELEMENT = "pictureChronology";
+
+    /**
+     * XML element name for a picture chronology miniature.
+     */
     public static final String PICTURE_CHRONOLOGY_MINIATURE_ELEMENT = "pictureChronologyMiniature";
+
+    /**
+     * XML element name for a picture chronology link.
+     */
     public static final String PICTURE_CHRONOLOGY_LINK_ELEMENT = "pictureChronologyLink";
-    //
+
+    /**
+     * XML attribute name for the pictures folder location.
+     */
     public static final String PICTURES_LOCATION_ATR = "picsLoc";
-    //
+
+    /**
+     * XML attribute name for the portraits folder location.
+     */
     public static final String PORTRAIT_FOLDER_ATR = "portraitsFolder";
+
+    /**
+     * XML attribute name for the pictures folder location.
+     */
     public static final String PICTURES_FOLDER_ATR = "picturesFolder";
+
+    /**
+     * XML attribute name for the miniatures folder location.
+     */
     public static final String MINIATURES_FOLDER_ATR = "miniaturesFolder";
-    //
+
+    /**
+     * XML attribute name for an element's id.
+     */
     public static final String ID_ATR = "id";
+
+    /**
+     * XML attribute name for an element's name.
+     */
     public static final String NAME_ATR = "name";
+
+    /**
+     * XML attribute name for an element's type.
+     */
     public static final String TYPE_ATR = "type";
+
+    /**
+     * XML attribute name for a file path.
+     */
     public static final String PATH_ATR = "path";
+
+    /**
+     * XML attribute name for a date/time value.
+     */
     public static final String DATE_ATR = "date";
+
+    /**
+     * XML attribute name for a place's level.
+     */
     public static final String PLACE_LEVEL_ATR = "level";
+
+    /**
+     * XML attribute name for a color value.
+     */
     public static final String COLOR_ATR = "color";
+
+    /**
+     * XML attribute name for a reference to a stay's person.
+     */
     public static final String PERSON_ATR = "person";
+
+    /**
+     * XML attribute name for a person's default portrait reference.
+     */
     public static final String DEFAULT_PORTRAIT_REF_ATR = "defaultPortraitRef";
+
+    /**
+     * XML attribute name for a person's date of birth.
+     */
     public static final String DATE_OF_BIRTH_ATR = "dateOfBirth";
+
+    /**
+     * XML attribute name for a person's date of death.
+     */
     public static final String DATE_OF_DEATH_ATR = "dateOfDeath";
+
+    /**
+     * XML attribute name for a stay's start date.
+     */
     public static final String START_DATE_ATR = "startDate";
+
+    /**
+     * XML attribute name for a stay's end date.
+     */
     public static final String END_DATE_ATR = "endDate";
+
+    /**
+     * XML attribute name for a time format value.
+     */
     public static final String TIME_FORMAT_ATR = "timeFormat";
+
+    /**
+     * XML attribute name for a reference to a stay period.
+     */
     public static final String STAY_ID_ATR = "stayID";
+
+    /**
+     * XML attribute name for a stay's start plot id.
+     */
     public static final String START_ID_ATR = "startID";
+
+    /**
+     * XML attribute name for a stay's end plot id.
+     */
     public static final String END_ID_ATR = "endID";
+
+    /**
+     * XML attribute name for a reference to a place.
+     */
     public static final String PLACE_ID_ATR = "placeID";
+
+    /**
+     * XML attribute name for a chronology link's origin.
+     */
     public static final String FROM_ATR = "from";
+
+    /**
+     * XML attribute name for a chronology link's destination.
+     */
     public static final String TO_ATR = "to";
+
+    /**
+     * XML attribute name for a reference to a person.
+     */
     public static final String PERSON_REF_ATR = "personRef";
+
+    /**
+     * XML attribute name for a reference to a place.
+     */
     public static final String PLACE_REF_ATR = "placeRef";
+
+    /**
+     * XML attribute name for a reference to a portrait.
+     */
     public static final String PORTRAIT_REF_ATR = "portraitRef";
+
+    /**
+     * XML attribute name for a chronology link's parameters.
+     */
     public static final String PARAMETERS_ATR = "params";
+
+    /**
+     * XML attribute name for the id of a linked object.
+     */
     public static final String LINKED_OBJECT_ID_ATR = "linkedObjectID";
-    //
+
+    /**
+     * XML attribute name for a width value.
+     */
     public static final String WIDTH_ATR = "width";
+
+    /**
+     * XML attribute name for a height value.
+     */
     public static final String HEIGHT_ATR = "height";
+
+    /**
+     * XML attribute name for an X position.
+     */
     public static final String X_POS_ATR = "xPos";
+
+    /**
+     * XML attribute name for a Y position.
+     */
     public static final String Y_POS_ATR = "yPos";
+
+    /**
+     * XML attribute name for a radius value.
+     */
     public static final String RADIUS_ATR = "radius";
+
+    /**
+     * XML attribute name for a scale value.
+     */
     public static final String SCALE_ATR = "scale";
+
+    /**
+     * XML attribute name for a person's index within a place.
+     */
     public static final String INDEX_ATR = "index";
+
+    /**
+     * XML attribute name for a connector's plot size.
+     */
     public static final String PLOT_SIZE_ATR = "plotSize";
 
+    /**
+     * Logger used by this class.
+     */
     private static final Logger LOG = Logger.getGlobal();
 
+    /**
+     * The save format version this provider reads and writes.
+     */
     private static final String TARGET_VERSION = "4";
+
+    /**
+     * Default constructor, required for this provider to be discoverable as a service.
+     */
+    public TimeProjectProviderV4() {
+    }
 
     @Override
     public List<String> getSupportedVersions() {
@@ -179,44 +405,44 @@ public class TimeProjectProviderV4 implements TimelineProjectProvider {
     }
 
     @Override
-    public TimeLineProject load(File projectFile, Element e) {
-        var loadMethodName = getClass().getSimpleName() + "__load";
+    public TimeLineProject load(final File projectFile, final Element e) {
+        final var loadMethodName = getClass().getSimpleName() + "__load";
         CustomProfiler.start(loadMethodName);
-        String projectName = e.getAttribute(NAME_ATR);
+        final String projectName = e.getAttribute(NAME_ATR);
         // Load project properties
-        var portraitsFolderValue = e.hasAttribute(PORTRAIT_FOLDER_ATR) ? e.getAttribute(PORTRAIT_FOLDER_ATR) : TimeLineProject.DEFAULT_PORTRAIT_FOLDER;
-        var picturesFolderValue = e.hasAttribute(PICTURES_FOLDER_ATR) ? e.getAttribute(PICTURES_FOLDER_ATR) : TimeLineProject.DEFAULT_PICTURES_FOLDER;
-        var miniaturesFolderValue = e.hasAttribute(MINIATURES_FOLDER_ATR) ? e.getAttribute(MINIATURES_FOLDER_ATR) : TimeLineProject.DEFAULT_MINIATURES_FOLDER;
+        final var portraitsFolderValue = e.hasAttribute(PORTRAIT_FOLDER_ATR) ? e.getAttribute(PORTRAIT_FOLDER_ATR) : TimeLineProject.DEFAULT_PORTRAIT_FOLDER;
+        final var picturesFolderValue = e.hasAttribute(PICTURES_FOLDER_ATR) ? e.getAttribute(PICTURES_FOLDER_ATR) : TimeLineProject.DEFAULT_PICTURES_FOLDER;
+        final var miniaturesFolderValue = e.hasAttribute(MINIATURES_FOLDER_ATR) ? e.getAttribute(MINIATURES_FOLDER_ATR) : TimeLineProject.DEFAULT_MINIATURES_FOLDER;
         //
-        Map<String, String> configParams = Map.of(
+        final Map<String, String> configParams = Map.of(
                 TimeLineProject.PROJECT_FOLDER_KEY, projectFile.getParent(),
                 TimeLineProject.PORTRAIT_FOLDER_KEY, portraitsFolderValue,
                 TimeLineProject.PICTURES_FOLDER_KEY, picturesFolderValue,
                 TimeLineProject.MINIATURES_FOLDER_KEY, miniaturesFolderValue
         );
-        var timeFormatValue = e.hasAttribute(TIME_FORMAT_ATR) ? TimeFormat.valueOf(e.getAttribute(TIME_FORMAT_ATR)) : TimeFormat.LOCAL_TIME;
-        TimeLineProject project = TimeLineProjectFactory.createProject(projectName, configParams, timeFormatValue);
+        final var timeFormatValue = e.hasAttribute(TIME_FORMAT_ATR) ? TimeFormat.valueOf(e.getAttribute(TIME_FORMAT_ATR)) : TimeFormat.LOCAL_TIME;
+        final TimeLineProject project = TimeLineProjectFactory.createProject(projectName, configParams, timeFormatValue);
         //
-        List<String> relativePathLoaded = new LinkedList<>();
+        final List<String> relativePathLoaded = new LinkedList<>();
         //
-        NodeList rootChildren = e.getChildNodes();
+        final NodeList rootChildren = e.getChildNodes();
         for (int i = 0; i < rootChildren.getLength(); i++) {
-            Node node = rootChildren.item(i);
+            final Node node = rootChildren.item(i);
             if (node instanceof Element element) {
                 switch (element.getTagName()) {
                     case PLACES_GROUP -> {
-                        List<Place> places = parsePlaces(element, null);
+                        final List<Place> places = parsePlaces(element, null);
                         places.stream().filter(p -> p.getParent() == null).forEach(p -> project.addHighLevelPlace(p));
                     }
                     case PERSONS_GROUP -> {
-                        List<Person> persons = parsePersons(element, project, relativePathLoaded);
+                        final List<Person> persons = parsePersons(element, project, relativePathLoaded);
                         persons.forEach(p -> project.addPerson(p));
                     }
                     case PICTURES_GROUP -> {
                         parsePictures(element, project, relativePathLoaded);
                     }
                     case STAYS_GROUP -> {
-                        List<StayPeriod> stays = parseStays(element, timeFormatValue);
+                        final List<StayPeriod> stays = parseStays(element, timeFormatValue);
                         stays.forEach(s -> project.addStay(s));
                     }
                     case FRIEZES_GROUP -> {
@@ -232,21 +458,21 @@ public class TimeProjectProviderV4 implements TimelineProjectProvider {
         }
         // check every file exists
         relativePathLoaded.forEach(path -> {
-            var absolutePath = CustomFileUtils.fromProjectRelativeToAbsolute(project, path);
+            final var absolutePath = CustomFileUtils.fromProjectRelativeToAbsolute(project, path);
             // not optimal ...
-            File file = new File(absolutePath);
+            final File file = new File(absolutePath);
             if (!file.exists()) {
                 LOG.log(Level.SEVERE, "The file {0} does not exists. (saved as {1})", new Object[]{absolutePath, path});
             }
         });
         //
-        Set<Path> absolutePathsLoaded = relativePathLoaded
+        final Set<Path> absolutePathsLoaded = relativePathLoaded
                 .stream()
                 .map(p -> Paths.get(CustomFileUtils.fromProjectRelativeToAbsolute(project, p)))
                 .map(p -> p.normalize())
                 .collect(Collectors.toSet());
         // * Portraits
-        File portraitFolder = project.getPortraitsAbsoluteFolder();
+        final File portraitFolder = project.getPortraitsAbsoluteFolder();
         FileUtils.listFiles(portraitFolder, new RegexFileFilter("^(.*?)"), DirectoryFileFilter.DIRECTORY)
                 .stream()
                 .map(portraitFile -> Paths.get(portraitFile.toURI()))
@@ -256,7 +482,7 @@ public class TimeProjectProviderV4 implements TimelineProjectProvider {
                         LOG.log(Level.WARNING, "Found unused portrait file: {0}", new Object[]{portraitAbsolutePath})
                 );
         // * Pictures
-        File picturesFolder = project.getPicturesFolder();
+        final File picturesFolder = project.getPicturesFolder();
         FileUtils.listFiles(picturesFolder, new RegexFileFilter("^(.*?)"), DirectoryFileFilter.DIRECTORY)
                 .stream()
                 .map(pictureFile -> Paths.get(pictureFile.toURI()))
@@ -273,59 +499,59 @@ public class TimeProjectProviderV4 implements TimelineProjectProvider {
     }
 
     @Override
-    public boolean save(TimeLineProject project, File destFile) {
+    public boolean save(final TimeLineProject project, final File destFile) {
         try {
-            DocumentBuilderFactory docFactory = DocumentBuilderFactory.newInstance();
+            final DocumentBuilderFactory docFactory = DocumentBuilderFactory.newInstance();
             docFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-            DocumentBuilder docBuilder = docFactory.newDocumentBuilder();
+            final DocumentBuilder docBuilder = docFactory.newDocumentBuilder();
             // root elements
-            Document doc = docBuilder.newDocument();
-            Element rootElement = doc.createElement(PROJECT_GROUP);
+            final Document doc = docBuilder.newDocument();
+            final Element rootElement = doc.createElement(PROJECT_GROUP);
             rootElement.setAttribute(NAME_ATR, project.getName());
             rootElement.setAttribute(PROJECT_VERSION_ATR, TARGET_VERSION);
             //TODO can use other method
-            var portraitsFolderName = CustomFileUtils.fromAbsoluteToProjectRelative(project, project.getPortraitsAbsoluteFolder());
-            var picturesFolderName = CustomFileUtils.fromAbsoluteToProjectRelative(project, project.getPicturesFolder());
-            var miniaturesFolderName = CustomFileUtils.fromAbsoluteToProjectRelative(project, project.getMiniaturesFolder());
+            final var portraitsFolderName = CustomFileUtils.fromAbsoluteToProjectRelative(project, project.getPortraitsAbsoluteFolder());
+            final var picturesFolderName = CustomFileUtils.fromAbsoluteToProjectRelative(project, project.getPicturesFolder());
+            final var miniaturesFolderName = CustomFileUtils.fromAbsoluteToProjectRelative(project, project.getMiniaturesFolder());
             rootElement.setAttribute(PORTRAIT_FOLDER_ATR, portraitsFolderName);
             rootElement.setAttribute(PICTURES_LOCATION_ATR, picturesFolderName);
             rootElement.setAttribute(MINIATURES_FOLDER_ATR, miniaturesFolderName);
             rootElement.setAttribute(TIME_FORMAT_ATR, project.getTimeFormat().name());
             doc.appendChild(rootElement);
             // save places
-            Element placesGroupElement = doc.createElement(PLACES_GROUP);
+            final Element placesGroupElement = doc.createElement(PLACES_GROUP);
             rootElement.appendChild(placesGroupElement);
             project.getHighLevelPlaces().forEach(place -> placesGroupElement.appendChild(createPlaceElement(doc, place, "root")));
             // save persons
-            Element personsGroupElement = doc.createElement(PERSONS_GROUP);
+            final Element personsGroupElement = doc.createElement(PERSONS_GROUP);
             rootElement.appendChild(personsGroupElement);
             project.getPersons().forEach(person -> personsGroupElement.appendChild(createPersonElement(doc, person)));
             // save pictures
-            Element picturesGroupElement = doc.createElement(PICTURES_GROUP);
+            final Element picturesGroupElement = doc.createElement(PICTURES_GROUP);
             rootElement.appendChild(picturesGroupElement);
             PictureFactory.getPictures().forEach(picture -> picturesGroupElement.appendChild(createPictureElement(doc, picture)));
             // save stays
-            Element staysGroupElement = doc.createElement(STAYS_GROUP);
+            final Element staysGroupElement = doc.createElement(STAYS_GROUP);
             rootElement.appendChild(staysGroupElement);
             project.getStays().forEach(stay -> staysGroupElement.appendChild(createStayElement(doc, stay)));
             // save friezes
-            Element friezesGroupElement = doc.createElement(FRIEZES_GROUP);
+            final Element friezesGroupElement = doc.createElement(FRIEZES_GROUP);
             rootElement.appendChild(friezesGroupElement);
             project.getFriezes().forEach(frieze -> friezesGroupElement.appendChild(createFriezeElement(doc, frieze)));
             // save picture chronologies
-            Element pictureChronologiesGroupElement = doc.createElement(PICTURE_CHRONOLOGIES_GROUP);
+            final Element pictureChronologiesGroupElement = doc.createElement(PICTURE_CHRONOLOGIES_GROUP);
             rootElement.appendChild(pictureChronologiesGroupElement);
             project.getPictureChronologies().forEach(picChronology -> pictureChronologiesGroupElement.appendChild(createPictureChronologyElement(doc, picChronology)));
             //
             rootElement.normalize();
             // write the content into xml file
-            TransformerFactory transformerFactory = TransformerFactory.newDefaultInstance();
+            final TransformerFactory transformerFactory = TransformerFactory.newDefaultInstance();
             transformerFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-            Transformer transformer = transformerFactory.newTransformer();
+            final Transformer transformer = transformerFactory.newTransformer();
             transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2");
             transformer.setOutputProperty(OutputKeys.INDENT, "yes");
-            DOMSource source = new DOMSource(doc);
-            StreamResult result = new StreamResult(destFile);
+            final DOMSource source = new DOMSource(doc);
+            final StreamResult result = new StreamResult(destFile);
             transformer.transform(source, result);
         } catch (ParserConfigurationException | TransformerException ex) {
             LOG.log(Level.SEVERE, " Exception while exporting timeline :: {0}", new Object[]{ex});
@@ -335,15 +561,15 @@ public class TimeProjectProviderV4 implements TimelineProjectProvider {
     }
 
     /**
-     * Finds the first direct child element with the given tag name, without recursing into descendants (unlike {@link Element#getElementsByTagName(String)}, which walks the whole
-     * subtree).
+     * Finds the first direct child element with the given tag name, without recursing into
+     * descendants (unlike {@link Element#getElementsByTagName(String)}, which walks the whole subtree).
      *
      * @param parent the element whose direct children are searched
      * @param tagName the tag name to look for
      * @return the first matching direct child, or {@code null} if none exists
      */
     protected static Element firstDirectChildByTagName(final Element parent, final String tagName) {
-        var children = parent.getChildNodes();
+        final var children = parent.getChildNodes();
         for (int i = 0; i < children.getLength(); i++) {
             if (children.item(i) instanceof Element child && child.getTagName().equals(tagName)) {
                 return child;
@@ -353,15 +579,15 @@ public class TimeProjectProviderV4 implements TimelineProjectProvider {
     }
 
     /**
-     * Parses the given attribute as a double, failing with a message identifying the element, attribute and raw value instead of the bare
-     * {@link NumberFormatException} {@link Double#parseDouble(String)} would throw.
+     * Parses the given attribute as a double, failing with a message identifying the element, attribute and
+     * raw value instead of the bare {@link NumberFormatException} {@link Double#parseDouble(String)} would throw.
      *
      * @param element the element carrying the attribute
      * @param attributeName the attribute to parse
      * @return the parsed value
      */
     protected static double parseDoubleAttribute(final Element element, final String attributeName) {
-        var value = element.getAttribute(attributeName);
+        final var value = element.getAttribute(attributeName);
         try {
             return Double.parseDouble(value);
         } catch (NumberFormatException e) {
@@ -369,61 +595,61 @@ public class TimeProjectProviderV4 implements TimelineProjectProvider {
         }
     }
 
-    private static List<Place> parsePlaces(Element placesRootElement, Place parentPlace) {
-        List<Place> places = new LinkedList<>();
-        NodeList placeElements = placesRootElement.getChildNodes();
+    private static List<Place> parsePlaces(final Element placesRootElement, final Place parentPlace) {
+        final List<Place> places = new LinkedList<>();
+        final NodeList placeElements = placesRootElement.getChildNodes();
         for (int i = 0; i < placeElements.getLength(); i++) {
             if (placeElements.item(i).getNodeName().equals(PLACE_ELEMENT)) {
-                Element e = (Element) placeElements.item(i);
-                Place p = parsePlace(e, parentPlace);
+                final Element e = (Element) placeElements.item(i);
+                final Place p = parsePlace(e, parentPlace);
                 places.add(p);
             }
         }
         return places;
     }
 
-    private static Place parsePlace(Element placeElement, Place parentPlace) {
+    private static Place parsePlace(final Element placeElement, final Place parentPlace) {
         // <place color="0xf5deb3ff" id="1" level="GALAXY" name="Galaxy">
-        Color color = Color.valueOf(placeElement.getAttribute(COLOR_ATR));
-        long id = Long.parseLong(placeElement.getAttribute(ID_ATR));
-        PlaceLevel level = PlaceLevel.valueOf(placeElement.getAttribute(PLACE_LEVEL_ATR));
-        String name = placeElement.getAttribute(NAME_ATR);
-        Place place = PlaceFactory.createPlace(id, name, level, parentPlace, color);
+        final Color color = Color.valueOf(placeElement.getAttribute(COLOR_ATR));
+        final long id = Long.parseLong(placeElement.getAttribute(ID_ATR));
+        final PlaceLevel level = PlaceLevel.valueOf(placeElement.getAttribute(PLACE_LEVEL_ATR));
+        final String name = placeElement.getAttribute(NAME_ATR);
+        final Place place = PlaceFactory.createPlace(id, name, level, parentPlace, color);
         parsePlaces(placeElement, place);
         return place;
     }
 
-    private static List<Person> parsePersons(Element personsRootElement, TimeLineProject project, List<String> relativePathLoaded) {
-        List<Person> persons = new LinkedList<>();
-        NodeList personElements = personsRootElement.getChildNodes();
+    private static List<Person> parsePersons(final Element personsRootElement, final TimeLineProject project, final List<String> relativePathLoaded) {
+        final List<Person> persons = new LinkedList<>();
+        final NodeList personElements = personsRootElement.getChildNodes();
         for (int i = 0; i < personElements.getLength(); i++) {
             if (personElements.item(i).getNodeName().equals(PERSON_ELEMENT)) {
-                Element e = (Element) personElements.item(i);
-                Person p = parsePerson(e, project, relativePathLoaded);
+                final Element e = (Element) personElements.item(i);
+                final Person p = parsePerson(e, project, relativePathLoaded);
                 persons.add(p);
             }
         }
         return persons;
     }
 
-    private static Person parsePerson(Element personElement, TimeLineProject project, List<String> relativePathLoaded) {
+    private static Person parsePerson(final Element personElement, final TimeLineProject project, final List<String> relativePathLoaded) {
         // <person color="0x7fffd4ff" id="1" name="Obi Wan Kenobi"/>
-        var color = Color.valueOf(personElement.getAttribute(COLOR_ATR));
-        var id = Long.parseLong(personElement.getAttribute(ID_ATR));
-        var name = personElement.getAttribute(NAME_ATR);
+        final var color = Color.valueOf(personElement.getAttribute(COLOR_ATR));
+        final var id = Long.parseLong(personElement.getAttribute(ID_ATR));
+        final var name = personElement.getAttribute(NAME_ATR);
         var defaultPortraitRef = Long.MIN_VALUE;
         if (personElement.hasAttribute(DEFAULT_PORTRAIT_REF_ATR)) {
             defaultPortraitRef = Long.parseLong(personElement.getAttribute(DEFAULT_PORTRAIT_REF_ATR));
         }
-        var person = PersonFactory.createPerson(project, id, name, color);
-        var childrenElements = personElement.getChildNodes();
+        final var person = PersonFactory.createPerson(project, id, name, color);
+        final var childrenElements = personElement.getChildNodes();
         for (int i = 0; i < childrenElements.getLength(); i++) {
             if (childrenElements.item(i).getNodeName().equals(PORTRAIT_ELEMENT)) {
                 // <portrait id="147" path="portraits\obi_wan.png"/>
-                var portraitElement = (Element) childrenElements.item(i);
-                var portraitID = Long.parseLong(portraitElement.getAttribute(ID_ATR));
-                var portraitPath = portraitElement.getAttribute(PATH_ATR);
-                var portrait = PortraitFactory.createPortrait(portraitID, person, portraitPath);
+                final var portraitElement = (Element) childrenElements.item(i);
+                final var portraitID = Long.parseLong(portraitElement.getAttribute(ID_ATR));
+                final var portraitPath = portraitElement.getAttribute(PATH_ATR);
+                final var portrait = PortraitFactory.createPortrait(portraitID, person, portraitPath);
                 if (portrait.getId() == defaultPortraitRef) {
                     person.setDefaultPortrait(portrait);
                 } else {
@@ -435,30 +661,30 @@ public class TimeProjectProviderV4 implements TimelineProjectProvider {
         }
         //
         if (personElement.hasAttribute(TIME_FORMAT_ATR)) {
-            var timeFormat = TimeFormat.valueOf(personElement.getAttribute(TIME_FORMAT_ATR));
+            final var timeFormat = TimeFormat.valueOf(personElement.getAttribute(TIME_FORMAT_ATR));
             person.setTimeFormat(timeFormat);
             switch (timeFormat) {
                 case LOCAL_TIME -> {
                     if (personElement.hasAttribute(DATE_OF_BIRTH_ATR)) {
-                        var dateOfBirthS = personElement.getAttribute(DATE_OF_BIRTH_ATR);
-                        var dateOfBirth = LocalDate.parse(dateOfBirthS);
+                        final var dateOfBirthS = personElement.getAttribute(DATE_OF_BIRTH_ATR);
+                        final var dateOfBirth = LocalDate.parse(dateOfBirthS);
                         person.setDateOfBirth(dateOfBirth);
                     }
                     if (personElement.hasAttribute(DATE_OF_DEATH_ATR)) {
-                        var dateOfDeathS = personElement.getAttribute(DATE_OF_DEATH_ATR);
-                        var dateOfDeath = LocalDate.parse(dateOfDeathS);
+                        final var dateOfDeathS = personElement.getAttribute(DATE_OF_DEATH_ATR);
+                        final var dateOfDeath = LocalDate.parse(dateOfDeathS);
                         person.setDateOfDeath(dateOfDeath);
                     }
                 }
                 case TIME_MIN -> {
                     if (personElement.hasAttribute(DATE_OF_BIRTH_ATR)) {
-                        var timeOfBirthS = personElement.getAttribute(DATE_OF_BIRTH_ATR);
-                        var timeOfBirth = Long.parseLong(timeOfBirthS);
+                        final var timeOfBirthS = personElement.getAttribute(DATE_OF_BIRTH_ATR);
+                        final var timeOfBirth = Long.parseLong(timeOfBirthS);
                         person.setTimeOfBirth(timeOfBirth);
                     }
                     if (personElement.hasAttribute(DATE_OF_DEATH_ATR)) {
-                        var timeOfDeathS = personElement.getAttribute(DATE_OF_DEATH_ATR);
-                        var timeOfDeath = Long.parseLong(timeOfDeathS);
+                        final var timeOfDeathS = personElement.getAttribute(DATE_OF_DEATH_ATR);
+                        final var timeOfDeath = Long.parseLong(timeOfDeathS);
                         person.setTimeOfDeath(timeOfDeath);
                     }
                 }
@@ -469,14 +695,14 @@ public class TimeProjectProviderV4 implements TimelineProjectProvider {
         return person;
     }
 
-    protected static void parseObjectTimeValue(Element sourceElement, IDateObject aDateObject, TimeFormat aTimeFormat) {
+    protected static void parseObjectTimeValue(final Element sourceElement, final IDateObject aDateObject, final TimeFormat aTimeFormat) {
         aDateObject.setTimeFormat(aTimeFormat);
         switch (aTimeFormat) {
             case LOCAL_TIME -> {
                 if (sourceElement.hasAttribute(DATE_ATR)) {
-                    var dateS = sourceElement.getAttribute(DATE_ATR);
+                    final var dateS = sourceElement.getAttribute(DATE_ATR);
                     try {
-                        var date = LocalDate.parse(dateS);
+                        final var date = LocalDate.parse(dateS);
                         aDateObject.setDate(date);
                     } catch (Exception e) {
                         LOG.log(Level.SEVERE, "Could not parse date {0}, for element {1}, using default date.", new Object[]{e.getMessage(), sourceElement});
@@ -486,7 +712,7 @@ public class TimeProjectProviderV4 implements TimelineProjectProvider {
             }
             case TIME_MIN -> {
                 if (sourceElement.hasAttribute(DATE_ATR)) {
-                    var time = parseDoubleAttribute(sourceElement, DATE_ATR);
+                    final var time = parseDoubleAttribute(sourceElement, DATE_ATR);
                     aDateObject.setTimestamp(time);
                 }
             }
@@ -495,45 +721,45 @@ public class TimeProjectProviderV4 implements TimelineProjectProvider {
         }
     }
 
-    private static List<Picture> parsePictures(Element picturesRootElement, TimeLineProject project, List<String> relativePathLoaded) {
-        List<Picture> pictures = new LinkedList<>();
-        NodeList picturesElements = picturesRootElement.getChildNodes();
+    private static List<Picture> parsePictures(final Element picturesRootElement, final TimeLineProject project, final List<String> relativePathLoaded) {
+        final List<Picture> pictures = new LinkedList<>();
+        final NodeList picturesElements = picturesRootElement.getChildNodes();
         for (int i = 0; i < picturesElements.getLength(); i++) {
             if (picturesElements.item(i).getNodeName().equals(PICTURE_ELEMENT)) {
-                Element e = (Element) picturesElements.item(i);
-                Picture p = parsePicture(e, project, relativePathLoaded);
+                final Element e = (Element) picturesElements.item(i);
+                final Picture p = parsePicture(e, project, relativePathLoaded);
                 pictures.add(p);
             }
         }
         return pictures;
     }
 
-    private static Picture parsePicture(Element pictureElement, TimeLineProject project, List<String> relativePathLoaded) {
-        Long milliIn = System.currentTimeMillis();
-        var id = Long.parseLong(pictureElement.getAttribute(ID_ATR));
-        var name = pictureElement.getAttribute(NAME_ATR);
-        var path = pictureElement.getAttribute(PATH_ATR);
+    private static Picture parsePicture(final Element pictureElement, final TimeLineProject project, final List<String> relativePathLoaded) {
+        final Long milliIn = System.currentTimeMillis();
+        final var id = Long.parseLong(pictureElement.getAttribute(ID_ATR));
+        final var name = pictureElement.getAttribute(NAME_ATR);
+        final var path = pictureElement.getAttribute(PATH_ATR);
         relativePathLoaded.add(path);
-        var width = Integer.parseInt(pictureElement.getAttribute(WIDTH_ATR));
-        var height = Integer.parseInt(pictureElement.getAttribute(HEIGHT_ATR));
+        final var width = Integer.parseInt(pictureElement.getAttribute(WIDTH_ATR));
+        final var height = Integer.parseInt(pictureElement.getAttribute(HEIGHT_ATR));
         //
-        Picture picture = PictureFactory.createPicture(project, id, name, LocalDateTime.MIN, path, width, height);
+        final Picture picture = PictureFactory.createPicture(project, id, name, LocalDateTime.MIN, path, width, height);
         parseObjectTimeValue(pictureElement, picture, project.getTimeFormat());
         //
-        var pictureChildrenElements = pictureElement.getChildNodes();
+        final var pictureChildrenElements = pictureElement.getChildNodes();
         for (int i = 0; i < pictureChildrenElements.getLength(); i++) {
-            Node n = pictureChildrenElements.item(i);
+            final Node n = pictureChildrenElements.item(i);
             switch (n.getNodeName()) {
                 case PERSON_REF_ELEMENT -> {
-                    Element e = (Element) n;
-                    long personID = Long.parseLong(e.getAttribute(ID_ATR));
-                    Person person = PersonFactory.getPerson(personID);
+                    final Element e = (Element) n;
+                    final long personID = Long.parseLong(e.getAttribute(ID_ATR));
+                    final Person person = PersonFactory.getPerson(personID);
                     picture.addPerson(person);
                 }
                 case PLACE_REF_ELEMENT -> {
-                    Element e = (Element) n;
-                    long placeID = Long.parseLong(e.getAttribute(ID_ATR));
-                    Place place = PlaceFactory.getPlace(placeID);
+                    final Element e = (Element) n;
+                    final long placeID = Long.parseLong(e.getAttribute(ID_ATR));
+                    final Place place = PlaceFactory.getPlace(placeID);
                     picture.addPlace(place);
                 }
                 case "#text" ->
@@ -543,39 +769,39 @@ public class TimeProjectProviderV4 implements TimelineProjectProvider {
             }
         }
         //
-        var milliOut = System.currentTimeMillis();
-        var time = milliOut - milliIn;
+        final var milliOut = System.currentTimeMillis();
+        final var time = milliOut - milliIn;
         if (time > 1) {
             LOG.log(Level.SEVERE, "Parsed picture: {0}\n > took {1}ms.", new Object[]{name, Long.toString(time)});
         }
         return picture;
     }
 
-    private List<Frieze> parseFriezes(TimeLineProject project, Element friezesRootElement) {
-        List<Frieze> friezes = new LinkedList<>();
-        NodeList friezeElements = friezesRootElement.getChildNodes();
+    private List<Frieze> parseFriezes(final TimeLineProject project, final Element friezesRootElement) {
+        final List<Frieze> friezes = new LinkedList<>();
+        final NodeList friezeElements = friezesRootElement.getChildNodes();
         for (int i = 0; i < friezeElements.getLength(); i++) {
             if (friezeElements.item(i).getNodeName().equals(FRIEZE_ELEMENT)) {
-                Element e = (Element) friezeElements.item(i);
-                Frieze f = parseFrieze(project, e);
+                final Element e = (Element) friezeElements.item(i);
+                final Frieze f = parseFrieze(project, e);
                 friezes.add(f);
             }
         }
         return friezes;
     }
 
-    private Frieze parseFrieze(TimeLineProject project, Element friezeElement) {
+    private Frieze parseFrieze(final TimeLineProject project, final Element friezeElement) {
         // <frieze name="SW 1-2">
-        var name = friezeElement.getAttribute(NAME_ATR);
-        var id = Long.parseLong(friezeElement.getAttribute(ID_ATR));
-        var staysElement = firstDirectChildByTagName(friezeElement, STAYS_REF_GROUP);
+        final var name = friezeElement.getAttribute(NAME_ATR);
+        final var id = Long.parseLong(friezeElement.getAttribute(ID_ATR));
+        final var staysElement = firstDirectChildByTagName(friezeElement, STAYS_REF_GROUP);
         if (staysElement == null) {
             throw new IllegalStateException("Wrong number of STAYS_GROUP : 0");
         }
-        var stays = parseStaysInFreize(staysElement);
-        var frieze = FriezeFactory.createFrieze(id, project, name, stays);
+        final var stays = parseStaysInFreize(staysElement);
+        final var frieze = FriezeFactory.createFrieze(id, project, name, stays);
         //
-        var freemapsElement = firstDirectChildByTagName(friezeElement, FreeMapProviderV4.FREEMAPS_GROUP);
+        final var freemapsElement = firstDirectChildByTagName(friezeElement, FreeMapProviderV4.FREEMAPS_GROUP);
         if (freemapsElement == null) {
             throw new IllegalStateException("Wrong number of FREEMAPS_GROUP : 0");
         }
@@ -584,15 +810,15 @@ public class TimeProjectProviderV4 implements TimelineProjectProvider {
         return frieze;
     }
 
-    private List<StayPeriod> parseStays(Element staysRootElement, TimeFormat aTimeFormat) {
-        List<StayPeriod> stayPeriods = new LinkedList<>();
-        NodeList stayElements = staysRootElement.getChildNodes();
+    private List<StayPeriod> parseStays(final Element staysRootElement, final TimeFormat aTimeFormat) {
+        final List<StayPeriod> stayPeriods = new LinkedList<>();
+        final NodeList stayElements = staysRootElement.getChildNodes();
         for (int i = 0; i < stayElements.getLength(); i++) {
             if (stayElements.item(i).getNodeName().equals(STAY_ELEMENT)) {
-                Element e = (Element) stayElements.item(i);
+                final Element e = (Element) stayElements.item(i);
                 // a stay keeps the time format it was created with, which may predate a later change to the
                 // project's own time format, so prefer its own attribute over the project's current default
-                var stayTimeFormat = e.hasAttribute(TIME_FORMAT_ATR) ? TimeFormat.valueOf(e.getAttribute(TIME_FORMAT_ATR)) : aTimeFormat;
+                final var stayTimeFormat = e.hasAttribute(TIME_FORMAT_ATR) ? TimeFormat.valueOf(e.getAttribute(TIME_FORMAT_ATR)) : aTimeFormat;
                 switch (stayTimeFormat) {
                     case LOCAL_TIME ->
                         stayPeriods.add(parseStayPeriodLocalTime(e));
@@ -606,14 +832,14 @@ public class TimeProjectProviderV4 implements TimelineProjectProvider {
         return stayPeriods;
     }
 
-    private List<StayPeriod> parseStaysInFreize(Element staysRootElement) {
-        List<StayPeriod> stayPeriods = new LinkedList<>();
-        NodeList stayElements = staysRootElement.getChildNodes();
+    private List<StayPeriod> parseStaysInFreize(final Element staysRootElement) {
+        final List<StayPeriod> stayPeriods = new LinkedList<>();
+        final NodeList stayElements = staysRootElement.getChildNodes();
         for (int i = 0; i < stayElements.getLength(); i++) {
             if (stayElements.item(i).getNodeName().equals(STAY_ELEMENT_REF)) {
-                Element e = (Element) stayElements.item(i);
-                long id = Long.parseLong(e.getAttribute(ID_ATR));
-                var stay = StayFactory.getStay(id);
+                final Element e = (Element) stayElements.item(i);
+                final long id = Long.parseLong(e.getAttribute(ID_ATR));
+                final var stay = StayFactory.getStay(id);
                 if (stay == null) {
                     throw new UnsupportedOperationException("StayPeriod reference does not exist " + id);
                 }
@@ -623,93 +849,93 @@ public class TimeProjectProviderV4 implements TimelineProjectProvider {
         return stayPeriods;
     }
 
-    private StayPeriodLocalDate parseStayPeriodLocalTime(Element stayElement) {
+    private StayPeriodLocalDate parseStayPeriodLocalTime(final Element stayElement) {
         // <stay endDate="20" id="1" person="5" startDate="0" timeFormat="LOCAL_TIME"/>
-        long id = Long.parseLong(stayElement.getAttribute(ID_ATR));
-        long personID = Long.parseLong(stayElement.getAttribute(PERSON_ATR));
-        Person person = PersonFactory.getPerson(personID);
+        final long id = Long.parseLong(stayElement.getAttribute(ID_ATR));
+        final long personID = Long.parseLong(stayElement.getAttribute(PERSON_ATR));
+        final Person person = PersonFactory.getPerson(personID);
         if (person == null) {
             throw new IllegalStateException();
         }
-        long placeID = Long.parseLong(stayElement.getAttribute(PLACE_ID_ATR));
-        Place place = PlaceFactory.getPlace(placeID);
+        final long placeID = Long.parseLong(stayElement.getAttribute(PLACE_ID_ATR));
+        final Place place = PlaceFactory.getPlace(placeID);
         if (place == null) {
             throw new IllegalStateException();
         }
-        String startS = stayElement.getAttribute(START_DATE_ATR);
-        String endS = stayElement.getAttribute(END_DATE_ATR);
-        LocalDate start = LocalDate.parse(startS);
-        LocalDate end = LocalDate.parse(endS);
+        final String startS = stayElement.getAttribute(START_DATE_ATR);
+        final String endS = stayElement.getAttribute(END_DATE_ATR);
+        final LocalDate start = LocalDate.parse(startS);
+        final LocalDate end = LocalDate.parse(endS);
         return StayFactory.createStayPeriodLocalDate(id, person, start, end, place);
     }
 
-    private StayPeriodSimpleTime parseStayPeriodSimpleTime(Element stayElement) {
+    private StayPeriodSimpleTime parseStayPeriodSimpleTime(final Element stayElement) {
         // <stay endDate="20" id="1" person="5" startDate="0" timeFormat="TIME_MIN"/>
-        long id = Long.parseLong(stayElement.getAttribute(ID_ATR));
-        long personID = Long.parseLong(stayElement.getAttribute(PERSON_ATR));
-        Person person = PersonFactory.getPerson(personID);
+        final long id = Long.parseLong(stayElement.getAttribute(ID_ATR));
+        final long personID = Long.parseLong(stayElement.getAttribute(PERSON_ATR));
+        final Person person = PersonFactory.getPerson(personID);
         if (person == null) {
             throw new IllegalStateException("Could not load StayPeriodSimpleTime id=" + id + " with personID=" + personID);
         }
-        long placeID = Long.parseLong(stayElement.getAttribute(PLACE_ID_ATR));
-        Place place = PlaceFactory.getPlace(placeID);
+        final long placeID = Long.parseLong(stayElement.getAttribute(PLACE_ID_ATR));
+        final Place place = PlaceFactory.getPlace(placeID);
         if (place == null) {
             throw new IllegalStateException("Could not load StayPeriodSimpleTime id=" + id + " with placeID=" + placeID);
         }
-        var start = parseDoubleAttribute(stayElement, START_DATE_ATR);
-        var end = parseDoubleAttribute(stayElement, END_DATE_ATR);
+        final var start = parseDoubleAttribute(stayElement, START_DATE_ATR);
+        final var end = parseDoubleAttribute(stayElement, END_DATE_ATR);
         return StayFactory.createStayPeriodSimpleTime(id, person, start, end, place);
     }
 
-    private List<PictureChronology> parsePictureChronologies(TimeLineProject project, Element pictureChronologiesRootElement) {
-        List<PictureChronology> pictureChronologys = new LinkedList<>();
-        NodeList pictureChronologiesElements = pictureChronologiesRootElement.getChildNodes();
+    private List<PictureChronology> parsePictureChronologies(final TimeLineProject project, final Element pictureChronologiesRootElement) {
+        final List<PictureChronology> pictureChronologys = new LinkedList<>();
+        final NodeList pictureChronologiesElements = pictureChronologiesRootElement.getChildNodes();
         for (int i = 0; i < pictureChronologiesElements.getLength(); i++) {
             if (pictureChronologiesElements.item(i).getNodeName().equals(PICTURE_CHRONOLOGY_ELEMENT)) {
-                Element e = (Element) pictureChronologiesElements.item(i);
-                PictureChronology pC = parsePictureChronology(project, e);
+                final Element e = (Element) pictureChronologiesElements.item(i);
+                final PictureChronology pC = parsePictureChronology(project, e);
                 pictureChronologys.add(pC);
             }
         }
         return pictureChronologys;
     }
 
-    private PictureChronology parsePictureChronology(TimeLineProject project, Element pictureChronologyElement) {
-        long id = Long.parseLong(pictureChronologyElement.getAttribute(ID_ATR));
-        String name = pictureChronologyElement.getAttribute(NAME_ATR);
-        double width = parseDoubleAttribute(pictureChronologyElement, WIDTH_ATR);
-        double height = parseDoubleAttribute(pictureChronologyElement, HEIGHT_ATR);
+    private PictureChronology parsePictureChronology(final TimeLineProject project, final Element pictureChronologyElement) {
+        final long id = Long.parseLong(pictureChronologyElement.getAttribute(ID_ATR));
+        final String name = pictureChronologyElement.getAttribute(NAME_ATR);
+        final double width = parseDoubleAttribute(pictureChronologyElement, WIDTH_ATR);
+        final double height = parseDoubleAttribute(pictureChronologyElement, HEIGHT_ATR);
         //
-        List<ChronologyPictureMiniature> miniatures = new LinkedList<>();
-        List<ChronologyLink> links = new LinkedList<>();
+        final List<ChronologyPictureMiniature> miniatures = new LinkedList<>();
+        final List<ChronologyLink> links = new LinkedList<>();
         //
-        NodeList miniaturesElements = pictureChronologyElement.getChildNodes();
+        final NodeList miniaturesElements = pictureChronologyElement.getChildNodes();
         for (int i = 0; i < miniaturesElements.getLength(); i++) {
             if (miniaturesElements.item(i).getNodeName().equals(PICTURE_CHRONOLOGY_MINIATURE_ELEMENT)) {
-                Element e = (Element) miniaturesElements.item(i);
-                var miniature = parseChronologyPictureMiniature(e, project.getTimeFormat());
+                final Element e = (Element) miniaturesElements.item(i);
+                final var miniature = parseChronologyPictureMiniature(e, project.getTimeFormat());
                 miniatures.add(miniature);
             } else if (miniaturesElements.item(i).getNodeName().equals(PICTURE_CHRONOLOGY_LINK_ELEMENT)) {
-                Element e = (Element) miniaturesElements.item(i);
+                final Element e = (Element) miniaturesElements.item(i);
                 links.add(parsePictureChronologyLink(e));
             }
         }
         //
-        var pictureChronology = PictureChronologyFactory.createPictureChronology(id, project, name, miniatures, links);
+        final var pictureChronology = PictureChronologyFactory.createPictureChronology(id, project, name, miniatures, links);
         pictureChronology.setWidth(width);
         pictureChronology.setHeight(height);
         //
         return pictureChronology;
     }
 
-    private ChronologyPictureMiniature parseChronologyPictureMiniature(Element miniatureElement, TimeFormat aTimeFormat) {
+    private ChronologyPictureMiniature parseChronologyPictureMiniature(final Element miniatureElement, final TimeFormat aTimeFormat) {
 //        <pictureChronologyMiniature id="138" pictureRef="125" xPos="897.0" yPos="329.0" scale="0.5"/>
-        long id = Long.parseLong(miniatureElement.getAttribute(ID_ATR));
-        long pictureRef = Long.parseLong(miniatureElement.getAttribute(PICTURE_REF_ELEMENT));
-        double xPos = parseDoubleAttribute(miniatureElement, X_POS_ATR);
-        double yPos = parseDoubleAttribute(miniatureElement, Y_POS_ATR);
-        double scale = parseDoubleAttribute(miniatureElement, SCALE_ATR);
-        var miniature = PictureChronologyFactory.createChronologyPictureMiniature(id, IPicture.getPicture(pictureRef), new Point2D(xPos, yPos), scale);
+        final long id = Long.parseLong(miniatureElement.getAttribute(ID_ATR));
+        final long pictureRef = Long.parseLong(miniatureElement.getAttribute(PICTURE_REF_ELEMENT));
+        final double xPos = parseDoubleAttribute(miniatureElement, X_POS_ATR);
+        final double yPos = parseDoubleAttribute(miniatureElement, Y_POS_ATR);
+        final double scale = parseDoubleAttribute(miniatureElement, SCALE_ATR);
+        final var miniature = PictureChronologyFactory.createChronologyPictureMiniature(id, IPicture.getPicture(pictureRef), new Point2D(xPos, yPos), scale);
         miniature.setUseCustomTime(!miniature.isInSyncWithPicture());
         if (!miniature.isInSyncWithPicture()) {
             parseObjectTimeValue(miniatureElement, miniature.getDateObject(), aTimeFormat);
@@ -717,23 +943,23 @@ public class TimeProjectProviderV4 implements TimelineProjectProvider {
         return miniature;
     }
 
-    private static ChronologyLink parsePictureChronologyLink(Element linkElement) {
-        var id = Long.parseLong(linkElement.getAttribute(ID_ATR));
-        var type = ChronologyLinkType.valueOf(linkElement.getAttribute(TYPE_ATR));
-        var fromID = Long.parseLong(linkElement.getAttribute(FROM_ATR));
-        var from = PictureChronologyFactory.getChronologyPictureMiniature(fromID);
-        var toID = Long.parseLong(linkElement.getAttribute(TO_ATR));
-        var to = PictureChronologyFactory.getChronologyPictureMiniature(toID);
-        var personRef = Long.parseLong(linkElement.getAttribute(PERSON_REF_ATR));
-        var person = PersonFactory.getPerson(personRef);
-        var paramsAsString = linkElement.getAttribute(PARAMETERS_ATR);
-        var parameters = CustomFileUtils.toDoubleArray(paramsAsString);
+    private static ChronologyLink parsePictureChronologyLink(final Element linkElement) {
+        final var id = Long.parseLong(linkElement.getAttribute(ID_ATR));
+        final var type = ChronologyLinkType.valueOf(linkElement.getAttribute(TYPE_ATR));
+        final var fromID = Long.parseLong(linkElement.getAttribute(FROM_ATR));
+        final var from = PictureChronologyFactory.getChronologyPictureMiniature(fromID);
+        final var toID = Long.parseLong(linkElement.getAttribute(TO_ATR));
+        final var to = PictureChronologyFactory.getChronologyPictureMiniature(toID);
+        final var personRef = Long.parseLong(linkElement.getAttribute(PERSON_REF_ATR));
+        final var person = PersonFactory.getPerson(personRef);
+        final var paramsAsString = linkElement.getAttribute(PARAMETERS_ATR);
+        final var parameters = CustomFileUtils.toDoubleArray(paramsAsString);
         return PictureChronologyFactory.createChronologyLink(id, person, from, to, type, parameters);
     }
 
-    private static Element createPlaceElement(Document doc, Place place, String fromPlace) {
+    private static Element createPlaceElement(final Document doc, final Place place, final String fromPlace) {
         LOG.log(Level.FINE, "> Creating place {0} from {1}", new Object[]{place.getName(), fromPlace});
-        var placeElement = doc.createElement(PLACE_ELEMENT);
+        final var placeElement = doc.createElement(PLACE_ELEMENT);
         placeElement.setAttribute(ID_ATR, Long.toString(place.getId()));
         placeElement.setAttribute(NAME_ATR, place.getName());
         placeElement.setAttribute(PLACE_LEVEL_ATR, place.getLevel().name());
@@ -742,9 +968,9 @@ public class TimeProjectProviderV4 implements TimelineProjectProvider {
         return placeElement;
     }
 
-    private static Element createPersonElement(Document doc, Person person) {
+    private static Element createPersonElement(final Document doc, final Person person) {
         LOG.log(Level.FINE, "> Creating person {0}", new Object[]{person.getName()});
-        var personElement = doc.createElement(PERSON_ELEMENT);
+        final var personElement = doc.createElement(PERSON_ELEMENT);
         personElement.setAttribute(ID_ATR, Long.toString(person.getId()));
         personElement.setAttribute(NAME_ATR, person.getName());
         if (person.getDefaultPortrait() != null) {
@@ -769,7 +995,7 @@ public class TimeProjectProviderV4 implements TimelineProjectProvider {
                 throw new UnsupportedOperationException(Messages.UNSUPPORTED_TIME_FORMAT + person.getTimeFormat());
         }
         person.getPortraits().forEach(portrait -> {
-            var portraitElement = doc.createElement(PORTRAIT_ELEMENT);
+            final var portraitElement = doc.createElement(PORTRAIT_ELEMENT);
             portraitElement.setAttribute(ID_ATR, Long.toString(portrait.getId()));
             portraitElement.setAttribute(PATH_ATR, portrait.getProjectRelativePath());
             saveObjectTime(portraitElement, portrait);
@@ -778,7 +1004,7 @@ public class TimeProjectProviderV4 implements TimelineProjectProvider {
         return personElement;
     }
 
-    private static void saveObjectTime(Element targetElement, IDateObject aDateObject) {
+    private static void saveObjectTime(final Element targetElement, final IDateObject aDateObject) {
         switch (aDateObject.getTimeFormat()) {
             case LOCAL_TIME -> {
                 if (aDateObject.getDate() != null) {
@@ -793,20 +1019,20 @@ public class TimeProjectProviderV4 implements TimelineProjectProvider {
         }
     }
 
-    private static Element createPictureElement(Document doc, Picture picture) {
-        Element pictureElement = doc.createElement(PICTURE_ELEMENT);
+    private static Element createPictureElement(final Document doc, final Picture picture) {
+        final Element pictureElement = doc.createElement(PICTURE_ELEMENT);
         pictureElement.setAttribute(ID_ATR, Long.toString(picture.getId()));
         pictureElement.setAttribute(NAME_ATR, picture.getName());
         pictureElement.setAttribute(PATH_ATR, picture.getProjectRelativePath());
         pictureElement.setAttribute(WIDTH_ATR, Integer.toString((int) picture.getWidth()));
         pictureElement.setAttribute(HEIGHT_ATR, Integer.toString((int) picture.getHeight()));
         picture.getPersons().forEach(person -> {
-            Element personElement = doc.createElement(PERSON_REF_ELEMENT);
+            final Element personElement = doc.createElement(PERSON_REF_ELEMENT);
             personElement.setAttribute(ID_ATR, Long.toString(person.getId()));
             pictureElement.appendChild(personElement);
         });
         picture.getPlaces().forEach(place -> {
-            Element placeElement = doc.createElement(PLACE_REF_ELEMENT);
+            final Element placeElement = doc.createElement(PLACE_REF_ELEMENT);
             placeElement.setAttribute(ID_ATR, Long.toString(place.getId()));
             pictureElement.appendChild(placeElement);
         });
@@ -814,30 +1040,30 @@ public class TimeProjectProviderV4 implements TimelineProjectProvider {
         return pictureElement;
     }
 
-    private static Element createFriezeElement(Document doc, Frieze frieze) {
+    private static Element createFriezeElement(final Document doc, final Frieze frieze) {
         LOG.log(Level.INFO, "Saving Frieze {0}", new Object[]{frieze.getName()});
-        var friezeElement = doc.createElement(FRIEZE_ELEMENT);
+        final var friezeElement = doc.createElement(FRIEZE_ELEMENT);
         friezeElement.setAttribute(NAME_ATR, frieze.getName());
         friezeElement.setAttribute(ID_ATR, Long.toString(frieze.getId()));
         // Stays
-        var staysElement = doc.createElement(STAYS_REF_GROUP);
+        final var staysElement = doc.createElement(STAYS_REF_GROUP);
         friezeElement.appendChild(staysElement);
         frieze.getStayPeriods().forEach(stay -> staysElement.appendChild(createStayElementInFreize(doc, stay)));
         // FreeMaps
-        var freemapsElement = doc.createElement(FreeMapProviderV4.FREEMAPS_GROUP);
+        final var freemapsElement = doc.createElement(FreeMapProviderV4.FREEMAPS_GROUP);
         friezeElement.appendChild(freemapsElement);
         frieze.getFriezeFreeMaps().forEach(freeMap -> freemapsElement.appendChild(FreeMapProviderV4.saveFreeMapElement(doc, freeMap)));
         return friezeElement;
     }
 
-    private static Element createStayElement(Document doc, StayPeriod stay) {
-        Element stayElement = doc.createElement(STAY_ELEMENT);
+    private static Element createStayElement(final Document doc, final StayPeriod stay) {
+        final Element stayElement = doc.createElement(STAY_ELEMENT);
         stayElement.setAttribute(ID_ATR, Long.toString(stay.getId()));
         stayElement.setAttribute(PERSON_ATR, Long.toString(stay.getPerson().getId()));
         switch (stay.getTimeFormat()) {
             case LOCAL_TIME -> {
-                LocalDate startDate = LocalDate.ofEpochDay((long) stay.getStartDate());
-                LocalDate endDate = LocalDate.ofEpochDay((long) stay.getEndDate());
+                final LocalDate startDate = LocalDate.ofEpochDay((long) stay.getStartDate());
+                final LocalDate endDate = LocalDate.ofEpochDay((long) stay.getEndDate());
                 stayElement.setAttribute(START_DATE_ATR, IDateObject.DEFAULT_DATE_FORMATTER.format(startDate));
                 stayElement.setAttribute(END_DATE_ATR, IDateObject.DEFAULT_DATE_FORMATTER.format(endDate));
             }
@@ -853,14 +1079,14 @@ public class TimeProjectProviderV4 implements TimelineProjectProvider {
         return stayElement;
     }
 
-    private static Element createStayElementInFreize(Document doc, StayPeriod stay) {
-        Element stayElement = doc.createElement(STAY_ELEMENT_REF);
+    private static Element createStayElementInFreize(final Document doc, final StayPeriod stay) {
+        final Element stayElement = doc.createElement(STAY_ELEMENT_REF);
         stayElement.setAttribute(ID_ATR, Long.toString(stay.getId()));
         return stayElement;
     }
 
-    private static Element createPictureChronologyElement(Document doc, PictureChronology pictureChronology) {
-        var pictureChronologyElement = doc.createElement(PICTURE_CHRONOLOGY_ELEMENT);
+    private static Element createPictureChronologyElement(final Document doc, final PictureChronology pictureChronology) {
+        final var pictureChronologyElement = doc.createElement(PICTURE_CHRONOLOGY_ELEMENT);
         pictureChronologyElement.setAttribute(ID_ATR, Long.toString(pictureChronology.getId()));
         pictureChronologyElement.setAttribute(NAME_ATR, pictureChronology.getName());
         pictureChronologyElement.setAttribute(WIDTH_ATR, Double.toString(pictureChronology.getWidth()));
@@ -871,8 +1097,8 @@ public class TimeProjectProviderV4 implements TimelineProjectProvider {
         return pictureChronologyElement;
     }
 
-    private static Element createPictureChronologyMiniature(Document doc, ChronologyPictureMiniature miniature) {
-        var pictureChronologyMiniatureElement = doc.createElement(PICTURE_CHRONOLOGY_MINIATURE_ELEMENT);
+    private static Element createPictureChronologyMiniature(final Document doc, final ChronologyPictureMiniature miniature) {
+        final var pictureChronologyMiniatureElement = doc.createElement(PICTURE_CHRONOLOGY_MINIATURE_ELEMENT);
         pictureChronologyMiniatureElement.setAttribute(ID_ATR, Long.toString(miniature.getId()));
         pictureChronologyMiniatureElement.setAttribute(X_POS_ATR, Double.toString(miniature.getPosition().getX()));
         pictureChronologyMiniatureElement.setAttribute(Y_POS_ATR, Double.toString(miniature.getPosition().getY()));
@@ -884,8 +1110,8 @@ public class TimeProjectProviderV4 implements TimelineProjectProvider {
         return pictureChronologyMiniatureElement;
     }
 
-    private static Element createPictureChronologyLink(Document doc, ChronologyLink link) {
-        var pictureChronologyLinkElement = doc.createElement(PICTURE_CHRONOLOGY_LINK_ELEMENT);
+    private static Element createPictureChronologyLink(final Document doc, final ChronologyLink link) {
+        final var pictureChronologyLinkElement = doc.createElement(PICTURE_CHRONOLOGY_LINK_ELEMENT);
         pictureChronologyLinkElement.setAttribute(ID_ATR, Long.toString(link.getId()));
         pictureChronologyLinkElement.setAttribute(TYPE_ATR, link.getLinkType().name());
         pictureChronologyLinkElement.setAttribute(FROM_ATR, Long.toString(link.getStartMiniature().getId()));

--- a/src/main/java/com/github/noony/app/timelinefx/save/v4/TimeProjectProviderV4.java
+++ b/src/main/java/com/github/noony/app/timelinefx/save/v4/TimeProjectProviderV4.java
@@ -1,0 +1,901 @@
+/*
+ * Copyright (C) 2021 NoOnY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.github.noony.app.timelinefx.save.v4;
+
+import com.github.noony.app.timelinefx.core.Frieze;
+import com.github.noony.app.timelinefx.core.FriezeFactory;
+import com.github.noony.app.timelinefx.core.IDateObject;
+import com.github.noony.app.timelinefx.core.IPicture;
+import com.github.noony.app.timelinefx.core.Messages;
+import com.github.noony.app.timelinefx.core.Person;
+import com.github.noony.app.timelinefx.core.PersonFactory;
+import com.github.noony.app.timelinefx.core.Picture;
+import com.github.noony.app.timelinefx.core.PictureFactory;
+import com.github.noony.app.timelinefx.core.Place;
+import com.github.noony.app.timelinefx.core.PlaceFactory;
+import com.github.noony.app.timelinefx.core.PlaceLevel;
+import com.github.noony.app.timelinefx.core.PortraitFactory;
+import com.github.noony.app.timelinefx.core.StayFactory;
+import com.github.noony.app.timelinefx.core.StayPeriod;
+import com.github.noony.app.timelinefx.core.StayPeriodLocalDate;
+import com.github.noony.app.timelinefx.core.StayPeriodSimpleTime;
+import com.github.noony.app.timelinefx.core.TimeFormat;
+import static com.github.noony.app.timelinefx.core.TimeFormat.LOCAL_TIME;
+import com.github.noony.app.timelinefx.core.TimeLineProject;
+import com.github.noony.app.timelinefx.core.TimeLineProjectFactory;
+import com.github.noony.app.timelinefx.core.picturechronology.ChronologyLink;
+import com.github.noony.app.timelinefx.core.picturechronology.ChronologyLinkType;
+import com.github.noony.app.timelinefx.core.picturechronology.ChronologyPictureMiniature;
+import com.github.noony.app.timelinefx.core.picturechronology.PictureChronology;
+import com.github.noony.app.timelinefx.core.picturechronology.PictureChronologyFactory;
+import com.github.noony.app.timelinefx.save.TimelineProjectProvider;
+import com.github.noony.app.timelinefx.utils.CustomFileUtils;
+import com.github.noony.app.timelinefx.utils.CustomProfiler;
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+import javafx.geometry.Point2D;
+import javafx.scene.paint.Color;
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.filefilter.DirectoryFileFilter;
+import org.apache.commons.io.filefilter.RegexFileFilter;
+import org.openide.util.lookup.ServiceProvider;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+/**
+ *
+ * @author hamon
+ */
+@ServiceProvider(service = TimelineProjectProvider.class)
+public class TimeProjectProviderV4 implements TimelineProjectProvider {
+
+    public static final String PROJECT_GROUP = "PROJECT";
+
+    public static final String PLACES_GROUP = "PLACES";
+
+    public static final String PERSONS_GROUP = "PERSONS";
+
+    public static final String PICTURES_GROUP = "PICTURES";
+
+    public static final String FRIEZES_GROUP = "FRIEZES";
+
+    public static final String STAYS_GROUP = "STAYS";
+
+    public static final String STAYS_REF_GROUP = "stays";
+
+    public static final String PORTRAITS_GROUP = "portraits";
+
+    public static final String PICTURE_CHRONOLOGIES_GROUP = "PICTURE_CHRONOLOGIES";
+
+    public static final String PLACE_ELEMENT = "place";
+
+    public static final String PLACE_REF_ELEMENT = "placeRef";
+
+    public static final String PERSON_ELEMENT = "person";
+
+    public static final String PERSON_REF_ELEMENT = "personRef";
+
+    public static final String PICTURE_ELEMENT = "picture";
+
+    public static final String PICTURE_REF_ELEMENT = "pictureRef";
+
+    public static final String FRIEZE_ELEMENT = "frieze";
+
+    public static final String STAY_ELEMENT = "stay";
+
+    public static final String STAY_ELEMENT_REF = "stayRef";
+
+    public static final String PORTRAIT_ELEMENT = "portrait";
+
+    public static final String PICTURE_CHRONOLOGY_ELEMENT = "pictureChronology";
+    public static final String PICTURE_CHRONOLOGY_MINIATURE_ELEMENT = "pictureChronologyMiniature";
+    public static final String PICTURE_CHRONOLOGY_LINK_ELEMENT = "pictureChronologyLink";
+    //
+    public static final String PICTURES_LOCATION_ATR = "picsLoc";
+    //
+    public static final String PORTRAIT_FOLDER_ATR = "portraitsFolder";
+    public static final String PICTURES_FOLDER_ATR = "picturesFolder";
+    public static final String MINIATURES_FOLDER_ATR = "miniaturesFolder";
+    //
+    public static final String ID_ATR = "id";
+    public static final String NAME_ATR = "name";
+    public static final String TYPE_ATR = "type";
+    public static final String PATH_ATR = "path";
+    public static final String DATE_ATR = "date";
+    public static final String PLACE_LEVEL_ATR = "level";
+    public static final String COLOR_ATR = "color";
+    public static final String PERSON_ATR = "person";
+    public static final String DEFAULT_PORTRAIT_REF_ATR = "defaultPortraitRef";
+    public static final String DATE_OF_BIRTH_ATR = "dateOfBirth";
+    public static final String DATE_OF_DEATH_ATR = "dateOfDeath";
+    public static final String START_DATE_ATR = "startDate";
+    public static final String END_DATE_ATR = "endDate";
+    public static final String TIME_FORMAT_ATR = "timeFormat";
+    public static final String STAY_ID_ATR = "stayID";
+    public static final String START_ID_ATR = "startID";
+    public static final String END_ID_ATR = "endID";
+    public static final String PLACE_ID_ATR = "placeID";
+    public static final String FROM_ATR = "from";
+    public static final String TO_ATR = "to";
+    public static final String PERSON_REF_ATR = "personRef";
+    public static final String PLACE_REF_ATR = "placeRef";
+    public static final String PORTRAIT_REF_ATR = "portraitRef";
+    public static final String PARAMETERS_ATR = "params";
+    public static final String LINKED_OBJECT_ID_ATR = "linkedObjectID";
+    //
+    public static final String WIDTH_ATR = "width";
+    public static final String HEIGHT_ATR = "height";
+    public static final String X_POS_ATR = "xPos";
+    public static final String Y_POS_ATR = "yPos";
+    public static final String RADIUS_ATR = "radius";
+    public static final String SCALE_ATR = "scale";
+    public static final String INDEX_ATR = "index";
+    public static final String PLOT_SIZE_ATR = "plotSize";
+
+    private static final Logger LOG = Logger.getGlobal();
+
+    private static final String TARGET_VERSION = "4";
+
+    @Override
+    public List<String> getSupportedVersions() {
+        return Arrays.asList(TARGET_VERSION);
+    }
+
+    @Override
+    public TimeLineProject load(File projectFile, Element e) {
+        var loadMethodName = getClass().getSimpleName() + "__load";
+        CustomProfiler.start(loadMethodName);
+        String projectName = e.getAttribute(NAME_ATR);
+        // Load project properties
+        var portraitsFolderValue = e.hasAttribute(PORTRAIT_FOLDER_ATR) ? e.getAttribute(PORTRAIT_FOLDER_ATR) : TimeLineProject.DEFAULT_PORTRAIT_FOLDER;
+        var picturesFolderValue = e.hasAttribute(PICTURES_FOLDER_ATR) ? e.getAttribute(PICTURES_FOLDER_ATR) : TimeLineProject.DEFAULT_PICTURES_FOLDER;
+        var miniaturesFolderValue = e.hasAttribute(MINIATURES_FOLDER_ATR) ? e.getAttribute(MINIATURES_FOLDER_ATR) : TimeLineProject.DEFAULT_MINIATURES_FOLDER;
+        //
+        Map<String, String> configParams = Map.of(
+                TimeLineProject.PROJECT_FOLDER_KEY, projectFile.getParent(),
+                TimeLineProject.PORTRAIT_FOLDER_KEY, portraitsFolderValue,
+                TimeLineProject.PICTURES_FOLDER_KEY, picturesFolderValue,
+                TimeLineProject.MINIATURES_FOLDER_KEY, miniaturesFolderValue
+        );
+        TimeLineProject project = TimeLineProjectFactory.createProject(projectName, configParams);
+        var timeFormatValue = e.hasAttribute(TIME_FORMAT_ATR) ? TimeFormat.valueOf(e.getAttribute(TIME_FORMAT_ATR)) : TimeFormat.LOCAL_TIME;
+        project.setTimeFormat(timeFormatValue);
+        //
+        List<String> relativePathLoaded = new LinkedList<>();
+        //
+        NodeList rootChildren = e.getChildNodes();
+        for (int i = 0; i < rootChildren.getLength(); i++) {
+            Node node = rootChildren.item(i);
+            if (node instanceof Element element) {
+                switch (element.getTagName()) {
+                    case PLACES_GROUP -> {
+                        List<Place> places = parsePlaces(element, null);
+                        places.stream().filter(p -> p.getParent() == null).forEach(p -> project.addHighLevelPlace(p));
+                    }
+                    case PERSONS_GROUP -> {
+                        List<Person> persons = parsePersons(element, project, relativePathLoaded);
+                        persons.forEach(p -> project.addPerson(p));
+                    }
+                    case PICTURES_GROUP -> {
+                        parsePictures(element, project, relativePathLoaded);
+                    }
+                    case STAYS_GROUP -> {
+                        List<StayPeriod> stays = parseStays(element, timeFormatValue);
+                        stays.forEach(s -> project.addStay(s));
+                    }
+                    case FRIEZES_GROUP -> {
+                        parseFriezes(project, element);
+                    }
+                    case PICTURE_CHRONOLOGIES_GROUP -> {
+                        parsePictureChronologies(project, element);
+                    }
+                    default ->
+                        throw new UnsupportedOperationException("Unknown element :: " + element.getTagName());
+                }
+            }
+        }
+        // check every file exists
+        relativePathLoaded.forEach(path -> {
+            var absolutePath = CustomFileUtils.fromProjectRelativeToAbsolute(project, path);
+            // not optimal ...
+            File file = new File(absolutePath);
+            if (!file.exists()) {
+                LOG.log(Level.SEVERE, "The file {0} does not exists. (saved as {1})", new Object[]{absolutePath, path});
+            }
+        });
+        //
+        Set<Path> absolutePathsLoaded = relativePathLoaded
+                .stream()
+                .map(p -> Paths.get(CustomFileUtils.fromProjectRelativeToAbsolute(project, p)))
+                .map(p -> p.normalize())
+                .collect(Collectors.toSet());
+        // * Portraits
+        File portraitFolder = project.getPortraitsAbsoluteFolder();
+        FileUtils.listFiles(portraitFolder, new RegexFileFilter("^(.*?)"), DirectoryFileFilter.DIRECTORY)
+                .stream()
+                .map(portraitFile -> Paths.get(portraitFile.toURI()))
+                .filter(portraitAbsolutePath -> !absolutePathsLoaded.contains(portraitAbsolutePath))
+                .forEach(portraitAbsolutePath
+                        -> // FUTURE IMPROVMENT : create actions
+                        LOG.log(Level.WARNING, "Found unused portrait file: {0}", new Object[]{portraitAbsolutePath})
+                );
+        // * Pictures
+        File picturesFolder = project.getPicturesFolder();
+        FileUtils.listFiles(picturesFolder, new RegexFileFilter("^(.*?)"), DirectoryFileFilter.DIRECTORY)
+                .stream()
+                .map(pictureFile -> Paths.get(pictureFile.toURI()))
+                .filter(pictureAbsolutePath -> !absolutePathsLoaded.contains(pictureAbsolutePath))
+                .forEach(pictureAbsolutePath
+                        -> // FUTURE IMPROVMENT : create actions
+                        LOG.log(Level.WARNING, "Found unused picture file: {0}", new Object[]{pictureAbsolutePath})
+                );
+        //
+        // FUTURE IMPROVMENT : ENABLE AUTO IMPORT => in config
+        //
+        CustomProfiler.stop(loadMethodName);
+        return project;
+    }
+
+    @Override
+    public boolean save(TimeLineProject project, File destFile) {
+        try {
+            DocumentBuilderFactory docFactory = DocumentBuilderFactory.newInstance();
+            docFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            DocumentBuilder docBuilder = docFactory.newDocumentBuilder();
+            // root elements
+            Document doc = docBuilder.newDocument();
+            Element rootElement = doc.createElement(PROJECT_GROUP);
+            rootElement.setAttribute(NAME_ATR, project.getName());
+            rootElement.setAttribute(PROJECT_VERSION_ATR, TARGET_VERSION);
+            //TODO can use other method
+            var portraitsFolderName = CustomFileUtils.fromAbsoluteToProjectRelative(project, project.getPortraitsAbsoluteFolder());
+            var picturesFolderName = CustomFileUtils.fromAbsoluteToProjectRelative(project, project.getPicturesFolder());
+            var miniaturesFolderName = CustomFileUtils.fromAbsoluteToProjectRelative(project, project.getMiniaturesFolder());
+            rootElement.setAttribute(PORTRAIT_FOLDER_ATR, portraitsFolderName);
+            rootElement.setAttribute(PICTURES_LOCATION_ATR, picturesFolderName);
+            rootElement.setAttribute(MINIATURES_FOLDER_ATR, miniaturesFolderName);
+            rootElement.setAttribute(TIME_FORMAT_ATR, project.getTimeFormat().name());
+            doc.appendChild(rootElement);
+            // save places
+            Element placesGroupElement = doc.createElement(PLACES_GROUP);
+            rootElement.appendChild(placesGroupElement);
+            project.getHighLevelPlaces().forEach(place -> placesGroupElement.appendChild(createPlaceElement(doc, place, "root")));
+            // save persons
+            Element personsGroupElement = doc.createElement(PERSONS_GROUP);
+            rootElement.appendChild(personsGroupElement);
+            project.getPersons().forEach(person -> personsGroupElement.appendChild(createPersonElement(doc, person)));
+            // save pictures
+            Element picturesGroupElement = doc.createElement(PICTURES_GROUP);
+            rootElement.appendChild(picturesGroupElement);
+            PictureFactory.getPictures().forEach(picture -> picturesGroupElement.appendChild(createPictureElement(doc, picture)));
+            // save stays
+            Element staysGroupElement = doc.createElement(STAYS_GROUP);
+            rootElement.appendChild(staysGroupElement);
+            project.getStays().forEach(stay -> staysGroupElement.appendChild(createStayElement(doc, stay)));
+            // save friezes
+            Element friezesGroupElement = doc.createElement(FRIEZES_GROUP);
+            rootElement.appendChild(friezesGroupElement);
+            project.getFriezes().forEach(frieze -> friezesGroupElement.appendChild(createFriezeElement(doc, frieze)));
+            // save picture chronologies
+            Element pictureChronologiesGroupElement = doc.createElement(PICTURE_CHRONOLOGIES_GROUP);
+            rootElement.appendChild(pictureChronologiesGroupElement);
+            project.getPictureChronologies().forEach(picChronology -> pictureChronologiesGroupElement.appendChild(createPictureChronologyElement(doc, picChronology)));
+            //
+            rootElement.normalize();
+            // write the content into xml file
+            TransformerFactory transformerFactory = TransformerFactory.newDefaultInstance();
+            transformerFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            Transformer transformer = transformerFactory.newTransformer();
+            transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2");
+            transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+            DOMSource source = new DOMSource(doc);
+            StreamResult result = new StreamResult(destFile);
+            transformer.transform(source, result);
+        } catch (ParserConfigurationException | TransformerException ex) {
+            LOG.log(Level.SEVERE, " Exception while exporting timeline :: {0}", new Object[]{ex});
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Finds the first direct child element with the given tag name, without recursing into descendants (unlike {@link Element#getElementsByTagName(String)}, which walks the whole
+     * subtree).
+     *
+     * @param parent the element whose direct children are searched
+     * @param tagName the tag name to look for
+     * @return the first matching direct child, or {@code null} if none exists
+     */
+    protected static Element firstDirectChildByTagName(final Element parent, final String tagName) {
+        var children = parent.getChildNodes();
+        for (int i = 0; i < children.getLength(); i++) {
+            if (children.item(i) instanceof Element child && child.getTagName().equals(tagName)) {
+                return child;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Parses the given attribute as a double, failing with a message identifying the element, attribute and raw value instead of the bare
+     * {@link NumberFormatException} {@link Double#parseDouble(String)} would throw.
+     *
+     * @param element the element carrying the attribute
+     * @param attributeName the attribute to parse
+     * @return the parsed value
+     */
+    protected static double parseDoubleAttribute(final Element element, final String attributeName) {
+        var value = element.getAttribute(attributeName);
+        try {
+            return Double.parseDouble(value);
+        } catch (NumberFormatException e) {
+            throw new IllegalStateException("Could not parse attribute '" + attributeName + "' of <" + element.getTagName() + "> as a double: '" + value + "'", e);
+        }
+    }
+
+    private static List<Place> parsePlaces(Element placesRootElement, Place parentPlace) {
+        List<Place> places = new LinkedList<>();
+        NodeList placeElements = placesRootElement.getChildNodes();
+        for (int i = 0; i < placeElements.getLength(); i++) {
+            if (placeElements.item(i).getNodeName().equals(PLACE_ELEMENT)) {
+                Element e = (Element) placeElements.item(i);
+                Place p = parsePlace(e, parentPlace);
+                places.add(p);
+            }
+        }
+        return places;
+    }
+
+    private static Place parsePlace(Element placeElement, Place parentPlace) {
+        // <place color="0xf5deb3ff" id="1" level="GALAXY" name="Galaxy">
+        Color color = Color.valueOf(placeElement.getAttribute(COLOR_ATR));
+        long id = Long.parseLong(placeElement.getAttribute(ID_ATR));
+        PlaceLevel level = PlaceLevel.valueOf(placeElement.getAttribute(PLACE_LEVEL_ATR));
+        String name = placeElement.getAttribute(NAME_ATR);
+        Place place = PlaceFactory.createPlace(id, name, level, parentPlace, color);
+        parsePlaces(placeElement, place);
+        return place;
+    }
+
+    private static List<Person> parsePersons(Element personsRootElement, TimeLineProject project, List<String> relativePathLoaded) {
+        List<Person> persons = new LinkedList<>();
+        NodeList personElements = personsRootElement.getChildNodes();
+        for (int i = 0; i < personElements.getLength(); i++) {
+            if (personElements.item(i).getNodeName().equals(PERSON_ELEMENT)) {
+                Element e = (Element) personElements.item(i);
+                Person p = parsePerson(e, project, relativePathLoaded);
+                persons.add(p);
+            }
+        }
+        return persons;
+    }
+
+    private static Person parsePerson(Element personElement, TimeLineProject project, List<String> relativePathLoaded) {
+        // <person color="0x7fffd4ff" id="1" name="Obi Wan Kenobi"/>
+        var color = Color.valueOf(personElement.getAttribute(COLOR_ATR));
+        var id = Long.parseLong(personElement.getAttribute(ID_ATR));
+        var name = personElement.getAttribute(NAME_ATR);
+        var defaultPortraitRef = Long.MIN_VALUE;
+        if (personElement.hasAttribute(DEFAULT_PORTRAIT_REF_ATR)) {
+            defaultPortraitRef = Long.parseLong(personElement.getAttribute(DEFAULT_PORTRAIT_REF_ATR));
+        }
+        var person = PersonFactory.createPerson(project, id, name, color);
+        var childrenElements = personElement.getChildNodes();
+        for (int i = 0; i < childrenElements.getLength(); i++) {
+            if (childrenElements.item(i).getNodeName().equals(PORTRAIT_ELEMENT)) {
+                // <portrait id="147" path="portraits\obi_wan.png"/>
+                var portraitElement = (Element) childrenElements.item(i);
+                var portraitID = Long.parseLong(portraitElement.getAttribute(ID_ATR));
+                var portraitPath = portraitElement.getAttribute(PATH_ATR);
+                var portrait = PortraitFactory.createPortrait(portraitID, person, portraitPath);
+                if (portrait.getId() == defaultPortraitRef) {
+                    person.setDefaultPortrait(portrait);
+                } else {
+                    person.addPortrait(portrait);
+                }
+                parseObjectTimeValue(portraitElement, portrait, project.getTimeFormat());
+                relativePathLoaded.add(portraitPath);
+            }
+        }
+        //
+        if (personElement.hasAttribute(TIME_FORMAT_ATR)) {
+            var timeFormat = TimeFormat.valueOf(personElement.getAttribute(TIME_FORMAT_ATR));
+            person.setTimeFormat(timeFormat);
+            switch (timeFormat) {
+                case LOCAL_TIME -> {
+                    if (personElement.hasAttribute(DATE_OF_BIRTH_ATR)) {
+                        var dateOfBirthS = personElement.getAttribute(DATE_OF_BIRTH_ATR);
+                        var dateOfBirth = LocalDate.parse(dateOfBirthS);
+                        person.setDateOfBirth(dateOfBirth);
+                    }
+                    if (personElement.hasAttribute(DATE_OF_DEATH_ATR)) {
+                        var dateOfDeathS = personElement.getAttribute(DATE_OF_DEATH_ATR);
+                        var dateOfDeath = LocalDate.parse(dateOfDeathS);
+                        person.setDateOfDeath(dateOfDeath);
+                    }
+                }
+                case TIME_MIN -> {
+                    if (personElement.hasAttribute(DATE_OF_BIRTH_ATR)) {
+                        var timeOfBirthS = personElement.getAttribute(DATE_OF_BIRTH_ATR);
+                        var timeOfBirth = Long.parseLong(timeOfBirthS);
+                        person.setTimeOfBirth(timeOfBirth);
+                    }
+                    if (personElement.hasAttribute(DATE_OF_DEATH_ATR)) {
+                        var timeOfDeathS = personElement.getAttribute(DATE_OF_DEATH_ATR);
+                        var timeOfDeath = Long.parseLong(timeOfDeathS);
+                        person.setTimeOfDeath(timeOfDeath);
+                    }
+                }
+                default ->
+                    throw new UnsupportedOperationException(Messages.UNSUPPORTED_TIME_FORMAT + timeFormat);
+            }
+        }
+        return person;
+    }
+
+    protected static void parseObjectTimeValue(Element sourceElement, IDateObject aDateObject, TimeFormat aTimeFormat) {
+        aDateObject.setTimeFormat(aTimeFormat);
+        switch (aTimeFormat) {
+            case LOCAL_TIME -> {
+                if (sourceElement.hasAttribute(DATE_ATR)) {
+                    var dateS = sourceElement.getAttribute(DATE_ATR);
+                    try {
+                        var date = LocalDate.parse(dateS);
+                        aDateObject.setDate(date);
+                    } catch (Exception e) {
+                        LOG.log(Level.SEVERE, "Could not parse date {0}, for element {1}, using default date.", new Object[]{e.getMessage(), sourceElement});
+                        aDateObject.setDate(LocalDate.EPOCH);
+                    }
+                }
+            }
+            case TIME_MIN -> {
+                if (sourceElement.hasAttribute(DATE_ATR)) {
+                    var time = parseDoubleAttribute(sourceElement, DATE_ATR);
+                    aDateObject.setTimestamp(time);
+                }
+            }
+            default ->
+                throw new UnsupportedOperationException(Messages.UNSUPPORTED_TIME_FORMAT + aTimeFormat);
+        }
+    }
+
+    private static List<Picture> parsePictures(Element picturesRootElement, TimeLineProject project, List<String> relativePathLoaded) {
+        List<Picture> pictures = new LinkedList<>();
+        NodeList picturesElements = picturesRootElement.getChildNodes();
+        for (int i = 0; i < picturesElements.getLength(); i++) {
+            if (picturesElements.item(i).getNodeName().equals(PICTURE_ELEMENT)) {
+                Element e = (Element) picturesElements.item(i);
+                Picture p = parsePicture(e, project, relativePathLoaded);
+                pictures.add(p);
+            }
+        }
+        return pictures;
+    }
+
+    private static Picture parsePicture(Element pictureElement, TimeLineProject project, List<String> relativePathLoaded) {
+        Long milliIn = System.currentTimeMillis();
+        var id = Long.parseLong(pictureElement.getAttribute(ID_ATR));
+        var name = pictureElement.getAttribute(NAME_ATR);
+        var path = pictureElement.getAttribute(PATH_ATR);
+        relativePathLoaded.add(path);
+        var width = Integer.parseInt(pictureElement.getAttribute(WIDTH_ATR));
+        var height = Integer.parseInt(pictureElement.getAttribute(HEIGHT_ATR));
+        //
+        Picture picture = PictureFactory.createPicture(project, id, name, LocalDateTime.MIN, path, width, height);
+        parseObjectTimeValue(pictureElement, picture, project.getTimeFormat());
+        //
+        var pictureChildrenElements = pictureElement.getChildNodes();
+        for (int i = 0; i < pictureChildrenElements.getLength(); i++) {
+            Node n = pictureChildrenElements.item(i);
+            switch (n.getNodeName()) {
+                case PERSON_REF_ELEMENT -> {
+                    Element e = (Element) n;
+                    long personID = Long.parseLong(e.getAttribute(ID_ATR));
+                    Person person = PersonFactory.getPerson(personID);
+                    picture.addPerson(person);
+                }
+                case PLACE_REF_ELEMENT -> {
+                    Element e = (Element) n;
+                    long placeID = Long.parseLong(e.getAttribute(ID_ATR));
+                    Place place = PlaceFactory.getPlace(placeID);
+                    picture.addPlace(place);
+                }
+                case "#text" ->
+                    LOG.log(Level.FINE, "Ignoring text element");
+                default ->
+                    throw new UnsupportedOperationException("Could not parse child element of picture " + name + " :: " + n);
+            }
+        }
+        //
+        var milliOut = System.currentTimeMillis();
+        var time = milliOut - milliIn;
+        if (time > 1) {
+            LOG.log(Level.SEVERE, "Parsed picture: {0}\n > took {1}ms.", new Object[]{name, Long.toString(time)});
+        }
+        return picture;
+    }
+
+    private List<Frieze> parseFriezes(TimeLineProject project, Element friezesRootElement) {
+        List<Frieze> friezes = new LinkedList<>();
+        NodeList friezeElements = friezesRootElement.getChildNodes();
+        for (int i = 0; i < friezeElements.getLength(); i++) {
+            if (friezeElements.item(i).getNodeName().equals(FRIEZE_ELEMENT)) {
+                Element e = (Element) friezeElements.item(i);
+                Frieze f = parseFrieze(project, e);
+                friezes.add(f);
+            }
+        }
+        return friezes;
+    }
+
+    private Frieze parseFrieze(TimeLineProject project, Element friezeElement) {
+        // <frieze name="SW 1-2">
+        var name = friezeElement.getAttribute(NAME_ATR);
+        var id = Long.parseLong(friezeElement.getAttribute(ID_ATR));
+        var staysElement = firstDirectChildByTagName(friezeElement, STAYS_REF_GROUP);
+        if (staysElement == null) {
+            throw new IllegalStateException("Wrong number of STAYS_GROUP : 0");
+        }
+        var stays = parseStaysInFreize(staysElement);
+        var frieze = FriezeFactory.createFrieze(id, project, name, stays);
+        //
+        var freemapsElement = firstDirectChildByTagName(friezeElement, FreeMapProviderV4.FREEMAPS_GROUP);
+        if (freemapsElement == null) {
+            throw new IllegalStateException("Wrong number of FREEMAPS_GROUP : 0");
+        }
+        FreeMapProviderV4.parseFreeMaps(freemapsElement, frieze);
+        //
+        return frieze;
+    }
+
+    private List<StayPeriod> parseStays(Element staysRootElement, TimeFormat aTimeFormat) {
+        List<StayPeriod> stayPeriods = new LinkedList<>();
+        NodeList stayElements = staysRootElement.getChildNodes();
+        for (int i = 0; i < stayElements.getLength(); i++) {
+            if (stayElements.item(i).getNodeName().equals(STAY_ELEMENT)) {
+                Element e = (Element) stayElements.item(i);
+                switch (aTimeFormat) {
+                    case LOCAL_TIME ->
+                        stayPeriods.add(parseStayPeriodLocalTime(e));
+                    case TIME_MIN ->
+                        stayPeriods.add(parseStayPeriodSimpleTime(e));
+                    default ->
+                        throw new UnsupportedOperationException("Time format not recognized: " + e.getAttribute(TIME_FORMAT_ATR));
+                }
+            }
+        }
+        return stayPeriods;
+    }
+
+    private List<StayPeriod> parseStaysInFreize(Element staysRootElement) {
+        List<StayPeriod> stayPeriods = new LinkedList<>();
+        NodeList stayElements = staysRootElement.getChildNodes();
+        for (int i = 0; i < stayElements.getLength(); i++) {
+            if (stayElements.item(i).getNodeName().equals(STAY_ELEMENT_REF)) {
+                Element e = (Element) stayElements.item(i);
+                long id = Long.parseLong(e.getAttribute(ID_ATR));
+                var stay = StayFactory.getStay(id);
+                if (stay == null) {
+                    throw new UnsupportedOperationException("StayPeriod reference does not exist " + id);
+                }
+                stayPeriods.add(stay);
+            }
+        }
+        return stayPeriods;
+    }
+
+    private StayPeriodLocalDate parseStayPeriodLocalTime(Element stayElement) {
+        // <stay endDate="20" id="1" person="5" startDate="0" timeFormat="LOCAL_TIME"/>
+        long id = Long.parseLong(stayElement.getAttribute(ID_ATR));
+        long personID = Long.parseLong(stayElement.getAttribute(PERSON_ATR));
+        Person person = PersonFactory.getPerson(personID);
+        if (person == null) {
+            throw new IllegalStateException();
+        }
+        long placeID = Long.parseLong(stayElement.getAttribute(PLACE_ID_ATR));
+        Place place = PlaceFactory.getPlace(placeID);
+        if (place == null) {
+            throw new IllegalStateException();
+        }
+        String startS = stayElement.getAttribute(START_DATE_ATR);
+        String endS = stayElement.getAttribute(END_DATE_ATR);
+        LocalDate start = LocalDate.parse(startS);
+        LocalDate end = LocalDate.parse(endS);
+        return StayFactory.createStayPeriodLocalDate(id, person, start, end, place);
+    }
+
+    private StayPeriodSimpleTime parseStayPeriodSimpleTime(Element stayElement) {
+        // <stay endDate="20" id="1" person="5" startDate="0" timeFormat="TIME_MIN"/>
+        long id = Long.parseLong(stayElement.getAttribute(ID_ATR));
+        long personID = Long.parseLong(stayElement.getAttribute(PERSON_ATR));
+        Person person = PersonFactory.getPerson(personID);
+        if (person == null) {
+            throw new IllegalStateException("Could not load StayPeriodSimpleTime id=" + id + " with personID=" + personID);
+        }
+        long placeID = Long.parseLong(stayElement.getAttribute(PLACE_ID_ATR));
+        Place place = PlaceFactory.getPlace(placeID);
+        if (place == null) {
+            throw new IllegalStateException("Could not load StayPeriodSimpleTime id=" + id + " with placeID=" + placeID);
+        }
+        var start = parseDoubleAttribute(stayElement, START_DATE_ATR);
+        var end = parseDoubleAttribute(stayElement, END_DATE_ATR);
+        return StayFactory.createStayPeriodSimpleTime(id, person, start, end, place);
+    }
+
+    private List<PictureChronology> parsePictureChronologies(TimeLineProject project, Element pictureChronologiesRootElement) {
+        List<PictureChronology> pictureChronologys = new LinkedList<>();
+        NodeList pictureChronologiesElements = pictureChronologiesRootElement.getChildNodes();
+        for (int i = 0; i < pictureChronologiesElements.getLength(); i++) {
+            if (pictureChronologiesElements.item(i).getNodeName().equals(PICTURE_CHRONOLOGY_ELEMENT)) {
+                Element e = (Element) pictureChronologiesElements.item(i);
+                PictureChronology pC = parsePictureChronology(project, e);
+                pictureChronologys.add(pC);
+            }
+        }
+        return pictureChronologys;
+    }
+
+    private PictureChronology parsePictureChronology(TimeLineProject project, Element pictureChronologyElement) {
+        long id = Long.parseLong(pictureChronologyElement.getAttribute(ID_ATR));
+        String name = pictureChronologyElement.getAttribute(NAME_ATR);
+        double width = parseDoubleAttribute(pictureChronologyElement, WIDTH_ATR);
+        double height = parseDoubleAttribute(pictureChronologyElement, HEIGHT_ATR);
+        //
+        List<ChronologyPictureMiniature> miniatures = new LinkedList<>();
+        List<ChronologyLink> links = new LinkedList<>();
+        //
+        NodeList miniaturesElements = pictureChronologyElement.getChildNodes();
+        for (int i = 0; i < miniaturesElements.getLength(); i++) {
+            if (miniaturesElements.item(i).getNodeName().equals(PICTURE_CHRONOLOGY_MINIATURE_ELEMENT)) {
+                Element e = (Element) miniaturesElements.item(i);
+                var miniature = parseChronologyPictureMiniature(e, project.getTimeFormat());
+                miniatures.add(miniature);
+            } else if (miniaturesElements.item(i).getNodeName().equals(PICTURE_CHRONOLOGY_LINK_ELEMENT)) {
+                Element e = (Element) miniaturesElements.item(i);
+                links.add(parsePictureChronologyLink(e));
+            }
+        }
+        //
+        var pictureChronology = PictureChronologyFactory.createPictureChronology(id, project, name, miniatures, links);
+        pictureChronology.setWidth(width);
+        pictureChronology.setHeight(height);
+        //
+        return pictureChronology;
+    }
+
+    private ChronologyPictureMiniature parseChronologyPictureMiniature(Element miniatureElement, TimeFormat aTimeFormat) {
+//        <pictureChronologyMiniature id="138" pictureRef="125" xPos="897.0" yPos="329.0" scale="0.5"/>
+        long id = Long.parseLong(miniatureElement.getAttribute(ID_ATR));
+        long pictureRef = Long.parseLong(miniatureElement.getAttribute(PICTURE_REF_ELEMENT));
+        double xPos = parseDoubleAttribute(miniatureElement, X_POS_ATR);
+        double yPos = parseDoubleAttribute(miniatureElement, Y_POS_ATR);
+        double scale = parseDoubleAttribute(miniatureElement, SCALE_ATR);
+        var miniature = PictureChronologyFactory.createChronologyPictureMiniature(id, IPicture.getPicture(pictureRef), new Point2D(xPos, yPos), scale);
+        miniature.setUseCustomTime(!miniature.isInSyncWithPicture());
+        if (!miniature.isInSyncWithPicture()) {
+            parseObjectTimeValue(miniatureElement, miniature.getDateObject(), aTimeFormat);
+        }
+        return miniature;
+    }
+
+    private static ChronologyLink parsePictureChronologyLink(Element linkElement) {
+        var id = Long.parseLong(linkElement.getAttribute(ID_ATR));
+        var type = ChronologyLinkType.valueOf(linkElement.getAttribute(TYPE_ATR));
+        var fromID = Long.parseLong(linkElement.getAttribute(FROM_ATR));
+        var from = PictureChronologyFactory.getChronologyPictureMiniature(fromID);
+        var toID = Long.parseLong(linkElement.getAttribute(TO_ATR));
+        var to = PictureChronologyFactory.getChronologyPictureMiniature(toID);
+        var personRef = Long.parseLong(linkElement.getAttribute(PERSON_REF_ATR));
+        var person = PersonFactory.getPerson(personRef);
+        var paramsAsString = linkElement.getAttribute(PARAMETERS_ATR);
+        var parameters = CustomFileUtils.toDoubleArray(paramsAsString);
+        return PictureChronologyFactory.createChronologyLink(id, person, from, to, type, parameters);
+    }
+
+    private static Element createPlaceElement(Document doc, Place place, String fromPlace) {
+        LOG.log(Level.FINE, "> Creating place {0} from {1}", new Object[]{place.getName(), fromPlace});
+        var placeElement = doc.createElement(PLACE_ELEMENT);
+        placeElement.setAttribute(ID_ATR, Long.toString(place.getId()));
+        placeElement.setAttribute(NAME_ATR, place.getName());
+        placeElement.setAttribute(PLACE_LEVEL_ATR, place.getLevel().name());
+        placeElement.setAttribute(COLOR_ATR, place.getColor().toString());
+        place.getPlaces().forEach(p -> placeElement.appendChild(createPlaceElement(doc, p, place.getName())));
+        return placeElement;
+    }
+
+    private static Element createPersonElement(Document doc, Person person) {
+        LOG.log(Level.FINE, "> Creating person {0}", new Object[]{person.getName()});
+        var personElement = doc.createElement(PERSON_ELEMENT);
+        personElement.setAttribute(ID_ATR, Long.toString(person.getId()));
+        personElement.setAttribute(NAME_ATR, person.getName());
+        if (person.getDefaultPortrait() != null) {
+            personElement.setAttribute(DEFAULT_PORTRAIT_REF_ATR, Long.toString(person.getDefaultPortrait().getId()));
+        }
+        personElement.setAttribute(COLOR_ATR, person.getColor().toString());
+        personElement.setAttribute(TIME_FORMAT_ATR, person.getTimeFormat().name());
+        switch (person.getTimeFormat()) {
+            case LOCAL_TIME -> {
+                if (person.getDateOfBirth() != null) {
+                    personElement.setAttribute(DATE_OF_BIRTH_ATR, IDateObject.DEFAULT_DATE_FORMATTER.format(person.getDateOfBirth()));
+                }
+                if (person.getDateOfDeath() != null) {
+                    personElement.setAttribute(DATE_OF_DEATH_ATR, IDateObject.DEFAULT_DATE_FORMATTER.format(person.getDateOfDeath()));
+                }
+            }
+            case TIME_MIN -> {
+                personElement.setAttribute(DATE_OF_BIRTH_ATR, Long.toString(person.getTimeOfBirth()));
+                personElement.setAttribute(DATE_OF_DEATH_ATR, Long.toString(person.getTimeOfDeath()));
+            }
+            default ->
+                throw new UnsupportedOperationException(Messages.UNSUPPORTED_TIME_FORMAT + person.getTimeFormat());
+        }
+        person.getPortraits().forEach(portrait -> {
+            var portraitElement = doc.createElement(PORTRAIT_ELEMENT);
+            portraitElement.setAttribute(ID_ATR, Long.toString(portrait.getId()));
+            portraitElement.setAttribute(PATH_ATR, portrait.getProjectRelativePath());
+            saveObjectTime(portraitElement, portrait);
+            personElement.appendChild(portraitElement);
+        });
+        return personElement;
+    }
+
+    private static void saveObjectTime(Element targetElement, IDateObject aDateObject) {
+        switch (aDateObject.getTimeFormat()) {
+            case LOCAL_TIME -> {
+                if (aDateObject.getDate() != null) {
+                    targetElement.setAttribute(DATE_ATR, IDateObject.DEFAULT_DATE_FORMATTER.format(aDateObject.getDate()));
+                }
+            }
+            case TIME_MIN -> {
+                targetElement.setAttribute(DATE_ATR, Double.toString(aDateObject.getTimestamp()));
+            }
+            default ->
+                throw new UnsupportedOperationException(Messages.UNSUPPORTED_TIME_FORMAT + aDateObject.getTimeFormat());
+        }
+    }
+
+    private static Element createPictureElement(Document doc, Picture picture) {
+        Element pictureElement = doc.createElement(PICTURE_ELEMENT);
+        pictureElement.setAttribute(ID_ATR, Long.toString(picture.getId()));
+        pictureElement.setAttribute(NAME_ATR, picture.getName());
+        pictureElement.setAttribute(PATH_ATR, picture.getProjectRelativePath());
+        pictureElement.setAttribute(WIDTH_ATR, Integer.toString((int) picture.getWidth()));
+        pictureElement.setAttribute(HEIGHT_ATR, Integer.toString((int) picture.getHeight()));
+        picture.getPersons().forEach(person -> {
+            Element personElement = doc.createElement(PERSON_REF_ELEMENT);
+            personElement.setAttribute(ID_ATR, Long.toString(person.getId()));
+            pictureElement.appendChild(personElement);
+        });
+        picture.getPlaces().forEach(place -> {
+            Element placeElement = doc.createElement(PLACE_REF_ELEMENT);
+            placeElement.setAttribute(ID_ATR, Long.toString(place.getId()));
+            pictureElement.appendChild(placeElement);
+        });
+        saveObjectTime(pictureElement, picture);
+        return pictureElement;
+    }
+
+    private static Element createFriezeElement(Document doc, Frieze frieze) {
+        LOG.log(Level.INFO, "Saving Frieze {0}", new Object[]{frieze.getName()});
+        var friezeElement = doc.createElement(FRIEZE_ELEMENT);
+        friezeElement.setAttribute(NAME_ATR, frieze.getName());
+        friezeElement.setAttribute(ID_ATR, Long.toString(frieze.getId()));
+        // Stays
+        var staysElement = doc.createElement(STAYS_REF_GROUP);
+        friezeElement.appendChild(staysElement);
+        frieze.getStayPeriods().forEach(stay -> staysElement.appendChild(createStayElementInFreize(doc, stay)));
+        // FreeMaps
+        var freemapsElement = doc.createElement(FreeMapProviderV4.FREEMAPS_GROUP);
+        friezeElement.appendChild(freemapsElement);
+        frieze.getFriezeFreeMaps().forEach(freeMap -> freemapsElement.appendChild(FreeMapProviderV4.saveFreeMapElement(doc, freeMap)));
+        return friezeElement;
+    }
+
+    private static Element createStayElement(Document doc, StayPeriod stay) {
+        Element stayElement = doc.createElement(STAY_ELEMENT);
+        stayElement.setAttribute(ID_ATR, Long.toString(stay.getId()));
+        stayElement.setAttribute(PERSON_ATR, Long.toString(stay.getPerson().getId()));
+        switch (stay.getTimeFormat()) {
+            case LOCAL_TIME -> {
+                LocalDate startDate = LocalDate.ofEpochDay((long) stay.getStartDate());
+                LocalDate endDate = LocalDate.ofEpochDay((long) stay.getEndDate());
+                stayElement.setAttribute(START_DATE_ATR, IDateObject.DEFAULT_DATE_FORMATTER.format(startDate));
+                stayElement.setAttribute(END_DATE_ATR, IDateObject.DEFAULT_DATE_FORMATTER.format(endDate));
+            }
+            case TIME_MIN -> {
+                stayElement.setAttribute(START_DATE_ATR, Double.toString(stay.getStartDate()));
+                stayElement.setAttribute(END_DATE_ATR, Double.toString(stay.getEndDate()));
+            }
+            default ->
+                throw new UnsupportedOperationException(Messages.UNSUPPORTED_TIME_FORMAT + stay.getTimeFormat());
+        }
+        stayElement.setAttribute(TIME_FORMAT_ATR, stay.getTimeFormat().name());
+        stayElement.setAttribute(PLACE_ID_ATR, Long.toString(stay.getPlace().getId()));
+        return stayElement;
+    }
+
+    private static Element createStayElementInFreize(Document doc, StayPeriod stay) {
+        Element stayElement = doc.createElement(STAY_ELEMENT_REF);
+        stayElement.setAttribute(ID_ATR, Long.toString(stay.getId()));
+        return stayElement;
+    }
+
+    private static Element createPictureChronologyElement(Document doc, PictureChronology pictureChronology) {
+        var pictureChronologyElement = doc.createElement(PICTURE_CHRONOLOGY_ELEMENT);
+        pictureChronologyElement.setAttribute(ID_ATR, Long.toString(pictureChronology.getId()));
+        pictureChronologyElement.setAttribute(NAME_ATR, pictureChronology.getName());
+        pictureChronologyElement.setAttribute(WIDTH_ATR, Double.toString(pictureChronology.getWidth()));
+        pictureChronologyElement.setAttribute(HEIGHT_ATR, Double.toString(pictureChronology.getHeight()));
+        //
+        pictureChronology.getChronologyPictures().forEach(miniature -> pictureChronologyElement.appendChild(createPictureChronologyMiniature(doc, miniature)));
+        pictureChronology.getLinks().forEach(link -> pictureChronologyElement.appendChild(createPictureChronologyLink(doc, link)));
+        return pictureChronologyElement;
+    }
+
+    private static Element createPictureChronologyMiniature(Document doc, ChronologyPictureMiniature miniature) {
+        var pictureChronologyMiniatureElement = doc.createElement(PICTURE_CHRONOLOGY_MINIATURE_ELEMENT);
+        pictureChronologyMiniatureElement.setAttribute(ID_ATR, Long.toString(miniature.getId()));
+        pictureChronologyMiniatureElement.setAttribute(X_POS_ATR, Double.toString(miniature.getPosition().getX()));
+        pictureChronologyMiniatureElement.setAttribute(Y_POS_ATR, Double.toString(miniature.getPosition().getY()));
+        pictureChronologyMiniatureElement.setAttribute(PICTURE_REF_ELEMENT, Long.toString(miniature.getPicture().getId()));
+        pictureChronologyMiniatureElement.setAttribute(SCALE_ATR, Double.toString(miniature.getScale()));
+        if (!miniature.isInSyncWithPicture()) {
+            saveObjectTime(pictureChronologyMiniatureElement, miniature.getDateObject());
+        }
+        return pictureChronologyMiniatureElement;
+    }
+
+    private static Element createPictureChronologyLink(Document doc, ChronologyLink link) {
+        var pictureChronologyLinkElement = doc.createElement(PICTURE_CHRONOLOGY_LINK_ELEMENT);
+        pictureChronologyLinkElement.setAttribute(ID_ATR, Long.toString(link.getId()));
+        pictureChronologyLinkElement.setAttribute(TYPE_ATR, link.getLinkType().name());
+        pictureChronologyLinkElement.setAttribute(FROM_ATR, Long.toString(link.getStartMiniature().getId()));
+        pictureChronologyLinkElement.setAttribute(TO_ATR, Long.toString(link.getEndMiniature().getId()));
+        pictureChronologyLinkElement.setAttribute(PERSON_REF_ATR, Long.toString(link.getPerson().getId()));
+        pictureChronologyLinkElement.setAttribute(PARAMETERS_ATR, Arrays.toString(link.getLinkParameters()));
+        return pictureChronologyLinkElement;
+    }
+
+    @Override
+    public String toString() {
+        return this.getClass().getSimpleName();
+    }
+
+}

--- a/src/main/java/com/github/noony/app/timelinefx/save/v4/TimeProjectProviderV4.java
+++ b/src/main/java/com/github/noony/app/timelinefx/save/v4/TimeProjectProviderV4.java
@@ -34,7 +34,6 @@ import com.github.noony.app.timelinefx.core.StayPeriod;
 import com.github.noony.app.timelinefx.core.StayPeriodLocalDate;
 import com.github.noony.app.timelinefx.core.StayPeriodSimpleTime;
 import com.github.noony.app.timelinefx.core.TimeFormat;
-import static com.github.noony.app.timelinefx.core.TimeFormat.LOCAL_TIME;
 import com.github.noony.app.timelinefx.core.TimeLineProject;
 import com.github.noony.app.timelinefx.core.TimeLineProjectFactory;
 import com.github.noony.app.timelinefx.core.picturechronology.ChronologyLink;
@@ -78,6 +77,7 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
+import static com.github.noony.app.timelinefx.core.TimeFormat.LOCAL_TIME;
 
 /**
  *
@@ -194,9 +194,8 @@ public class TimeProjectProviderV4 implements TimelineProjectProvider {
                 TimeLineProject.PICTURES_FOLDER_KEY, picturesFolderValue,
                 TimeLineProject.MINIATURES_FOLDER_KEY, miniaturesFolderValue
         );
-        TimeLineProject project = TimeLineProjectFactory.createProject(projectName, configParams);
         var timeFormatValue = e.hasAttribute(TIME_FORMAT_ATR) ? TimeFormat.valueOf(e.getAttribute(TIME_FORMAT_ATR)) : TimeFormat.LOCAL_TIME;
-        project.setTimeFormat(timeFormatValue);
+        TimeLineProject project = TimeLineProjectFactory.createProject(projectName, configParams, timeFormatValue);
         //
         List<String> relativePathLoaded = new LinkedList<>();
         //
@@ -591,13 +590,16 @@ public class TimeProjectProviderV4 implements TimelineProjectProvider {
         for (int i = 0; i < stayElements.getLength(); i++) {
             if (stayElements.item(i).getNodeName().equals(STAY_ELEMENT)) {
                 Element e = (Element) stayElements.item(i);
-                switch (aTimeFormat) {
+                // a stay keeps the time format it was created with, which may predate a later change to the
+                // project's own time format, so prefer its own attribute over the project's current default
+                var stayTimeFormat = e.hasAttribute(TIME_FORMAT_ATR) ? TimeFormat.valueOf(e.getAttribute(TIME_FORMAT_ATR)) : aTimeFormat;
+                switch (stayTimeFormat) {
                     case LOCAL_TIME ->
                         stayPeriods.add(parseStayPeriodLocalTime(e));
                     case TIME_MIN ->
                         stayPeriods.add(parseStayPeriodSimpleTime(e));
                     default ->
-                        throw new UnsupportedOperationException("Time format not recognized: " + e.getAttribute(TIME_FORMAT_ATR));
+                        throw new UnsupportedOperationException("Time format not recognized: " + stayTimeFormat);
                 }
             }
         }

--- a/src/main/java/com/github/noony/app/timelinefx/save/v4/package-info.java
+++ b/src/main/java/com/github/noony/app/timelinefx/save/v4/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2026 NoOnY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * The V4 project save format providers.
+ */
+package com.github.noony.app.timelinefx.save.v4;

--- a/src/main/resources/META-INF/services/com.github.noony.app.timelinefx.save.TimelineProjectProvider
+++ b/src/main/resources/META-INF/services/com.github.noony.app.timelinefx.save.TimelineProjectProvider
@@ -1,1 +1,2 @@
 com.github.noony.app.timelinefx.save.v3.TimeProjectProviderV3
+com.github.noony.app.timelinefx.save.v4.TimeProjectProviderV4

--- a/src/main/resources/com/github/noony/app/timelinefx/hmi/ProjectCreationWizard.fxml
+++ b/src/main/resources/com/github/noony/app/timelinefx/hmi/ProjectCreationWizard.fxml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <?import javafx.scene.control.Button?>
+<?import javafx.scene.control.ChoiceBox?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.control.TextField?>
 <?import javafx.scene.layout.AnchorPane?>
@@ -22,22 +23,25 @@
             <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="NEVER" />
             <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="NEVER" />
             <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="NEVER" />
+            <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="NEVER" />
           <RowConstraints maxHeight="1.7976931348623157E308" minHeight="10.0" prefHeight="10.0" vgrow="SOMETIMES" />
           <RowConstraints vgrow="NEVER" />
         </rowConstraints>
          <children>
-            <Button fx:id="createB" mnemonicParsing="false" onAction="#handleCreate" text="Create" GridPane.columnIndex="2" GridPane.rowIndex="6" />
-            <Button cancelButton="true" defaultButton="true" mnemonicParsing="false" onAction="#handleCancel" text="Cancel" GridPane.rowIndex="6" />
+            <Button fx:id="createB" mnemonicParsing="false" onAction="#handleCreate" text="Create" GridPane.columnIndex="2" GridPane.rowIndex="7" />
+            <Button cancelButton="true" defaultButton="true" mnemonicParsing="false" onAction="#handleCancel" text="Cancel" GridPane.rowIndex="7" />
             <Label text="Project Name:" />
             <TextField fx:id="nameField" prefWidth="250.0" GridPane.columnIndex="1" />
             <Label text="Project Directory:" GridPane.rowIndex="1" />
             <Label text="Portraits SubFolder:" GridPane.rowIndex="2" />
             <Label text="Pictures SubFolder:" GridPane.rowIndex="3" />
             <Label text="Miniatures SubFolder:" GridPane.rowIndex="4" />
+            <Label text="Time Format:" GridPane.rowIndex="5" />
             <TextField fx:id="directoryField" prefWidth="500.0" GridPane.columnIndex="1" GridPane.rowIndex="1" />
             <TextField fx:id="portraitsField" GridPane.columnIndex="1" GridPane.rowIndex="2" />
             <TextField fx:id="picturesField" GridPane.columnIndex="1" GridPane.rowIndex="3" />
             <TextField fx:id="miniaturesField" GridPane.columnIndex="1" GridPane.rowIndex="4" />
+            <ChoiceBox fx:id="timeFormatCB" prefWidth="150.0" GridPane.columnIndex="1" GridPane.rowIndex="5" />
             <Button contentDisplay="CENTER" mnemonicParsing="false" onAction="#handleDirectoryButton" text="..." textAlignment="CENTER" GridPane.columnIndex="2" GridPane.rowIndex="1" />
          </children>
       </GridPane>

--- a/src/main/resources/com/github/noony/app/timelinefx/hmi/ProjectView.fxml
+++ b/src/main/resources/com/github/noony/app/timelinefx/hmi/ProjectView.fxml
@@ -4,6 +4,7 @@
 <?import javafx.scene.control.MenuBar?>
 <?import javafx.scene.control.MenuItem?>
 <?import javafx.scene.control.RadioMenuItem?>
+<?import javafx.scene.control.SeparatorMenuItem?>
 <?import javafx.scene.input.KeyCodeCombination?>
 <?import javafx.scene.layout.AnchorPane?>
 <?import javafx.scene.layout.BorderPane?>
@@ -37,6 +38,9 @@
                                       <KeyCodeCombination alt="UP" code="Y" control="UP" meta="UP" shift="UP" shortcut="DOWN" />
                                   </accelerator>
                               </MenuItem>
+                              <SeparatorMenuItem />
+                              <RadioMenuItem fx:id="dateTimeFormatMI" disable="true" mnemonicParsing="false" text="Use Dates" />
+                              <RadioMenuItem fx:id="minTimeFormatMI" disable="true" mnemonicParsing="false" text="Use Time" />
                           </items>
                       </Menu>
                   <Menu fx:id="friezesMenu" mnemonicParsing="false" text="Friezes">

--- a/src/main/resources/com/github/noony/app/timelinefx/hmi/frieze/FriezeContentEditor.fxml
+++ b/src/main/resources/com/github/noony/app/timelinefx/hmi/frieze/FriezeContentEditor.fxml
@@ -2,6 +2,7 @@
 
 <?import javafx.scene.control.Button?>
 <?import javafx.scene.control.CheckBox?>
+<?import javafx.scene.control.DatePicker?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.control.ListView?>
 <?import javafx.scene.control.Separator?>
@@ -19,7 +20,7 @@
 <?import org.controlsfx.control.CheckListView?>
 <?import org.controlsfx.control.CheckTreeView?>
 
-<AnchorPane xmlns="http://javafx.com/javafx/20.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.github.noony.app.timelinefx.hmi.frieze.FriezeContentEditorController">
+<AnchorPane xmlns="http://javafx.com/javafx/24" xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.github.noony.app.timelinefx.hmi.frieze.FriezeContentEditorController">
    <children>
       <TabPane fx:id="tabPane" tabClosingPolicy="UNAVAILABLE" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
         <tabs>
@@ -39,11 +40,11 @@
                               </HBox>
                               <GridPane fx:id="timeGrid" hgap="8.0" vgap="8.0">
                                  <columnConstraints>
-                                    <ColumnConstraints halignment="RIGHT" hgrow="SOMETIMES" maxWidth="1.7976931348623157E308" minWidth="50.0" />
-                                    <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" />
+                                    <ColumnConstraints halignment="RIGHT" hgrow="SOMETIMES" maxWidth="1.7976931348623157E308" />
+                                    <ColumnConstraints hgrow="SOMETIMES" maxWidth="-Infinity" minWidth="10.0" />
+                                    <ColumnConstraints halignment="CENTER" hgrow="SOMETIMES" maxWidth="1.7976931348623157E308" minWidth="10.0" />
+                                    <ColumnConstraints halignment="RIGHT" hgrow="SOMETIMES" maxWidth="1.7976931348623157E308" />
                                     <ColumnConstraints halignment="CENTER" hgrow="SOMETIMES" />
-                                    <ColumnConstraints halignment="RIGHT" hgrow="SOMETIMES" minWidth="10.0" />
-                                    <ColumnConstraints halignment="CENTER" hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
                                  </columnConstraints>
                                  <rowConstraints>
                                     <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
@@ -57,8 +58,14 @@
                                     <Label text="Project end:" GridPane.columnIndex="3" GridPane.rowIndex="1" />
                                     <Label text="Frieze's stays star:t" GridPane.rowIndex="2" />
                                     <Label text="Frieze's stays end:" GridPane.columnIndex="3" GridPane.rowIndex="2" />
-                                    <CheckBox mnemonicParsing="false" text="Constraint frieze start:" GridPane.rowIndex="3" />
-                                    <CheckBox mnemonicParsing="false" text="Constraint frieze end:" GridPane.columnIndex="3" GridPane.rowIndex="3" />
+                                    <CheckBox fx:id="constraintStartCB" mnemonicParsing="false" text="Constraint start:" GridPane.rowIndex="3" />
+                                    <CheckBox fx:id="constraintEndCB" mnemonicParsing="false" text="Constraint end:" GridPane.columnIndex="3" GridPane.rowIndex="3" />
+                                    <Label fx:id="projectStartDateLabel" GridPane.columnIndex="1" GridPane.rowIndex="1" />
+                                    <Label fx:id="projectEndDateLabel" GridPane.columnIndex="4" GridPane.rowIndex="1" />
+                                    <DatePicker GridPane.columnIndex="1" GridPane.rowIndex="2" />
+                                    <DatePicker GridPane.columnIndex="4" GridPane.rowIndex="2" />
+                                    <DatePicker GridPane.columnIndex="1" GridPane.rowIndex="3" />
+                                    <DatePicker GridPane.columnIndex="4" GridPane.rowIndex="3" />
                                  </children>
                               </GridPane>
                               <Separator prefWidth="200.0" />

--- a/src/test/java/com/github/noony/app/timelinefx/core/PortraitFactoryTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/core/PortraitFactoryTest.java
@@ -19,6 +19,7 @@ package com.github.noony.app.timelinefx.core;
 
 import java.io.File;
 import java.nio.file.Path;
+import java.time.LocalDate;
 import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -107,6 +108,30 @@ public final class PortraitFactoryTest {
         final var relativePath = person.getProject().getPortraitsRelativeFolder() + File.separator + Person.DEFAULT_PICTURE_NAME;
         final var portrait = PortraitFactory.createPortrait(42L, person, relativePath);
         assertEquals(42L, portrait.getId());
+    }
+
+    /**
+     * Test of createPortrait(Person) method, of class PortraitFactory, with the project's default (LOCAL_TIME)
+     * time format: the portrait's date is taken from the picture's own (parsed, or metadata-parser-default)
+     * creation date, not from an unrelated default value.
+     */
+    @Test
+    public void testCreatePortraitUsesLocalTimeFormat() {
+        final var portrait = PortraitFactory.createPortrait(person);
+        assertEquals(TimeFormat.LOCAL_TIME, portrait.getTimeFormat());
+        assertEquals(LocalDate.MIN, portrait.getDate());
+    }
+
+    /**
+     * Test of createPortrait(Person) method, of class PortraitFactory, with the project set to the TIME_MIN
+     * time format: the portrait's timestamp is derived from the picture's own creation date.
+     */
+    @Test
+    public void testCreatePortraitUsesTimeMinFormat() {
+        project.setTimeFormat(TimeFormat.TIME_MIN);
+        final var portrait = PortraitFactory.createPortrait(person);
+        assertEquals(TimeFormat.TIME_MIN, portrait.getTimeFormat());
+        assertEquals(LocalDate.MIN.toEpochDay(), portrait.getTimestamp());
     }
 
     /**

--- a/src/test/java/com/github/noony/app/timelinefx/save/XMLHandlerTest.java
+++ b/src/test/java/com/github/noony/app/timelinefx/save/XMLHandlerTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2026 NoOnY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.github.noony.app.timelinefx.save;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link XMLHandler}.
+ *
+ * @author hamon
+ */
+public final class XMLHandlerTest {
+
+    /**
+     * Default constructor.
+     */
+    public XMLHandlerTest() {
+    }
+
+    /**
+     * Test of compareVersions method, of class XMLHandler, with equal versions.
+     */
+    @Test
+    public void testCompareVersionsEqual() {
+        assertEquals(0, XMLHandler.compareVersions("3", "3"));
+        assertEquals(0, XMLHandler.compareVersions("3.1", "3.1"));
+    }
+
+    /**
+     * Test of compareVersions method, of class XMLHandler, with simple single-segment versions: the higher
+     * version compares greater, regardless of argument order.
+     */
+    @Test
+    public void testCompareVersionsSimple() {
+        assertTrue(XMLHandler.compareVersions("4", "3") > 0);
+        assertTrue(XMLHandler.compareVersions("3", "4") < 0);
+    }
+
+    /**
+     * Test of compareVersions method, of class XMLHandler, with multi-segment versions.
+     */
+    @Test
+    public void testCompareVersionsMultiSegment() {
+        assertTrue(XMLHandler.compareVersions("3.2", "3.1") > 0);
+        assertTrue(XMLHandler.compareVersions("3.1", "3.2") < 0);
+    }
+
+    /**
+     * Test that the highest-version provider found via the stream/max pattern used by XMLHandler's save-provider
+     * selection is picked correctly, mirroring the fix to that selection logic.
+     */
+    @Test
+    public void testCompareVersionsPicksMax() {
+        final var versions = List.of("3", "1", "4", "2");
+        final var max = versions.stream().max(XMLHandler::compareVersions).get();
+        assertEquals("4", max);
+    }
+
+}

--- a/src/test/java/com/github/noony/app/timelinefx/save/package-info.java
+++ b/src/test/java/com/github/noony/app/timelinefx/save/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2026 NoOnY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Tests for the project save/load entry point.
+ */
+package com.github.noony.app.timelinefx.save;

--- a/src/test/java/com/github/noony/app/timelinefx/save/v4/FreeMapProviderV4Test.java
+++ b/src/test/java/com/github/noony/app/timelinefx/save/v4/FreeMapProviderV4Test.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2026 NoOnY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.github.noony.app.timelinefx.save.v4;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Element;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link FreeMapProviderV4}.
+ *
+ * @author hamon
+ */
+public final class FreeMapProviderV4Test {
+
+    /**
+     * Default constructor.
+     */
+    public FreeMapProviderV4Test() {
+    }
+
+    /**
+     * Builds a minimal {@code <freeMaps>} element containing one {@code <freeMap>} whose only place has a
+     * malformed {@code height} attribute. Parsing fails while resolving that attribute, before the
+     * {@code frieze} argument of {@link FreeMapProviderV4#parseFreeMaps} is ever dereferenced, so {@code null}
+     * is a safe stand-in for it here.
+     *
+     * @return the constructed {@code <freeMaps>} element
+     * @throws Exception if the document builder cannot be created
+     */
+    private static Element newFreeMapsElementWithMalformedPlaceHeight() throws Exception {
+        final var doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+        final var placeElement = doc.createElement("freeMapPlace");
+        placeElement.setAttribute("placeID", "1");
+        placeElement.setAttribute("height", "not-a-number");
+        placeElement.setAttribute("yPos", "0.0");
+        placeElement.setAttribute("fontSize", "10.0");
+        placeElement.setAttribute("placeNameWidth", "10.0");
+        final var placesElement = doc.createElement("freeMapPlaces");
+        placesElement.appendChild(placeElement);
+        final var freeMapElement = doc.createElement("freeMap");
+        freeMapElement.setAttribute("id", "1");
+        freeMapElement.setAttribute("name", "Test FreeMap");
+        freeMapElement.appendChild(doc.createElement("freeMapDateHandles"));
+        freeMapElement.appendChild(doc.createElement("freeMapPersons"));
+        freeMapElement.appendChild(placesElement);
+        final var freeMapsElement = doc.createElement("freeMaps");
+        freeMapsElement.appendChild(freeMapElement);
+        return freeMapsElement;
+    }
+
+    /**
+     * Regression test: confirms FreeMapProviderV4's own parsing methods are wired to the shared
+     * parseDoubleAttribute helper too, surfacing a clear IllegalStateException instead of a bare
+     * NumberFormatException for a malformed freemap place height.
+     */
+    @Test
+    public void testParseFreeMapsThrowsClearExceptionOnMalformedPlaceHeight() throws Exception {
+        final var freeMapsElement = newFreeMapsElementWithMalformedPlaceHeight();
+        final var exception = assertThrows(IllegalStateException.class,
+                () -> FreeMapProviderV4.parseFreeMaps(freeMapsElement, null));
+        assertTrue(exception.getMessage().contains("height"));
+        assertTrue(exception.getMessage().contains("not-a-number"));
+    }
+
+}

--- a/src/test/java/com/github/noony/app/timelinefx/save/v4/TimeProjectProviderV4Test.java
+++ b/src/test/java/com/github/noony/app/timelinefx/save/v4/TimeProjectProviderV4Test.java
@@ -1,0 +1,246 @@
+/*
+ * Copyright (C) 2026 NoOnY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.github.noony.app.timelinefx.save.v4;
+
+import com.github.noony.app.timelinefx.core.PersonFactory;
+import com.github.noony.app.timelinefx.core.Picture;
+import com.github.noony.app.timelinefx.core.PictureFactory;
+import com.github.noony.app.timelinefx.core.PlaceFactory;
+import com.github.noony.app.timelinefx.core.PlaceLevel;
+import com.github.noony.app.timelinefx.core.StayFactory;
+import com.github.noony.app.timelinefx.core.TimeFormat;
+import com.github.noony.app.timelinefx.core.TimeLineProject;
+import com.github.noony.app.timelinefx.core.TimeLineProjectFactory;
+import java.nio.file.Path;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Map;
+import javafx.scene.paint.Color;
+import javax.xml.parsers.DocumentBuilderFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.w3c.dom.Element;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link TimeProjectProviderV4}.
+ *
+ * @author hamon
+ */
+public final class TimeProjectProviderV4Test {
+
+    /**
+     * Temporary directory used to create a test project without touching the real user directories.
+     */
+    @TempDir
+    private Path tempDir;
+
+    /**
+     * The project used in these tests.
+     */
+    private TimeLineProject project;
+
+    /**
+     * Default constructor.
+     */
+    public TimeProjectProviderV4Test() {
+    }
+
+    /**
+     * Sets up test fixtures before each test.
+     */
+    @BeforeEach
+    public void setUp() {
+        PersonFactory.reset();
+        PlaceFactory.reset();
+        StayFactory.reset();
+        PictureFactory.reset();
+        final var configParams = Map.of(TimeLineProject.PROJECT_FOLDER_KEY, tempDir.toString());
+        project = TimeLineProjectFactory.createProject("TimeProjectProviderV4Test", configParams);
+    }
+
+    /**
+     * Tears down test fixtures after each test.
+     */
+    @AfterEach
+    public void tearDown() {
+        PersonFactory.reset();
+        PlaceFactory.reset();
+        StayFactory.reset();
+        PictureFactory.reset();
+    }
+
+    /**
+     * Builds a single-attribute element to feed to {@code parseDoubleAttribute}.
+     *
+     * @param tagName the element's tag name
+     * @param attributeName the attribute's name
+     * @param attributeValue the attribute's raw string value
+     * @return the constructed element
+     * @throws Exception if the document builder cannot be created
+     */
+    private static Element newElement(final String tagName, final String attributeName, final String attributeValue) throws Exception {
+        final var doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+        final var element = doc.createElement(tagName);
+        element.setAttribute(attributeName, attributeValue);
+        return element;
+    }
+
+    /**
+     * Test of parseDoubleAttribute method, of class TimeProjectProviderV4, with a well-formed value.
+     */
+    @Test
+    public void testParseDoubleAttributeValidValue() throws Exception {
+        final var element = newElement("stay", "startDate", "12.5");
+        assertEquals(12.5, TimeProjectProviderV4.parseDoubleAttribute(element, "startDate"));
+    }
+
+    /**
+     * Test of parseDoubleAttribute method, of class TimeProjectProviderV4, with a malformed value: fails with a
+     * message identifying the element, attribute and raw value instead of a bare NumberFormatException.
+     */
+    @Test
+    public void testParseDoubleAttributeThrowsClearExceptionOnMalformedValue() throws Exception {
+        final var element = newElement("stay", "startDate", "not-a-number");
+        final var exception = assertThrows(IllegalStateException.class,
+                () -> TimeProjectProviderV4.parseDoubleAttribute(element, "startDate"));
+        assertTrue(exception.getMessage().contains("startDate"));
+        assertTrue(exception.getMessage().contains("stay"));
+        assertTrue(exception.getMessage().contains("not-a-number"));
+        assertTrue(exception.getCause() instanceof NumberFormatException);
+    }
+
+    /**
+     * Test of parseObjectTimeValue method, of class TimeProjectProviderV4, with an explicit LOCAL_TIME format:
+     * unlike TimeProjectProviderV3 (which reads a per-element "timeFormat" attribute), the format is entirely
+     * determined by the caller-supplied argument.
+     */
+    @Test
+    public void testParseObjectTimeValueLocalTime() throws Exception {
+        final var doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+        final var element = doc.createElement("picture");
+        element.setAttribute("date", "2024-05-06");
+        final var picture = PictureFactory.createPicture(project, 1L, "testPicture", LocalDateTime.MIN, "pictures/foo.png", 10, 10);
+        TimeProjectProviderV4.parseObjectTimeValue(element, picture, TimeFormat.LOCAL_TIME);
+        assertEquals(TimeFormat.LOCAL_TIME, picture.getTimeFormat());
+        assertEquals(LocalDate.of(2024, 5, 6), picture.getDate());
+    }
+
+    /**
+     * Test of parseObjectTimeValue method, of class TimeProjectProviderV4, with an explicit TIME_MIN format.
+     */
+    @Test
+    public void testParseObjectTimeValueTimeMin() throws Exception {
+        final var doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+        final var element = doc.createElement("picture");
+        element.setAttribute("date", "42.0");
+        final var picture = PictureFactory.createPicture(project, 1L, "testPicture", LocalDateTime.MIN, "pictures/foo.png", 10, 10);
+        TimeProjectProviderV4.parseObjectTimeValue(element, picture, TimeFormat.TIME_MIN);
+        assertEquals(TimeFormat.TIME_MIN, picture.getTimeFormat());
+        assertEquals(42.0, picture.getTimestamp());
+    }
+
+    /**
+     * Builds a minimal {@code <PROJECT>} element with one place, one person and one stay linking them,
+     * ready to feed to {@link TimeProjectProviderV4#load}. Everything is described in the XML itself
+     * (rather than pre-seeded via the core factories) since {@code load} reconstructs the whole object graph
+     * from scratch, resetting the shared factories as its first step.
+     *
+     * @param projectTimeFormat the project's own "timeFormat" root attribute
+     * @param stayTimeFormat the stay's own "timeFormat" attribute, or {@code null} to omit it
+     * @param startDate the stay's raw "startDate" attribute value
+     * @param endDate the stay's raw "endDate" attribute value
+     * @return the constructed root element
+     * @throws Exception if the document builder cannot be created
+     */
+    private static Element newProjectWithOneStay(final TimeFormat projectTimeFormat, final TimeFormat stayTimeFormat,
+            final String startDate, final String endDate) throws Exception {
+        final var doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+        final var rootElement = doc.createElement(TimeProjectProviderV4.PROJECT_GROUP);
+        rootElement.setAttribute(TimeProjectProviderV4.NAME_ATR, "TestProject");
+        rootElement.setAttribute(TimeProjectProviderV4.TIME_FORMAT_ATR, projectTimeFormat.name());
+        //
+        final var placeElement = doc.createElement(TimeProjectProviderV4.PLACE_ELEMENT);
+        placeElement.setAttribute(TimeProjectProviderV4.ID_ATR, "1");
+        placeElement.setAttribute(TimeProjectProviderV4.NAME_ATR, "testPlace");
+        placeElement.setAttribute(TimeProjectProviderV4.PLACE_LEVEL_ATR, PlaceLevel.PLANET.name());
+        placeElement.setAttribute(TimeProjectProviderV4.COLOR_ATR, Color.WHITE.toString());
+        final var placesGroupElement = doc.createElement(TimeProjectProviderV4.PLACES_GROUP);
+        placesGroupElement.appendChild(placeElement);
+        rootElement.appendChild(placesGroupElement);
+        //
+        final var personElement = doc.createElement(TimeProjectProviderV4.PERSON_ELEMENT);
+        personElement.setAttribute(TimeProjectProviderV4.ID_ATR, "1");
+        personElement.setAttribute(TimeProjectProviderV4.NAME_ATR, "testPerson");
+        personElement.setAttribute(TimeProjectProviderV4.COLOR_ATR, Color.WHITE.toString());
+        final var personsGroupElement = doc.createElement(TimeProjectProviderV4.PERSONS_GROUP);
+        personsGroupElement.appendChild(personElement);
+        rootElement.appendChild(personsGroupElement);
+        //
+        final var stayElement = doc.createElement(TimeProjectProviderV4.STAY_ELEMENT);
+        stayElement.setAttribute(TimeProjectProviderV4.ID_ATR, "1");
+        stayElement.setAttribute(TimeProjectProviderV4.PERSON_ATR, "1");
+        stayElement.setAttribute(TimeProjectProviderV4.PLACE_ID_ATR, "1");
+        stayElement.setAttribute(TimeProjectProviderV4.START_DATE_ATR, startDate);
+        stayElement.setAttribute(TimeProjectProviderV4.END_DATE_ATR, endDate);
+        if (stayTimeFormat != null) {
+            stayElement.setAttribute(TimeProjectProviderV4.TIME_FORMAT_ATR, stayTimeFormat.name());
+        }
+        final var staysGroupElement = doc.createElement(TimeProjectProviderV4.STAYS_GROUP);
+        staysGroupElement.appendChild(stayElement);
+        rootElement.appendChild(staysGroupElement);
+        //
+        return rootElement;
+    }
+
+    /**
+     * Regression test: a stay keeps the time format it was created with, which may predate a later change to
+     * the project's own time format. Builds a minimal save file where the project's own time format is
+     * TIME_MIN but the one saved stay carries its own "timeFormat" attribute of LOCAL_TIME, and confirms the
+     * stay is parsed using its own format rather than silently defaulting to the project's.
+     */
+    @Test
+    public void testLoadPrefersStayOwnTimeFormatOverProjectDefault() throws Exception {
+        final var rootElement = newProjectWithOneStay(TimeFormat.TIME_MIN, TimeFormat.LOCAL_TIME, "2024-01-01", "2024-01-05");
+        final var provider = new TimeProjectProviderV4();
+        final var loadedProject = provider.load(tempDir.resolve("test.xml").toFile(), rootElement);
+        //
+        assertEquals(1, loadedProject.getStays().size());
+        assertEquals(TimeFormat.LOCAL_TIME, loadedProject.getStays().get(0).getTimeFormat());
+    }
+
+    /**
+     * Test of load method, of class TimeProjectProviderV4, without an explicit stay-level "timeFormat"
+     * attribute: falls back to the project's own time format, matching pre-fix behavior for freshly-saved
+     * V4 files where every stay already matches the project's current format.
+     */
+    @Test
+    public void testLoadFallsBackToProjectTimeFormatWhenStayHasNone() throws Exception {
+        final var rootElement = newProjectWithOneStay(TimeFormat.TIME_MIN, null, "1.0", "5.0");
+        final var provider = new TimeProjectProviderV4();
+        final var loadedProject = provider.load(tempDir.resolve("test.xml").toFile(), rootElement);
+        //
+        assertEquals(1, loadedProject.getStays().size());
+        assertEquals(TimeFormat.TIME_MIN, loadedProject.getStays().get(0).getTimeFormat());
+    }
+
+}

--- a/src/test/java/com/github/noony/app/timelinefx/save/v4/TimeProjectProviderV4Test.java
+++ b/src/test/java/com/github/noony/app/timelinefx/save/v4/TimeProjectProviderV4Test.java
@@ -18,7 +18,6 @@
 package com.github.noony.app.timelinefx.save.v4;
 
 import com.github.noony.app.timelinefx.core.PersonFactory;
-import com.github.noony.app.timelinefx.core.Picture;
 import com.github.noony.app.timelinefx.core.PictureFactory;
 import com.github.noony.app.timelinefx.core.PlaceFactory;
 import com.github.noony.app.timelinefx.core.PlaceLevel;

--- a/src/test/java/com/github/noony/app/timelinefx/save/v4/package-info.java
+++ b/src/test/java/com/github/noony/app/timelinefx/save/v4/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2026 NoOnY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Tests for the V4 project save format providers.
+ */
+package com.github.noony.app.timelinefx.save.v4;


### PR DESCRIPTION
## Summary
- The FriezeContentEditor's "Project start:"/"Project end:" labels (previously dead placeholder `"todo"` text, no `fx:id`) now show the project-wide min/max stay dates, via a new `TimeLineProject.getMinDate()`/`getMaxDate()` (computed from `getStays()`, mirroring `Frieze`'s own min/max computation). Refreshed on project load and whenever a stay is added to/removed from the project.
- The "Frieze's stays start:"/"end:" fields now also refresh when a stay is added, removed, or updated on the *currently displayed* frieze — previously they only refreshed once, when a frieze was first selected.
- The FXML already had "Constraint start:"/"Constraint end:" checkboxes and date fields, and `Frieze` already had `constraintMinDate`/`constraintMaxDate` fields — both entirely unwired/dead. This PR completes that: checking a box and entering a value clamps the frieze's visible date window (`setMinDateWindow`/`setMaxDateWindow`) to never exceed it, pushing the current window back in bounds immediately if needed. Both checkboxes default to unselected (unconstrained), matching a freshly-created `Frieze`'s default state.

## Scope notes
- No XML persistence was added for the constraint state (not requested); it lives only on the in-memory `Frieze`, matching the fact that `Frieze` currently persists nothing beyond name/id/stays/freemaps.
- The "Frieze's stays star:t" label typo and the `Frieze.NAME_CHANGED`/`DATE_WINDOW_CHANGED` `// TODO` no-ops in `handleFriezeChanges` are pre-existing and out of scope here.

## Test plan
- `mvn -o compile` / `mvn -o test`: green.
- FXML validated well-formed.
- Manual (not automated here): open a project with stays, confirm "Project start/end" populate; add/remove a stay and confirm both project and frieze fields refresh; check "Constraint start", enter a date past the current window's low edge, confirm the window doesn't go below it; uncheck to remove the constraint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)