### PR TITLE
Display calendar dates as day-month-year

### DIFF
--- a/src/main/java/com/github/noony/app/timelinefx/utils/TimeFormatToString.java
+++ b/src/main/java/com/github/noony/app/timelinefx/utils/TimeFormatToString.java
@@ -28,7 +28,7 @@ import java.time.format.DateTimeFormatter;
  */
 public class TimeFormatToString {
 
-    public static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("dd LLLL yyyy");
+    public static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("dd-MM-yyyy");
 
     public static String timeToString(long time, TimeFormat timeFormat) {
         switch (timeFormat) {


### PR DESCRIPTION
## Summary
`TimeFormatToString.DATE_TIME_FORMATTER` (used to display any `LOCAL_TIME`-format date: person birth/death dates via `DateObject`, picture dates via `AbstractPicture`, and a frieze's min/max dates when `TimeFormat.LOCAL_TIME` is used) is changed from `"dd LLLL yyyy"` (e.g. "29 August 2026") to `"dd-MM-yyyy"` (e.g. "29-08-2026"), matching the day-month-year format the app already uses elsewhere (`DateUtils.CONVERTER`, used for stay date entry in `StaysCreationViewController`).

Purely a display-format change — no parsing counterpart uses this formatter, so nothing else needed updating.

## Test plan
- `mvn -o compile` / `mvn -o test`: green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)